### PR TITLE
Print the reference energy immediately after recomputing.

### DIFF
--- a/src/mrdsrg-spin-integrated/mrdsrg.cc
+++ b/src/mrdsrg-spin-integrated/mrdsrg.cc
@@ -496,8 +496,7 @@ double MRDSRG::compute_energy_relaxed() {
                 Eref_ = compute_reference_energy(H_, F_, V_);
             }
 
-            outfile->Printf("\n\n  Reference rotation done. The reference energy is recomputed.");
-            outfile->Printf("\n    E0 (reference) = %23.15f", Eref_);
+            outfile->Printf("\n\n  Updated reference energy E0 = %23.15f", Eref_);
 
             // test convergence
             if (std::fabs(Edelta_dsrg) < e_conv && std::fabs(Edelta_relax) < e_conv) {

--- a/src/mrdsrg-spin-integrated/mrdsrg.cc
+++ b/src/mrdsrg-spin-integrated/mrdsrg.cc
@@ -496,6 +496,9 @@ double MRDSRG::compute_energy_relaxed() {
                 Eref_ = compute_reference_energy(H_, F_, V_);
             }
 
+            outfile->Printf("\n\n  Reference rotation done. The reference energy is recomputed.");
+            outfile->Printf("\n    E0 (reference) = %23.15f", Eref_);
+
             // test convergence
             if (std::fabs(Edelta_dsrg) < e_conv && std::fabs(Edelta_relax) < e_conv) {
                 converged = true;


### PR DESCRIPTION
This PR prints the recomputed reference energy before the DSRG iterations.
It enables estimation of results during computation when a job takes a long time.
- [x] Ready to go.