### PR TITLE
Added variable RELAX_E_CONVERGENCE to control relaxation convergence.

### DIFF
--- a/src/forte_old_options.cc
+++ b/src/forte_old_options.cc
@@ -169,6 +169,9 @@ void forte_old_options(Options& options) {
     /*- The energy convergence criterion -*/
     options.add_double("E_CONVERGENCE", 1.0e-8);
 
+    /*- The energy relaxation convergence criterion -*/
+    options.add_double("RELAX_E_CONVERGENCE", 1.0e-8);
+
     /*- The number of roots computed -*/
     options.add_int("NROOT", 1);
 

--- a/src/mrdsrg-spin-integrated/mrdsrg.cc
+++ b/src/mrdsrg-spin-integrated/mrdsrg.cc
@@ -393,7 +393,7 @@ double MRDSRG::compute_energy_relaxed() {
 
         // iteration variables
         int cycle = 0, maxiter = options_.get_int("MAXITER_RELAX_REF");
-        double e_conv = options_.get_double("E_CONVERGENCE");
+        double e_conv = options_.get_double("RELAX_E_CONVERGENCE");
         std::vector<double> Edsrg_vec, Erelax_vec;
         std::vector<double> Edelta_dsrg_vec, Edelta_relax_vec;
         bool converged = false, failed = false;
@@ -563,7 +563,7 @@ double MRDSRG::compute_energy_sa() {
     // iteration variables
     double Edsrg_sa = 0.0, Erelax_sa = 0.0;
     int cycle = 0, maxiter = options_.get_int("MAXITER_RELAX_REF");
-    double e_conv = options_.get_double("E_CONVERGENCE");
+    double e_conv = options_.get_double("RELAX_E_CONVERGENCE");
     std::vector<double> Edsrg_sa_vec, Erelax_sa_vec;
     std::vector<double> Edelta_dsrg_sa_vec, Edelta_relax_sa_vec;
     bool converged = false, failed = false;


### PR DESCRIPTION
MRDSRG relaxation convergence was controlled by e_convergence. This PR separates the convergence criteria so that relaxation process can converge at a larger energy difference where the convergence of HF and CASSCF is not affected.

- [ ] Ready to go.