### PR TITLE
CheMPS2, GlobalArrays, pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.pyc
 Makefile.*
 Makefile
+timer.dat
 *~
 
 # Qt Creator project files
@@ -25,6 +26,7 @@ Makefile
 /tests/methods/*/timer.dat
 /tests/methods/*/*.txt
 /tests/methods/*/*.npz
+tests/pytest/.cache/
 
 doc/doxygen/html
 doc/doxygen/latex

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 include(psi4OptionsTools)
 
+option_with_print(ENABLE_CheMPS2 "Enable CheMPS2 solver." OFF)
 option_with_print(ENABLE_OPENMP "Enable threadsafe linking to OpenMP parallelized programs." ON)
 option_with_print(ENABLE_MPI "Enable MPI parallelization" OFF)
 option_with_print(ENABLE_GA "Enable Global Arrays" OFF)
@@ -27,8 +28,9 @@ find_package(psi4 1.0 REQUIRED)
 
 find_package(TargetLAPACK REQUIRED)
 find_package(ambit REQUIRED)
-#find_package(CheMPS2 REQUIRED)
-
+if(ENABLE_CheMPS2)
+    find_package(CheMPS2 1.8.3 CONFIG REQUIRED)
+endif()
 
 add_psi4_plugin(forte
 src/active_dsrgpt2.cc
@@ -132,7 +134,9 @@ src/pci/pci_simple.cc
 )
 
 target_link_libraries(forte PRIVATE ambit::ambit)
-#target_link_libraries(forte PRIVATE CheMPS2::chemps2)
+if(TARGET CheMPS2::chemps2)
+    target_link_libraries(forte PRIVATE CheMPS2::chemps2)
+endif()
 
 target_include_directories(forte PRIVATE src/mini-boost)
 
@@ -145,4 +149,3 @@ endif()
 if(ENABLE_GA)
     target_link_libraries(forte PRIVATE GlobalArrays::ga)
 endif()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,11 @@ include(psi4OptionsTools)
 
 option_with_print(ENABLE_OPENMP "Enable threadsafe linking to OpenMP parallelized programs." ON)
 option_with_print(ENABLE_MPI "Enable MPI parallelization" OFF)
+option_with_print(ENABLE_GA "Enable Global Arrays" OFF)
 #option_with_print(ENABLE_GENERIC "Enable mostly static linking in shared library" OFF)
 
 include(autocmake_omp)
 include(autocmake_mpi)  # MPI option A
-#include(custom_cxxstandard)
 #include(custom_static_library)
 
 
@@ -140,5 +140,9 @@ if(ENABLE_MPI)
     target_link_libraries(forte PRIVATE ${MPI_CXX_LIBRARIES})  # MPI option A
     #target_link_libraries(forte PRIVATE MPI::MPI_CXX)  # MPI option B
     #target_add_definitions(forte PRIVATE HAVE_MPI)  # MPI option B
+endif()
+
+if(ENABLE_GA)
+    target_link_libraries(forte PRIVATE GlobalArrays::ga)
 endif()
 

--- a/__init__.py
+++ b/__init__.py
@@ -40,6 +40,5 @@ from .pymodule import *
 import os
 import psi4
 plugdir = os.path.split(os.path.abspath(__file__))[0]
-sofile = plugdir + '/' + os.path.split(plugdir)[1] + '.so'
-psi4.core.plugin_load(sofile)
-
+PLUGIN_SOFILE = plugdir + '/' + os.path.split(plugdir)[1] + '.so'
+psi4.core.plugin_load(PLUGIN_SOFILE)

--- a/cmake/FindGlobalArrays.cmake
+++ b/cmake/FindGlobalArrays.cmake
@@ -1,0 +1,109 @@
+#.rst:
+# FindGlobalArrays
+# ----------------
+#
+# Find the native GlobalArrays includes and libraries.
+#
+# Imported Targets
+# ^^^^^^^^^^^^^^^^
+#
+# If GA is found, this module defines the following :prop_tgt:`IMPORTED`
+# targets::
+#
+#  GlobalArrays::ga      - The main GA library.
+#  GA::armrrays::ga ci   - The ARMCI support library used by GA.
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module will set the following variables in your project::
+#
+#  GlobalArrays_FOUND          - True if GA found on the local system
+#  GlobalArrays_INCLUDE_DIRS   - Location of GA header files.
+#  GlobalArrays_LIBRARIES      - The GA libraries.
+#
+# Hints
+# ^^^^^
+#
+# Set ``GA_ROOT_DIR`` to a directory that contains a GA installation.
+#
+# This script expects to find libraries at ``$GA_ROOT_DIR/lib`` and the GA
+# headers at ``$GA_ROOT_DIR/include/ga/src``.
+#
+# Cache Variables
+# ^^^^^^^^^^^^^^^
+#
+# This module may set the following variables depending on platform and type
+# of GA installation discovered.  These variables may optionally be set to
+# help this module find the correct files::
+#
+#  ARMCI_LIBRARY       - Location of the ARMCI library.
+#  GA_LIBRARY          - Location of the GA library.
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+include (GNUInstallDirs)
+
+#=============================================================================
+# If the user has provided ``GA_ROOT_DIR``, use it!  Choose items found
+# at this location over system locations.
+if( EXISTS "$ENV{GA_ROOT_DIR}" )
+  file( TO_CMAKE_PATH "$ENV{GA_ROOT_DIR}" GA_ROOT_DIR )
+  set( GA_ROOT_DIR "${GA_ROOT_DIR}" CACHE PATH "Prefix for GlobalArrays installation." )
+endif()
+
+#=============================================================================
+# Set GA_INCLUDE_DIRS and GA_LIBRARIES. Try
+# to find the libraries at $GA_ROOT_DIR (if provided) or in standard system
+# locations.  These find_library and find_path calls will prefer custom
+# locations over standard locations (HINTS).  If the requested file is not found
+# at the HINTS location, standard system locations will be still be searched
+# (/usr/lib64 (Redhat), lib/i386-linux-gnu (Debian)).
+
+find_path( GA_INCLUDE_DIR
+  NAMES global/src/ga.h
+  HINTS ${GA_ROOT_DIR}
+  PATH_SUFFIXES include ${CMAKE_INSTALL_INCLUDEDIR})
+find_library( GA_LIBRARY
+  NAMES ga
+  HINTS ${GA_ROOT_DIR}
+  PATH_SUFFIXES lib lib64 ${CMAKE_INSTALL_LIBDIR})
+find_library( ARMCI_LIBRARY
+  NAMES armci
+  HINTS ${GA_ROOT_DIR}
+  PATH_SUFFIXES lib lib64 ${CMAKE_INSTALL_LIBDIR})
+set( GlobalArrays_INCLUDE_DIRS ${GA_INCLUDE_DIR} )
+set( GlobalArrays_LIBRARIES ${GA_LIBRARY} ${ARMCI_LIBRARY} )
+
+#=============================================================================
+# handle the QUIETLY and REQUIRED arguments and set GA_FOUND to TRUE if all
+# listed variables are TRUE
+find_package_handle_standard_args( GlobalArrays
+  FOUND_VAR
+    GSAL_FOUND
+  REQUIRED_VARS
+    GlobalArrays_INCLUDE_DIR
+    GlobalArrays_LIBRARY
+    ARMCI_LIBRARY
+    )
+
+mark_as_advanced( GA_ROOT_DIR GA_LIBRARY GA_INCLUDE_DIR
+  ARMCI_LIBRARY )
+
+#=============================================================================
+
+if( GlobalArrays_FOUND AND NOT TARGET GlobalArrays::ga )
+    add_library( GlobalArrays::ga    UNKNOWN IMPORTED )
+    add_library( GlobalArrays::armci UNKNOWN IMPORTED )
+    set_target_properties( GlobalArrays::armci PROPERTIES
+      IMPORTED_LOCATION                 "${ARMCI_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES     "${GA_INCLUDE_DIR}"
+      IMPORTED_LINK_INTERFACE_LANGUAGES "CXX" )
+    set_target_properties( GlobalArrays::ga PROPERTIES
+      IMPORTED_LOCATION                 "${GA_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES     "${GA_INCLUDE_DIR}"
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      INTERFACE_COMPILE_DEFINITIONS     "HAVE_GA"
+      INTERFACE_LINK_LIBRARIES          GlobalArrays::armci )
+endif()
+

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -1,0 +1,32 @@
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def set_up_overall(request):
+    import psi4
+    psi4.set_output_file("pytest_output.dat", False)
+    request.addfinalizer(tear_down)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def set_up():
+    import psi4
+    psi4.core.clean()
+    psi4.core.clean_options()
+    import forte
+    from forte import PLUGIN_SOFILE
+    psi4.core.plugin_load(PLUGIN_SOFILE)  # reloads plugin options
+    psi4.set_output_file("pytest_output.dat", True)
+
+
+def tear_down():
+    import os
+    import glob
+    patterns = ['cavity.*', 'grid*', 'pytest_output.*h5',
+                'pytest_output.dat',
+                '*pcmsolver.inp', 'PEDRA.OUT*', 'timer.dat']
+    pytest_scratches = []
+    for pat in patterns:
+        pytest_scratches.extend(glob.glob(pat))
+    for fl in pytest_scratches:
+        os.unlink(fl)

--- a/tests/pytest/test_aci.py
+++ b/tests/pytest/test_aci.py
@@ -1,0 +1,125 @@
+import psi4
+
+def test_psi4_basic():
+    """tu1-h2o-energy"""
+    #! Sample HF/cc-pVDZ H2O computation
+
+    h2o = psi4.geometry("""
+      O
+      H 1 0.96
+      H 1 0.96 2 104.5
+    """)
+
+    psi4.set_options({'basis': "cc-pVDZ"})
+    psi4.energy('scf')
+
+    assert psi4.compare_values(-76.0266327341067125, psi4.get_variable('SCF TOTAL ENERGY'), 6, 'SCF energy')
+
+
+# LAB 25 May 2017 segfaulting after PQ-space in both psithon and psiapi forms
+#def test_aci_1():
+#    """Basic ACI calculation with energy threshold selection"""
+#
+#    import forte
+#
+#    refscf = -14.839846512738 #TEST
+#    refaci = -14.888681221669 #TEST
+#    refacipt2 = -14.890314474716 #TEST
+#
+#    li2 = psi4.geometry("""
+#       Li
+#       Li 1 2.0000
+#    """)
+#
+#    psi4.set_options({
+#      'basis': 'DZ',
+#      'e_convergence': 10,
+#      'd_convergence': 10,
+#      'r_convergence': 10,
+#      'guess': 'gwh',
+#    })
+#
+#    psi4.set_module_options("SCF", {
+#        'scf_type': 'pk',
+#        'reference': 'rhf',
+#        'docc': [2,0,0,0,0,1,0,0],
+#    })
+#
+#    psi4.set_module_options("FORTE", {
+#        'job_type': 'aci',
+#        'multiplicity': 1,
+#        'ACI_SELECT_TYPE': 'energy',
+#        'sigma': 0.00001000,
+#        'gamma': 100.0,
+#        'aci_nroot': 1,
+#        'charge': 0,
+#        'aci_perturb_select': True,
+#        'aci_enforce_spin_complete': False,
+#    })
+#
+#    psi4.energy('scf')
+#    assert psi4.compare_values(refscf, psi4.get_variable("CURRENT ENERGY"),9, "SCF energy")
+#
+#    psi4.energy('forte')
+#    assert psi4.compare_values(refaci, psi4.get_variable("ACI ENERGY"),9, "ACI energy")
+#    assert psi4.compare_values(refacipt2, psi4.get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy")
+
+
+def test_aci_10():
+    """Perform aci on benzyne"""
+
+    refscf    = -229.20378006852584
+    refaci    = -229.359450812283
+    refacipt2 = -229.360444943286
+
+    mbenzyne = psi4.geometry("""
+      0 1
+       C   0.0000000000  -2.5451795941   0.0000000000
+       C   0.0000000000   2.5451795941   0.0000000000
+       C  -2.2828001669  -1.3508352528   0.0000000000
+       C   2.2828001669  -1.3508352528   0.0000000000
+       C   2.2828001669   1.3508352528   0.0000000000
+       C  -2.2828001669   1.3508352528   0.0000000000
+       H  -4.0782187459  -2.3208602146   0.0000000000
+       H   4.0782187459  -2.3208602146   0.0000000000
+       H   4.0782187459   2.3208602146   0.0000000000
+       H  -4.0782187459   2.3208602146   0.0000000000
+
+      units bohr
+    """)
+
+    psi4.set_options({
+       'basis': 'DZ',
+       'df_basis_mp2': 'cc-pvdz-ri',
+       'reference': 'uhf',
+       'scf_type': 'pk',
+       'd_convergence': 10,
+       'e_convergence': 12,
+       'guess': 'gwh',
+    })
+
+    psi4.set_module_options("FORTE", {
+      'root_sym': 0,
+      'frozen_docc':     [2,1,0,0,0,0,2,1],
+      'restricted_docc': [3,2,0,0,0,0,2,3],
+      'active':          [1,0,1,2,1,2,1,0],
+      'multiplicity': 1,
+      'aci_nroot': 1,
+      'job_type': 'aci',
+      'sigma': 0.001,
+      'aci_select_type': 'aimed_energy',
+      'aci_spin_projection': 1,
+      'aci_enforce_spin_complete': True,
+      'aci_add_aimed_degenerate': False,
+      'aci_project_out_spin_contaminants': False,
+      'diag_algorithm': 'full',
+      'aci_quiet_mode': True,
+    })
+
+    scf = psi4.energy('scf')
+    assert psi4.compare_values(refscf, scf,10,"SCF Energy")
+
+    psi4.energy('forte')
+    assert psi4.compare_values(refaci, psi4.get_variable("ACI ENERGY"),10,"ACI energy")
+    assert psi4.compare_values(refacipt2, psi4.get_variable("ACI+PT2 ENERGY"),8,"ACI+PT2 energy")
+

--- a/tests/pytest/test_ecp.py
+++ b/tests/pytest/test_ecp.py
@@ -1,0 +1,77 @@
+import psi4
+import pytest
+
+
+def is_psi4_new_enough(version_feature_introduced):
+    import psi4
+    from pkg_resources import parse_version
+    return parse_version(psi4.__version__) >= parse_version(version_feature_introduced)
+
+
+using_psi4_1p1 = pytest.mark.skipif(is_psi4_new_enough("1.2a1.dev190") is False,
+                                    reason="Psi4 1.1 not include ECPs. Update to developement head")
+
+
+@using_psi4_1p1
+def test_fci_ecp_1():
+    """Water-Argon complex with ECP present; RHF energy from FCI."""
+
+    nucenergy =   23.253113522963400
+    refenergy =  -96.673557940220277
+
+    arwater = psi4.geometry("""
+        Ar  0.000000000000     0.000000000000     3.000000000000
+        O   0.000000000000     0.000000000000    -0.071143036192
+        H   0.000000000000    -0.758215806856     0.564545805801
+        H   0.000000000000     0.758215806856     0.564545805801
+    """)
+
+    psi4.set_options({
+        'scf_type':       'pk',
+        'basis':          'lanl2dz',
+        'df_scf_guess':   False,
+        'd_convergence':  10,
+    })
+
+    psi4.set_module_options("FORTE", {
+      'job_type': 'fci',
+      'restricted_docc': [5,0,2,2],
+      'active':          [0,0,0,0],
+    })
+
+    e = psi4.energy('forte')
+    assert psi4.compare_values(nucenergy, arwater.nuclear_repulsion_energy(), 10, "Nuclear repulsion energy")
+    assert psi4.compare_values(refenergy, e, 10, "FCI energy with ECP")
+
+
+@using_psi4_1p1
+def test_fci_ecp_2():
+    """Water-Argon complex with ECP present; CASCI(6,6)."""
+
+    nucenergy =   23.253113522963400
+    refenergy =  -96.68319147222
+
+    arwater = psi4.geometry("""
+        Ar  0.000000000000     0.000000000000     3.000000000000
+        O   0.000000000000     0.000000000000    -0.071143036192
+        H   0.000000000000    -0.758215806856     0.564545805801
+        H   0.000000000000     0.758215806856     0.564545805801
+    """)
+
+    psi4.set_options({
+        'scf_type':      'pk',
+        'basis':         'lanl2dz',
+        'df_scf_guess':  False,
+        'd_convergence': 10,
+    })
+
+    psi4.set_module_options("FORTE", {
+      'job_type': 'fci',
+      'restricted_docc': [4,0,1,1],
+      'active':          [2,0,2,2],
+    })
+
+    e = psi4.energy('forte')
+    assert psi4.compare_values(nucenergy, arwater.nuclear_repulsion_energy(), 10, "Nuclear repulsion energy")
+    assert psi4.compare_values(refenergy, e, 10, "FCI energy with ECP")
+


### PR DESCRIPTION
- [x] Includes a sketchy GlobalArrays locator machinery via CMake. Untested. GlobalArrays does, in the newest version, build alternately through CMake, but the min CMake they require is too old to allow imported targets. I think GA is sufficiently remote from us to not mess with their build system and contribute back.
- [x] Allows CheMPS2 to be optional. Do `cmake ... -DENABLE_CheMPS2=ON` to require it. I did version `1.8.3` (same as Psi4) more for the build version than the contents version.
- [x] Introduces pytest. After build, just `pytest -v` and you should get 4 passes or 2 passes/2 skipped on psi4 1.1 (no ecp)
   * Requires rewriting tests in PsiAPI mode (straightforward but tedious). Files can contain multiple tests. Most appropriate use of file grouping is to quickly test subset (`pytest -v test_aci.py`)
   * To work, requires Psi4 to have [these two lines](https://github.com/psi4/psi4/blob/master/psi4/src/export_plugins.cc#L66-L67) _outside_ the `if` statement. Otherwise only first-run forte test will work.
- [x] Using `PLUGIN_SOFILE` from `__init__py` as a global module variable

@jturney