### PR TITLE
Test Forte w/o building Psi4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,27 +26,51 @@ matrix:
 #      - BUILD_TYPE='release'
 #      - NAME='gcc'
 #      - VERSION='4.9'
+#  - os: linux
+#    compiler: clang
+#    addons: &1
+#      apt:
+#        sources:
+#        - llvm-toolchain-precise-3.6
+#        - ubuntu-toolchain-r-test
+#        - george-edison55-precise-backports
+#        packages:
+#        - liblapack-dev
+#        - clang-3.6
+#        - libhdf5-serial-dev
+#        - gfortran
+#    env:
+#      - CXX_COMPILER='clang++-3.6'
+#      - PYTHON_VER='2.7'
+#      - C_COMPILER='clang-3.6'
+#      - Fortran_COMPILER='gfortran'
+#      - BUILD_TYPE='debug'
+#      - NAME='clang'
+#      - VERSION='3.6'
   - os: linux
-    compiler: clang
-    addons: &1
+    compiler: gcc
+    addons: &4
       apt:
         sources:
-        - llvm-toolchain-precise-3.6
         - ubuntu-toolchain-r-test
         - george-edison55-precise-backports
         packages:
-        - liblapack-dev
-        - clang-3.6
+        #- python-numpy
+        #- cmake
+        #- cmake-data
         - libhdf5-serial-dev
-        - gfortran
+        - liblapack-dev
+        - g++-6
+        - gcc-6
+        - gfortran-6
     env:
-      - CXX_COMPILER='clang++-3.6'
+      - CXX_COMPILER='g++-6'
       - PYTHON_VER='2.7'
-      - C_COMPILER='clang-3.6'
-      - Fortran_COMPILER='gfortran'
+      - C_COMPILER='gcc-6'
+      - Fortran_COMPILER='gfortran-6'
       - BUILD_TYPE='debug'
-      - NAME='clang'
-      - VERSION='3.6'
+      - NAME='gcc'
+      - VERSION=6
 
 install:
 - if [[ "$PYTHON_VER" == "2.7" ]]; then
@@ -114,6 +138,7 @@ install:
 - hash -r
 script:
 - cd ${TRAVIS_BUILD_DIR}/tests/methods
+- ldd -v ${TRAVIS_BUILD_DIR}/forte.so
 - python run_forte_tests_travis.py 
 
 # safelist

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,9 @@ install:
 - conda config --set always_yes yes --set changeps1 no
 - conda update -q conda
 - conda info -a
-- conda create -q -n p4env python=$PYTHON_VER numpy cmake gdma libint libxc -c psi4/label/test -c psi4
+- conda create -q -n p4env python=$PYTHON_VER psi4 cmake -c psi4
 - source activate p4env
-#- conda list
+- conda list
 #- python -V
 #- python -c 'import numpy; print(numpy.version.version)'
 - cd ${TRAVIS_BUILD_DIR}
@@ -83,26 +83,27 @@ install:
 - make -j2
 - make install
 # Compile Psi4
-- cd ${HOME}/build
-- git clone https://github.com/psi4/psi4.git psi4
+#- cd ${HOME}/build
+#- git clone https://github.com/psi4/psi4.git psi4
 #- git clone -b minipsi4 https://github.com/evangelistalab/psi4.git psi4
-- cd psi4
-- > 
-    cmake -Bbuild -H. 
-    -DCMAKE_CXX_COMPILER=${CXX_COMPILER} 
-    -DCMAKE_C_COMPILER=${C_COMPILER} 
-    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} 
-    -DCMAKE_PREFIX_PATH=${HOME}/miniconda/envs/p4env
-    -DPYTHON_EXECUTABLE="${HOME}/miniconda/envs/p4env/bin/python"
-    -DENABLE_gdma=ON
-    -DENABLE_PLUGIN_TESTING=ON
-    -DCMAKE_INSTALL_PREFIX=${HOME}/build/psi4-bin
-- cd build
-- make -j2
-- make install >& psi4_install.log
-- export PATH="$HOME/build/psi4-bin/bin:$PATH"
+#- cd psi4
+#- > 
+#    cmake -Bbuild -H. 
+#    -DCMAKE_CXX_COMPILER=${CXX_COMPILER} 
+#    -DCMAKE_C_COMPILER=${C_COMPILER} 
+#    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} 
+#    -DCMAKE_PREFIX_PATH=${HOME}/miniconda/envs/p4env
+#    -DPYTHON_EXECUTABLE="${HOME}/miniconda/envs/p4env/bin/python"
+#    -DENABLE_gdma=ON
+#    -DENABLE_PLUGIN_TESTING=ON
+#    -DCMAKE_INSTALL_PREFIX=${HOME}/build/psi4-bin
+#- cd build
+#- make -j2
+#- make install >& psi4_install.log
+#- export PATH="$HOME/build/psi4-bin/bin:$PATH"
 - hash -r
 - which psi4
+- psi4 --test
 # Compile forte
 - cd ${HOME}/build/evangelistalab/forte
 - ./cmake_setup --ambit-bindir=/home/travis/build/ambit-bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,9 +104,11 @@ install:
 #- export PATH="$HOME/build/psi4-bin/bin:$PATH"
 - hash -r
 - which psi4
-- psi4 --test
+# takes time - psi4 --test
 # Compile forte
 #- cd ${HOME}/build/evangelistalab/forte
+- cd
+- ls
 - ./cmake_setup --ambit-bindir=/home/travis/build/ambit-bin
 - bash cmake_commands
 - make -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ install:
 - conda info -a
 - conda create -q -n p4env python=$PYTHON_VER psi4 cmake -c psi4
 - source activate p4env
+- rm -rf $HOME/miniconda/envs/p4env/share/cmake/TargetLAPACK/
 - conda list
 #- python -V
 #- python -c 'import numpy; print(numpy.version.version)'
@@ -78,7 +79,7 @@ install:
 - pwd
 - git clone https://github.com/jturney/ambit.git ambit
 - cd ambit
-- cmake -H. -Bobjdir -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/home/travis/build/ambit-bin -DCMAKE_DISABLE_FIND_PACKAGE_TargetLAPACK=ON
+- cmake -H. -Bobjdir -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/home/travis/build/ambit-bin
 - cd objdir
 - make -j2
 - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ install:
 #- cd ${HOME}/build/evangelistalab/forte
 - cd
 - ls */*
-cd ${HOME}/build
+- cd ${HOME}/build
 - ls
 - ./cmake_setup --ambit-bindir=/home/travis/build/ambit-bin
 - bash cmake_commands

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
 - conda info -a
 - conda create -q -n p4env python=$PYTHON_VER psi4 cmake -c psi4
 - source activate p4env
-- rm -rf $HOME/miniconda/envs/p4env/share/cmake/TargetLAPACK/
+- rm -rf $HOME/miniconda/envs/p4env/share/cmake/Target*
 - conda list
 #- python -V
 #- python -c 'import numpy; print(numpy.version.version)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ install:
 - pwd
 - git clone https://github.com/jturney/ambit.git ambit
 - cd ambit
-- cmake -H. -Bobjdir -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/home/travis/build/ambit-bin
+- cmake -H. -Bobjdir -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/home/travis/build/ambit-bin -DCMAKE_DISABLE_FIND_PACKAGE_TargetLAPACK=ON
 - cd objdir
 - make -j2
 - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,3 +120,4 @@ branches:
   only:
   - master
   - travis
+  - psitravis

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,8 @@ install:
 #- cd ${HOME}/build/evangelistalab/forte
 - cd
 - ls */*
-- cd ${HOME}/build
+- echo ${TRAVIS_BUILD_DIR}
+- cd ${TRAVIS_BUILD_DIR}
 - ls
 - ./cmake_setup --ambit-bindir=/home/travis/build/ambit-bin
 - bash cmake_commands

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,10 +100,10 @@ install:
 - ${C_COMPILER} --version
 # Compile ambit
 - cd ${HOME}/build
-- pwd
 - git clone https://github.com/jturney/ambit.git ambit
 - cd ambit
-- cmake -H. -Bobjdir -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/home/travis/build/ambit-bin
+- cmake -H. -Bobjdir -C ${HOME}/miniconda/envs/p4env/share/cmake/psi4/psi4PluginCache.cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/home/travis/build/ambit-bin
+#- cmake -H. -Bobjdir -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/home/travis/build/ambit-bin
 - cd objdir
 - make -j2
 - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,6 +108,8 @@ install:
 # Compile forte
 #- cd ${HOME}/build/evangelistalab/forte
 - cd
+- ls */*
+cd ${HOME}/build
 - ls
 - ./cmake_setup --ambit-bindir=/home/travis/build/ambit-bin
 - bash cmake_commands

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ install:
 - cd ${HOME}/build
 - git clone https://github.com/jturney/ambit.git ambit
 - cd ambit
-- cmake -H. -Bobjdir -C ${HOME}/miniconda/envs/p4env/share/cmake/psi4/psi4PluginCache.cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/home/travis/build/ambit-bin
+- cmake -H. -Bobjdir -C${HOME}/miniconda/envs/p4env/share/cmake/psi4/psi4PluginCache.cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/home/travis/build/ambit-bin
 #- cmake -H. -Bobjdir -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/home/travis/build/ambit-bin
 - cd objdir
 - make -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,19 +106,14 @@ install:
 - which psi4
 # takes time - psi4 --test
 # Compile forte
-#- cd ${HOME}/build/evangelistalab/forte
-- cd
-- ls */*
-- echo ${TRAVIS_BUILD_DIR}
 - cd ${TRAVIS_BUILD_DIR}
-- ls
 - ./cmake_setup --ambit-bindir=/home/travis/build/ambit-bin
 - bash cmake_commands
 - make -j2
-- export PYTHONPATH="${HOME}/build/evangelistalab:$PYTHONPATH"
+- export PYTHONPATH="${TRAVIS_BUILD_DIR}/../:$PYTHONPATH"
 - hash -r
 script:
-- cd ${HOME}/build/evangelistalab/forte/tests/methods
+- cd ${TRAVIS_BUILD_DIR}/tests/methods
 - python run_forte_tests_travis.py 
 
 # safelist

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ install:
 - which psi4
 - psi4 --test
 # Compile forte
-- cd ${HOME}/build/evangelistalab/forte
+#- cd ${HOME}/build/evangelistalab/forte
 - ./cmake_setup --ambit-bindir=/home/travis/build/ambit-bin
 - bash cmake_commands
 - make -j2


### PR DESCRIPTION
I wouldn't accept this now unless you're really keen configuring Travis tonight, and in any case this should be squashed. It is working to the extent that Forte is running against pre-built Psi4 and freshly compiled ambit. All the tests that look to be running are passing, but the CASSCF and a few others are failing. Any chance these are expected failures?

https://travis-ci.org/loriab/forte/builds/235067991?utm_source=github_status&utm_medium=notification

Unfortunately using Psi4 pre-built with gcc-5.2 constrains Ambit and Forte, so the Travis build matrix isn't so useful.