### PR TITLE
Decouple the DSRG code with diagonalization

### DIFF
--- a/src/active_space_solver.h
+++ b/src/active_space_solver.h
@@ -34,6 +34,7 @@
 
 #include "helpers.h"
 #include "integrals/integrals.h"
+#include "reference.h"
 
 namespace psi {
 namespace forte {
@@ -51,6 +52,9 @@ class ActiveSpaceSolver : public Wavefunction {
     // enable deletion of a Derived* through a Base*
     virtual ~ActiveSpaceSolver() = default;
     //    virtual ~ActiveSpaceSolver() {};
+
+//    /// Return the reference object that contains density cumulants
+//    virtual Reference reference(const int& max_rdm_level) = 0;
 
   protected:
     // pure virtual implementation

--- a/src/fci/fci.h
+++ b/src/fci/fci.h
@@ -83,6 +83,11 @@ class FCI : public ActiveSpaceSolver {
     virtual double solver_compute_energy();
     /// Return a reference object
     Reference reference();
+
+//    /// TODO: reference needs to be virtual
+//    virtual Reference reference(const int& max_rdm_level);
+
+
     /// Set the print level
     void set_print(int value) { print_ = value; }
     /// Set the maximum RDM computed (0 - 3)

--- a/src/mrdsrg-helper/run_dsrg.h
+++ b/src/mrdsrg-helper/run_dsrg.h
@@ -9,17 +9,36 @@
 #include "../mrdsrg-spin-integrated/master_mrdsrg.h"
 #include "../mrdsrg-spin-integrated/three_dsrg_mrpt2.h"
 #include "../mrdsrg-spin-integrated/mrdsrg.h"
+#include "../dynamic_correlation_solver.h"
+#include "../active_space_solver.h"
 
 namespace psi {
 namespace forte {
 
 /// Set the DSRG options
-void set_DSRG_options(ForteOptions& foptions);
+void set_dsrg_options(ForteOptions& foptions);
+
+/// Select active-space solver according to CAS_TYPE
+std::shared_ptr<ActiveSpaceSolver>
+select_dsrg_actv_solver(SharedWavefunction ref_wfn, Options& options,
+                        std::shared_ptr<ForteIntegrals> ints,
+                        std::shared_ptr<MOSpaceInfo> mo_space_info);
+
+/// Select DSRG code according to JOB_TYPE
+std::shared_ptr<DynamicCorrelationSolver>
+select_dsrg_code(SharedWavefunction ref_wfn, Options& options, std::shared_ptr<ForteIntegrals> ints,
+                 std::shared_ptr<MOSpaceInfo> mo_space_info, Reference reference);
 
 /// Reference relaxation, relaxed dipoles, transition dipoles,
 /// general sequence of running dsrg should be implemented in this class
 
-//class RUN_DSRG {
+/// Compute DSRG energy
+void compute_dsrg_energy(SharedWavefunction ref_wfn, Options& options,
+                         std::shared_ptr<ForteIntegrals> ints,
+                         std::shared_ptr<MOSpaceInfo> mo_space_info);
+
+
+// class RUN_DSRG {
 //  public:
 //    /**
 //     * Constructor
@@ -37,10 +56,9 @@ void set_DSRG_options(ForteOptions& foptions);
 //    /// Compute DSRG density
 //    void compute_dsrg_density();
 
-//protected:
+// protected:
 //    /// Reference type (FCI for FCI_MO)
 //    std::string ref_type_;
-
 
 //};
 }


### PR DESCRIPTION
Here are the goals of this overhaul.

- [ ] Stage 1: DSRG-MRPT2/MRPT3 energy relaxations
    - [ ] DSRG-MRPT2, THREE-DSRG-MRPT2, DSRG-MRPT3 inherit from MASTER_DSRG and 
        - [ ] Support operations:
            - [x] `void compute_energy()`
            - [x] `shared_ptr<FCIIntegrals> compute_Hbar()`
            - [ ] `void set_reference(Reference)` or pass `Reference&`/`shared_ptr<Reference>`
    - [x] MASTER_DSRG inherits from DynamicCorrelationSolver
    - [ ] FCI and FCI_MO inherit from ActiveSpaceSolver
        - [ ] Support operations:
            - [ ] `void compute_energy()`
                - [x] FCI
                - [ ] FCI_MO
            - [ ] `Reference reference(max_rdm_level)`
                - [ ] FCI
                - [ ] FCI_MO
            - [ ] `void set_fci_ints(shared_ptr<FCIIntegrals>)`
                - [ ] FCI
                - [ ] FCI_MO
    - [ ] Combine everything in `compute_dsrg_energy` of *run_dsrg.cc*.

- [ ] Stage 2: DSRG-MRPT2/MRPT3 dipoles; adapt ACI/PCI to ActiveSpaceSolver

- [ ] Stage 3: MRDSRG inherits from MASTER_DSRG

- [ ] Stage 4: adapt V2RDM/DMRG to ActiveSpaceSolver