### PR TITLE
Using ACI with DSRG for computing excited states

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,30 @@ matrix:
       - BUILD_TYPE='Debug'
       - NAME='clang'
       - VERSION='3.6'
+      - MAX_DET_ORB=64
+  - os: linux
+    compiler: clang
+    addons: &1
+      apt:
+        sources:
+        - llvm-toolchain-precise-3.6
+        - ubuntu-toolchain-r-test
+        - george-edison55-precise-backports
+        packages:
+        - liblapack-dev
+        - clang-3.6
+        - libhdf5-serial-dev
+        - gfortran
+        - g++-4.9
+    env:
+      - CXX_COMPILER='clang++-3.6'
+      - PYTHON_VER='3.6'
+      - C_COMPILER='clang-3.6'
+      - Fortran_COMPILER='gfortran'
+      - BUILD_TYPE='Debug'
+      - NAME='clang'
+      - VERSION='3.6'
+      - MAX_DET_ORB=128
 # - os: linux
 #   compiler: clang
 #   addons: &2
@@ -156,13 +180,18 @@ install:
 # Compile forte
 - cd ${HOME}/build/evangelistalab/forte
 - FORTE_CMAKE_COM=$(psi4 --plugin-compile)
-- $FORTE_CMAKE_COM -Dambit_DIR=/home/travis/build/ambit-bin/share/cmake/ambit/ -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DENABLE_ForteTests=ON
+- $FORTE_CMAKE_COM -Dambit_DIR=/home/travis/build/ambit-bin/share/cmake/ambit/ -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DMAX_DET_ORB=${MAX_DET_ORB} -DENABLE_ForteTests=ON
 - make -j2
 - export PYTHONPATH="${HOME}/build/evangelistalab:$PYTHONPATH"
 - hash -r
 script:
 - cd ${HOME}/build/evangelistalab/forte/tests/methods
 - python run_forte_tests_travis.py 
+- grep 'Size of Determinant class' aci-1/output.dat
+- if [ "$MAX_DET_ORB" -ge "128" ]; then
+    cd ${HOME}/build/evangelistalab/forte/tests/large_det;
+    python run_forte_tests_travis.py;
+  fi
 - cd ${HOME}/build/evangelistalab/forte
 - ./forte_tests
 - ./forte_benchmarks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option_with_print(ENABLE_CheMPS2 "Enable CheMPS2 solver." OFF)
 option_with_print(ENABLE_OPENMP "Enable threadsafe linking to OpenMP parallelized programs." ON)
 option_with_print(ENABLE_MPI "Enable MPI parallelization" OFF)
 option_with_print(ENABLE_GA "Enable Global Arrays" OFF)
+option_with_print(MAX_DET_ORB  "Set the maximum number of orbitals (spin adapted) in a determinant."  64)
 #option_with_print(ENABLE_GENERIC "Enable mostly static linking in shared library" OFF)
 
 include(autocmake_omp)
@@ -173,8 +174,11 @@ endif()
 target_include_directories(forte PRIVATE src/mini-boost)
 
 ## 64bit implementation
-add_definitions(-DSMALL_BITSET)
-set(SMALL_BITSET true)
+if(MAX_DET_ORB LESS_EQUAL 64)
+    add_definitions(-DSMALL_BITSET)
+else()
+    add_definitions(-DMAX_DET_ORB=${MAX_DET_ORB})
+endif()
 
 if(ENABLE_MPI)
     target_link_libraries(forte PRIVATE ${MPI_CXX_LIBRARIES})  # MPI option A

--- a/src/aci/aci.cc
+++ b/src/aci/aci.cc
@@ -495,7 +495,8 @@ double AdaptiveCI::compute_energy() {
 
     DeterminantHashVec PQ_space;
 
-    if (options_.get_str("ACI_SCREEN_ALG") == "CORE") {
+    if (options_.get_str("ACI_SCREEN_ALG") == "CORE" or
+        options_.get_str("ACI_SCREEN_ALG") == "BATCH_CORE") {
         ex_alg_ = "ROOT_ORTHOGONALIZE";
     }
 
@@ -509,7 +510,8 @@ double AdaptiveCI::compute_energy() {
             root_ = i;
         }
 
-        if( (options_.get_str("ACI_SCREEN_ALG") == "CORE") and (i > 0) ){
+        if ( (options_.get_str("ACI_SCREEN_ALG") == "CORE" or
+            options_.get_str("ACI_SCREEN_ALG") == "BATCH_CORE") and (i>0) ) {
             ref_root_ = i-1; 
         }
 
@@ -879,7 +881,7 @@ void AdaptiveCI::find_Q_space(DeterminantHashVec& P_space, DeterminantHashVec& P
         get_excited_determinants_restrict(nroot_,evecs, evals, P_space, F_space);
     } else if (screen_alg == "CORE" ){
         get_excited_determinants_core(evecs, evals, P_space, F_space);
-    } else if ( screen_alg == "BATCH_HASH" ){
+    } else if ( screen_alg == "BATCH_HASH" or screen_alg == "BATCH_CORE" ){
         // hash batch
         remainder = get_excited_determinants_batch( evecs, evals, P_space, F_space);
     } else if ( screen_alg == "BATCH_VEC" ){
@@ -1873,7 +1875,8 @@ void AdaptiveCI::compute_aci(DeterminantHashVec& PQ_space, SharedMatrix& PQ_evec
     std::vector<double> P_ref_evecs;
     DeterminantHashVec P_space(initial_reference_);
 
-    if ((options_.get_str("ACI_SCREEN_ALG") == "CORE") and (root_ > 0)) {
+    if (( (options_.get_str("ACI_SCREEN_ALG") == "CORE") or (options_.get_str("ACI_SCREEN_ALG") == "BATCH_CORE") )
+             and (root_ > 0)) {
 
         int nf_orb = options_.get_int("ACI_NFROZEN_CORE");
         int ncstate = options_.get_int("ACI_ROOTS_PER_CORE");

--- a/src/aci/aci.cc
+++ b/src/aci/aci.cc
@@ -1896,8 +1896,10 @@ void AdaptiveCI::compute_aci(DeterminantHashVec& PQ_space, SharedMatrix& PQ_evec
 
         for (int n = 0, max_n = avir.size(); n < max_n; ++n) {
             if ((mo_symmetry_[hole_] ^ mo_symmetry_[avir[n]]) == 0) {
-                det.set_alfa_bit(avir[particle], true);
-                detb.set_beta_bit(avir[particle], true);
+                //det.set_alfa_bit(avir[particle], true);
+                //detb.set_beta_bit(avir[particle], true);
+                det.set_alfa_bit(avir[n], true);
+                detb.set_beta_bit(avir[n], true);
                 break;
             }
         }

--- a/src/aci/aci.cc
+++ b/src/aci/aci.cc
@@ -695,7 +695,7 @@ double AdaptiveCI::compute_energy() {
             op_.op_s_lists(final_wfn_);
             op_.tp_s_lists(final_wfn_);
         }
-        compute_rdms(fci_ints_, final_wfn_, op_, PQ_evecs, 0, 0);
+        compute_rdms(fci_ints_, final_wfn_, op_, PQ_evecs, ref_root_, ref_root_);
         list_time += totaltt.get();
         outfile->Printf("\n  RDMS took %1.6f", list_time);
     }
@@ -1749,7 +1749,7 @@ void AdaptiveCI::set_max_rdm(int rdm) {
 Reference AdaptiveCI::reference() {
     // const std::vector<Determinant>& final_wfn =
     //     final_wfn_.determinants();
-    CI_RDMS ci_rdms(final_wfn_, fci_ints_, evecs_, 0, 0);
+    CI_RDMS ci_rdms(final_wfn_, fci_ints_, evecs_, ref_root_, ref_root_);
     ci_rdms.set_max_rdm(rdm_level_);
     Reference aci_ref = ci_rdms.reference(ordm_a_, ordm_b_, trdm_aa_, trdm_ab_, trdm_bb_, trdm_aaa_,
                                           trdm_aab_, trdm_abb_, trdm_bbb_);

--- a/src/aci/aci.h
+++ b/src/aci/aci.h
@@ -268,6 +268,8 @@ class AdaptiveCI : public Wavefunction {
 
     bool set_rdm_ = false;
 
+    bool core_ = false;
+
     /// The alpha MO always unoccupied
     int hole_;
 
@@ -352,6 +354,10 @@ class AdaptiveCI : public Wavefunction {
 
     /// (DEFAULT)  Builds excited determinants for a bin, uses all threads, hash-based
     det_hash<double> get_bin_F_space(int bin, int nbin,double E0, SharedMatrix evecs,
+                                      DeterminantHashVec& P_space);
+
+    /// Builds core excited determinants for a bin, uses all threads, hash-based
+    det_hash<double> get_bin_F_space_core(int bin, int nbin,double E0, SharedMatrix evecs,
                                       DeterminantHashVec& P_space);
 
     /// Builds excited determinants in batch using sorting of vectors

--- a/src/aci/aci.h
+++ b/src/aci/aci.h
@@ -330,7 +330,10 @@ class AdaptiveCI : public Wavefunction {
                                            std::vector<std::pair<double, Determinant>>& F_space);
 
     /// Get excited determinants with a specified hole
-    void get_excited_determinants_restrict(SharedMatrix evecs, SharedVector evals,  DeterminantHashVec& P_space,
+    void get_excited_determinants_restrict(int nroot, SharedMatrix evecs, SharedVector evals,  DeterminantHashVec& P_space,
+                                           std::vector<std::pair<double, Determinant>>& F_space);
+    /// Get excited determinants with a specified hole
+    void get_excited_determinants_core(SharedMatrix evecs, SharedVector evals,  DeterminantHashVec& P_space,
                                            std::vector<std::pair<double, Determinant>>& F_space);
 
     // Optimized for a single root
@@ -440,6 +443,8 @@ class AdaptiveCI : public Wavefunction {
                                                             SharedMatrix& evecs, int nroot);
 
     std::vector<std::tuple<double, int, int>> sym_labeled_orbitals(std::string type);
+
+    std::vector<std::pair<int, Determinant>> ras_masks();
 
     //    int david2(double **A, int N, int M, double *eps, double **v,double
     //    cutoff, int print);

--- a/src/aci/aci.h
+++ b/src/aci/aci.h
@@ -192,8 +192,6 @@ class AdaptiveCI : public Wavefunction {
     double screen_thresh_;
     /// The number of roots computed
     int nroot_;
-    /// Use threshold from perturbation theory?
-    bool perturb_select_;
 
     /// Add missing degenerate determinants excluded from the aimed selection?
     bool add_aimed_degenerate_;
@@ -309,26 +307,23 @@ class AdaptiveCI : public Wavefunction {
                       SharedVector evals, SharedMatrix evecs);
 
     /// Batched version of find q space
-    void find_q_space_batched(DeterminantHashVec& P_space, DeterminantHashVec& PQ_space,
-                              SharedVector evals, SharedMatrix evecs);
-
-    /// Streamlined version of find q space
-    void default_find_q_space(DeterminantHashVec& P_space, DeterminantHashVec& PQ_space,
-                              SharedVector evals, SharedMatrix evecs);
-
+//    void find_q_space_batched(DeterminantHashVec& P_space, DeterminantHashVec& PQ_space,
+//                              SharedVector evals, SharedMatrix evecs);
+//
+//    /// Streamlined version of find q space
+//    void default_find_q_space(DeterminantHashVec& P_space, DeterminantHashVec& PQ_space,
+//                              SharedVector evals, SharedMatrix evecs);
+//
     /// Find all the relevant excitations out of the P space
-    void find_q_space(DeterminantHashVec& P_space, DeterminantHashVec& PQ_space, int nroot,
-                      SharedVector evals, SharedMatrix evecs);
+//    void find_q_space(DeterminantHashVec& P_space, DeterminantHashVec& PQ_space, int nroot,
+//                      SharedVector evals, SharedMatrix evecs);
 
     /// Generate set of state-averaged q-criteria and determinants
-    double average_q_values(int nroot, std::vector<double>& C1, std::vector<double>& E2);
-
-    /// Get criteria for a specific root
-    double root_select(int nroot, std::vector<double>& C1, std::vector<double>& E2);
+    double average_q_values(int nroot, std::vector<double>& E2);
 
     /// Find all the relevant excitations out of the P space - single root
     /// version
-    void find_q_space_single_root(int nroot, SharedVector evals, SharedMatrix evecs);
+//    void find_q_space_single_root(int nroot, SharedVector evals, SharedMatrix evecs);
 
     /// Basic determinant generator (threaded, no batching, all determinants stored)
     void get_excited_determinants_avg(int nroot, SharedMatrix evecs, SharedVector evals,  DeterminantHashVec& P_space,

--- a/src/aci/aci.h
+++ b/src/aci/aci.h
@@ -304,6 +304,9 @@ class AdaptiveCI : public Wavefunction {
 
     /// Print a wave function
     void print_wfn(DeterminantHashVec& space, WFNOperator& op, SharedMatrix evecs, int nroot);
+    /// Find all the relevant excitations out of the P space
+    void find_Q_space(DeterminantHashVec& P_space, DeterminantHashVec& PQ_space,
+                      SharedVector evals, SharedMatrix evecs);
 
     /// Batched version of find q space
     void find_q_space_batched(DeterminantHashVec& P_space, DeterminantHashVec& PQ_space,
@@ -328,24 +331,16 @@ class AdaptiveCI : public Wavefunction {
     void find_q_space_single_root(int nroot, SharedVector evals, SharedMatrix evecs);
 
     /// Basic determinant generator (threaded, no batching, all determinants stored)
-    void get_excited_determinants(int nroot, SharedMatrix evecs, DeterminantHashVec& P_space,
-                                  det_hash<std::vector<double>>& V_hash);
+    void get_excited_determinants_avg(int nroot, SharedMatrix evecs, SharedVector evals,  DeterminantHashVec& P_space,
+                                           std::vector<std::pair<double, Determinant>>& F_space);
 
-    /// Alternate/experimental determinant generator (threaded, each thread builds part of F)
-    void get_excited_determinants_seq(int nroot, SharedMatrix evecs, DeterminantHashVec& P_space,
-                                   det_hash<std::vector<double>>& V_hash);
     /// Get excited determinants with a specified hole
-    void get_core_excited_determinants(SharedMatrix evecs, DeterminantHashVec& P_space,
-                                       det_hash<std::vector<double>>& V_hash);
+    void get_excited_determinants_restrict(SharedMatrix evecs, SharedVector evals,  DeterminantHashVec& P_space,
+                                           std::vector<std::pair<double, Determinant>>& F_space);
 
     // Optimized for a single root
-    void get_excited_determinants_sr(SharedMatrix evecs, DeterminantHashVec& P_space,
-                                     det_hash<double>& V_hash);
-
-    // Primitive batching algorithm, each thread does one bin, to be removed
-    double get_excited_determinants_batch_old(SharedMatrix evecs, SharedVector evals,
-                                          DeterminantHashVec& P_space,
-                                          std::vector<std::pair<double, Determinant>>& F_space);
+    void get_excited_determinants_sr(SharedMatrix evecs, SharedVector evals,  DeterminantHashVec& P_space,
+                                           std::vector<std::pair<double, Determinant>>& F_space);
 
     // (DEFAULT in batching) Optimized batching algorithm, prescreens the batches to significantly reduce storage, based on hashes
     double get_excited_determinants_batch(SharedMatrix evecs, SharedVector evals,
@@ -356,10 +351,6 @@ class AdaptiveCI : public Wavefunction {
     double get_excited_determinants_batch_vecsort(SharedMatrix evecs, SharedVector evals,
                                            DeterminantHashVec& P_space,
                                            std::vector<std::pair<double, Determinant>>& F_space);
-
-    /// Builds excited determinants for a bin, no threading, hash-based, to be removed
-    det_hash<double> get_bin_F_space_old(int bin, int nbin, SharedMatrix evecs,
-                                     DeterminantHashVec& P_space);
 
     /// (DEFAULT)  Builds excited determinants for a bin, uses all threads, hash-based
     det_hash<double> get_bin_F_space(int bin, int nbin,double E0, SharedMatrix evecs,

--- a/src/aci/aci_build_F.cc
+++ b/src/aci/aci_build_F.cc
@@ -998,7 +998,6 @@ AdaptiveCI::get_excited_determinants_batch(SharedMatrix evecs, SharedVector eval
                 excluded += en;
             } else {
                 F_space.push_back(std::make_pair(en, det));
-                outfile->Printf("\n adding %s", det.str().c_str());
             }
         }
         total_excluded += excluded;

--- a/src/aci/aci_build_F.cc
+++ b/src/aci/aci_build_F.cc
@@ -13,13 +13,14 @@ bool pair_compd(const std::pair<Determinant, double> E1, const std::pair<Determi
     return E1.first < E2.first;
 }
 
-void AdaptiveCI::get_excited_determinants_sr(SharedMatrix evecs, DeterminantHashVec& P_space,
-                                             det_hash<double>& V_hash) {
+void AdaptiveCI::get_excited_determinants_sr(SharedMatrix evecs, SharedVector evals, DeterminantHashVec& P_space,
+                                             std::vector<std::pair<double,Determinant>>& F_space) {
     Timer build;
     size_t max_P = P_space.size();
     const det_hashvec& P_dets = P_space.wfn_hash();
     int nroot = 1;
 
+    det_hash<double> V_hash;
 // Loop over reference determinants
 #pragma omp parallel
     {
@@ -163,963 +164,432 @@ void AdaptiveCI::get_excited_determinants_sr(SharedMatrix evecs, DeterminantHash
     } // Close threads
 }
 
-void AdaptiveCI::get_excited_determinants_seq(int nroot, SharedMatrix evecs,
-                                           DeterminantHashVec& P_space,
-                                           det_hash<std::vector<double>>& V_hash) {
-    const size_t n_dets = P_space.size();
-
-    int nmo = fci_ints_->nmo();
-    double max_mem = options_.get_double("PT2_MAX_MEM");
-
-    size_t guess_size = n_dets * nmo * nmo;
-    double nbyte = (1073741824 * max_mem) / (sizeof(double));
-
-    int nbin = static_cast<int>(std::ceil(guess_size / (nbyte)));
-
-#pragma omp parallel
-    {
-        int tid = omp_get_thread_num();
-        int ntds = omp_get_num_threads();
-
-        if ((ntds > nbin)) {
-            nbin = ntds;
-        }
-
-        if (tid == 0) {
-            outfile->Printf("\n  Number of bins for exitation space:  %d", nbin);
-            outfile->Printf("\n  Number of threads: %d", ntds);
-        }
-        size_t bin_size = n_dets / ntds;
-        bin_size += (tid < (n_dets % ntds)) ? 1 : 0;
-        size_t start_idx = (tid < (n_dets % ntds)) ? tid * bin_size
-                                                   : (n_dets % ntds) * (bin_size + 1) +
-                                                         (tid - (n_dets % ntds)) * bin_size;
-        size_t end_idx = start_idx + bin_size;
-        for (int bin = 0; bin < nbin; ++bin) {
-
-            det_hash<std::vector<double>> A_I;
-            // std::vector<std::pair<Determinant, std::vector<double>>> A_I;
-
-            const det_hashvec& dets = P_space.wfn_hash();
-            for (size_t I = start_idx; I < end_idx; ++I) {
-                double c_norm = evecs->get_row(0, I)->norm();
-                const Determinant& det = dets[I];
-                std::vector<int> aocc = det.get_alfa_occ(nmo);
-                std::vector<int> bocc = det.get_beta_occ(nmo);
-                std::vector<int> avir = det.get_alfa_vir(nmo);
-                std::vector<int> bvir = det.get_beta_vir(nmo);
-
-                int noalpha = aocc.size();
-                int nobeta = bocc.size();
-                int nvalpha = avir.size();
-                int nvbeta = bvir.size();
-                Determinant new_det(det);
-
-                // Generate alpha excitations
-                for (int i = 0; i < noalpha; ++i) {
-                    int ii = aocc[i];
-                    for (int a = 0; a < nvalpha; ++a) {
-                        int aa = avir[a];
-                        if ((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) {
-                            new_det = det;
-                            new_det.set_alfa_bit(ii, false);
-                            new_det.set_alfa_bit(aa, true);
-                            if (P_space.has_det(new_det))
-                                continue;
-
-                            // Check if the determinant goes in this bin
-                            size_t hash_val = Determinant::Hash()(new_det);
-                            if ((hash_val % nbin) == bin) {
-                                double HIJ = fci_ints_->slater_rules_single_alpha(new_det, ii, aa);
-                                if ((std::fabs(HIJ) * c_norm >= screen_thresh_)) {
-                                    std::vector<double> coupling(nroot_);
-                                    for (int n = 0; n < nroot_; ++n) {
-                                        coupling[n] = HIJ * evecs->get(I, n);
-                                        if (A_I.find(new_det) != A_I.end()) {
-                                            coupling[n] += A_I[new_det][n];
-                                        }
-                                        A_I[new_det] = coupling;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                // Generate beta excitations
-                for (int i = 0; i < nobeta; ++i) {
-                    int ii = bocc[i];
-                    for (int a = 0; a < nvbeta; ++a) {
-                        int aa = bvir[a];
-                        if ((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) {
-                            new_det = det;
-                            new_det.set_beta_bit(ii, false);
-                            new_det.set_beta_bit(aa, true);
-                            if (P_space.has_det(new_det))
-                                continue;
-
-                            // Check if the determinant goes in this bin
-                            size_t hash_val = Determinant::Hash()(new_det);
-                            if ((hash_val % nbin) == bin) {
-                                double HIJ = fci_ints_->slater_rules_single_beta(new_det, ii, aa);
-                                if ((std::fabs(HIJ) * c_norm >= screen_thresh_)) {
-                                    std::vector<double> coupling(nroot_);
-                                    for (int n = 0; n < nroot_; ++n) {
-                                        coupling[n] = HIJ * evecs->get(I, n);
-                                        if (A_I.find(new_det) != A_I.end()) {
-                                            coupling[n] += A_I[new_det][n];
-                                        }
-                                        A_I[new_det] = coupling;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                // Generate aa excitations
-                for (int i = 0; i < noalpha; ++i) {
-                    int ii = aocc[i];
-                    for (int j = i + 1; j < noalpha; ++j) {
-                        int jj = aocc[j];
-                        for (int a = 0; a < nvalpha; ++a) {
-                            int aa = avir[a];
-                            for (int b = a + 1; b < nvalpha; ++b) {
-                                int bb = avir[b];
-                                if ((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
-                                     mo_symmetry_[bb]) == 0) {
-                                    new_det = det;
-                                    double sign = new_det.double_excitation_aa(ii, jj, aa, bb);
-                                    if (P_space.has_det(new_det))
-                                        continue;
-
-                                    // Check if the determinant goes in this bin
-                                    size_t hash_val = Determinant::Hash()(new_det);
-                                    if ((hash_val % nbin) == bin) {
-                                        double HIJ = fci_ints_->tei_aa(ii, jj, aa, bb);
-                                        if ((std::fabs(HIJ) * c_norm >= screen_thresh_)) {
-                                            HIJ *= sign;
-                                            std::vector<double> coupling(nroot_);
-                                            for (int n = 0; n < nroot_; ++n) {
-                                                coupling[n] = HIJ * evecs->get(I, n);
-                                                if (A_I.find(new_det) != A_I.end()) {
-                                                    coupling[n] += A_I[new_det][n];
-                                                }
-                                                A_I[new_det] = coupling;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                // Generate bb excitations
-                for (int i = 0; i < nobeta; ++i) {
-                    int ii = bocc[i];
-                    for (int j = i + 1; j < nobeta; ++j) {
-                        int jj = bocc[j];
-                        for (int a = 0; a < nvbeta; ++a) {
-                            int aa = bvir[a];
-                            for (int b = a + 1; b < nvbeta; ++b) {
-                                int bb = bvir[b];
-                                if ((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
-                                     mo_symmetry_[bb]) == 0) {
-                                    new_det = det;
-                                    double sign = new_det.double_excitation_bb(ii, jj, aa, bb);
-                                    if (P_space.has_det(new_det))
-                                        continue;
-
-                                    // Check if the determinant goes in this bin
-                                    size_t hash_val = Determinant::Hash()(new_det);
-                                    if ((hash_val % nbin) == bin) {
-                                        double HIJ = fci_ints_->tei_bb(ii, jj, aa, bb);
-                                        if ((std::fabs(HIJ) * c_norm >= screen_thresh_)) {
-                                            HIJ *= sign;
-                                            std::vector<double> coupling(nroot_);
-                                            for (int n = 0; n < nroot_; ++n) {
-                                                coupling[n] = HIJ * evecs->get(I, n);
-                                                if (A_I.find(new_det) != A_I.end()) {
-                                                    coupling[n] += A_I[new_det][n];
-                                                }
-                                                A_I[new_det] = coupling;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                // Generate ab excitations
-                for (int i = 0; i < noalpha; ++i) {
-                    int ii = aocc[i];
-                    for (int j = 0; j < nobeta; ++j) {
-                        int jj = bocc[j];
-                        for (int a = 0; a < nvalpha; ++a) {
-                            int aa = avir[a];
-                            for (int b = 0; b < nvbeta; ++b) {
-                                int bb = bvir[b];
-                                if ((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
-                                     mo_symmetry_[bb]) == 0) {
-                                    new_det = det;
-                                    double sign = new_det.double_excitation_ab(ii, jj, aa, bb);
-                                    if (P_space.has_det(new_det))
-                                        continue;
-
-                                    // Check if the determinant goes in this bin
-                                    size_t hash_val = Determinant::Hash()(new_det);
-                                    if ((hash_val % nbin) == bin) {
-                                        double HIJ = fci_ints_->tei_ab(ii, jj, aa, bb);
-                                        if ((std::fabs(HIJ) * c_norm >= screen_thresh_)) {
-                                            HIJ *= sign;
-                                            std::vector<double> coupling(nroot_);
-                                            for (int n = 0; n < nroot_; ++n) {
-                                                coupling[n] = HIJ * evecs->get(I, n);
-                                                if (A_I.find(new_det) != A_I.end()) {
-                                                    coupling[n] += A_I[new_det][n];
-                                                }
-                                                A_I[new_det] = coupling;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-#pragma omp critical
-            {
-                for (auto& dpair : A_I) {
-                    const std::vector<double>& coupling = dpair.second;
-                    const Determinant& det = dpair.first;
-                    if (V_hash.count(det) != 0) {
-                        for (int n = 0; n < nroot; ++n) {
-                            V_hash[det][n] += coupling[n];
-                        }
-                    } else {
-                        V_hash[det] = coupling;
-                    }
-                }
-            }
-            // outfile->Printf("\n TD, bin, size of hash: %d %d %zu", tid, bin, A_I.size());
-        }
-    }
-}
-
-void AdaptiveCI::get_excited_determinants(int nroot, SharedMatrix evecs,
-                                          DeterminantHashVec& P_space,
-                                          det_hash<std::vector<double>>& V_hash) {
-    size_t max_P = P_space.size();
-    const det_hashvec& P_dets = P_space.wfn_hash();
-
-// Loop over reference determinants
-#pragma omp parallel
-    {
-        int num_thread = omp_get_num_threads();
-        int tid = omp_get_thread_num();
-        size_t bin_size = max_P / num_thread;
-        bin_size += (tid < (max_P % num_thread)) ? 1 : 0;
-        size_t start_idx =
-            (tid < (max_P % num_thread))
-                ? tid * bin_size
-                : (max_P % num_thread) * (bin_size + 1) + (tid - (max_P % num_thread)) * bin_size;
-        size_t end_idx = start_idx + bin_size;
-
-        if (omp_get_thread_num() == 0 and !quiet_mode_) {
-            outfile->Printf("\n  Using %d threads.", num_thread);
-        }
-        // This will store the excited determinant info for each thread
-        std::vector<std::pair<Determinant, std::vector<double>>>
-            thread_ex_dets; //( noalpha * nvalpha  );
-
-        for (size_t P = start_idx; P < end_idx; ++P) {
-            const Determinant& det(P_dets[P]);
-            double evecs_P_row_norm = evecs->get_row(0, P)->norm();
-
-            std::vector<int> aocc = det.get_alfa_occ(nact_);
-            std::vector<int> bocc = det.get_beta_occ(nact_);
-            std::vector<int> avir = det.get_alfa_vir(nact_);
-            std::vector<int> bvir = det.get_beta_vir(nact_);
-
-            int noalpha = aocc.size();
-            int nobeta = bocc.size();
-            int nvalpha = avir.size();
-            int nvbeta = bvir.size();
-            Determinant new_det(det);
-
-            // Generate alpha excitations
-            for (int i = 0; i < noalpha; ++i) {
-                int ii = aocc[i];
-                for (int a = 0; a < nvalpha; ++a) {
-                    int aa = avir[a];
-                    if ((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) {
-                        double HIJ = fci_ints_->slater_rules_single_alpha(det, ii, aa);
-                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-                            //      if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
-                            new_det = det;
-                            new_det.set_alfa_bit(ii, false);
-                            new_det.set_alfa_bit(aa, true);
-                            if (!(P_space.has_det(new_det))) {
-                                std::vector<double> coupling(nroot, 0.0);
-                                for (int n = 0; n < nroot; ++n) {
-                                    coupling[n] += HIJ * evecs->get(P, n);
-                                }
-                                // thread_ex_dets[i * noalpha + a] =
-                                // std::make_pair(new_det,coupling);
-                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Generate beta excitations
-            for (int i = 0; i < nobeta; ++i) {
-                int ii = bocc[i];
-                for (int a = 0; a < nvbeta; ++a) {
-                    int aa = bvir[a];
-                    if ((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) {
-                        double HIJ = fci_ints_->slater_rules_single_beta(det, ii, aa);
-                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-                            // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
-                            new_det = det;
-                            new_det.set_beta_bit(ii, false);
-                            new_det.set_beta_bit(aa, true);
-                            if (!(P_space.has_det(new_det))) {
-                                std::vector<double> coupling(nroot, 0.0);
-                                for (int n = 0; n < nroot; ++n) {
-                                    coupling[n] += HIJ * evecs->get(P, n);
-                                }
-                                // thread_ex_dets[i * nobeta + a] =
-                                // std::make_pair(new_det,coupling);
-                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Generate aa excitations
-            for (int i = 0; i < noalpha; ++i) {
-                int ii = aocc[i];
-                for (int j = i + 1; j < noalpha; ++j) {
-                    int jj = aocc[j];
-                    for (int a = 0; a < nvalpha; ++a) {
-                        int aa = avir[a];
-                        for (int b = a + 1; b < nvalpha; ++b) {
-                            int bb = avir[b];
-                            if ((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
-                                 mo_symmetry_[bb]) == 0) {
-                                double HIJ = fci_ints_->tei_aa(ii, jj, aa, bb);
-                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-                                    new_det = det;
-                                    HIJ *= new_det.double_excitation_aa(ii, jj, aa, bb);
-                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
-
-                                    if (!(P_space.has_det(new_det))) {
-                                        std::vector<double> coupling(nroot, 0.0);
-                                        for (int n = 0; n < nroot; ++n) {
-                                            coupling[n] += HIJ * evecs->get(P, n);
-                                        }
-                                        // thread_ex_dets[i *
-                                        // noalpha*noalpha*nvalpha +
-                                        // j*nvalpha*noalpha +  a*nvalpha + b ]
-                                        // = std::make_pair(new_det,coupling);
-                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Generate ab excitations
-            for (int i = 0; i < noalpha; ++i) {
-                int ii = aocc[i];
-                for (int j = 0; j < nobeta; ++j) {
-                    int jj = bocc[j];
-                    for (int a = 0; a < nvalpha; ++a) {
-                        int aa = avir[a];
-                        for (int b = 0; b < nvbeta; ++b) {
-                            int bb = bvir[b];
-                            if ((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
-                                 mo_symmetry_[bb]) == 0) {
-                                double HIJ = fci_ints_->tei_ab(ii, jj, aa, bb);
-                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-                                    new_det = det;
-                                    HIJ *= new_det.double_excitation_ab(ii, jj, aa, bb);
-                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
-
-                                    if (!(P_space.has_det(new_det))) {
-                                        std::vector<double> coupling(nroot, 0.0);
-                                        for (int n = 0; n < nroot; ++n) {
-                                            coupling[n] += HIJ * evecs->get(P, n);
-                                        }
-                                        // thread_ex_dets[i * nobeta * nvalpha
-                                        // *nvbeta + j * bvalpha * nvbeta + a *
-                                        // nvalpha]
-                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Generate bb excitations
-            for (int i = 0; i < nobeta; ++i) {
-                int ii = bocc[i];
-                for (int j = i + 1; j < nobeta; ++j) {
-                    int jj = bocc[j];
-                    for (int a = 0; a < nvbeta; ++a) {
-                        int aa = bvir[a];
-                        for (int b = a + 1; b < nvbeta; ++b) {
-                            int bb = bvir[b];
-                            if ((mo_symmetry_[ii] ^
-                                 (mo_symmetry_[jj] ^ (mo_symmetry_[aa] ^ mo_symmetry_[bb]))) == 0) {
-                                double HIJ = fci_ints_->tei_bb(ii, jj, aa, bb);
-                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-                                    // if( std::abs(HIJ * evecs->get(0, P)) >= screen_thresh_ ){
-                                    new_det = det;
-                                    HIJ *= new_det.double_excitation_bb(ii, jj, aa, bb);
-
-                                    if (!(P_space.has_det(new_det))) {
-                                        std::vector<double> coupling(nroot, 0.0);
-                                        for (int n = 0; n < nroot; ++n) {
-                                            coupling[n] += HIJ * evecs->get(P, n);
-                                        }
-                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-#pragma omp critical
-        {
-            for (size_t I = 0, maxI = thread_ex_dets.size(); I < maxI; ++I) {
-                std::vector<double>& coupling = thread_ex_dets[I].second;
-                Determinant& det = thread_ex_dets[I].first;
-                if (V_hash.count(det) != 0) {
-                    for (int n = 0; n < nroot; ++n) {
-                        V_hash[det][n] += coupling[n];
-                    }
-                } else {
-                    V_hash[det] = coupling;
-                }
-            }
-        }
-    } // Close threads
-}
-
-void AdaptiveCI::get_core_excited_determinants(SharedMatrix evecs, DeterminantHashVec& P_space,
-                                               det_hash<std::vector<double>>& V_hash) {
-    size_t max_P = P_space.size();
-    const det_hashvec& P_dets = P_space.wfn_hash();
-    int nroot = 1;
-
-// Loop over reference determinants
-#pragma omp parallel
-    {
-        int num_thread = omp_get_num_threads();
-        int tid = omp_get_thread_num();
-        size_t bin_size = max_P / num_thread;
-        bin_size += (tid < (max_P % num_thread)) ? 1 : 0;
-        size_t start_idx =
-            (tid < (max_P % num_thread))
-                ? tid * bin_size
-                : (max_P % num_thread) * (bin_size + 1) + (tid - (max_P % num_thread)) * bin_size;
-        size_t end_idx = start_idx + bin_size;
-
-        if (omp_get_thread_num() == 0 and !quiet_mode_) {
-            outfile->Printf("\n  Using %d threads.", num_thread);
-        }
-        // This will store the excited determinant info for each thread
-        std::vector<std::pair<Determinant, std::vector<double>>>
-            thread_ex_dets; //( noalpha * nvalpha  );
-
-        for (size_t P = start_idx; P < end_idx; ++P) {
-            const Determinant& det(P_dets[P]);
-            double evecs_P_row_norm = evecs->get_row(0, P)->norm();
-
-            std::vector<int> aocc = det.get_alfa_occ(nact_); // TODO check size
-            std::vector<int> bocc = det.get_beta_occ(nact_); // TODO check size
-            std::vector<int> avir = det.get_alfa_vir(nact_); // TODO check size
-            std::vector<int> bvir = det.get_beta_vir(nact_); // TODO check size
-
-            int noalpha = aocc.size();
-            int nobeta = bocc.size();
-            int nvalpha = avir.size();
-            int nvbeta = bvir.size();
-            Determinant new_det(det);
-
-            // Generate alpha excitations
-            for (int i = 0; i < noalpha; ++i) {
-                int ii = aocc[i];
-                for (int a = 0; a < nvalpha; ++a) {
-                    int aa = avir[a];
-                    if (((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) and
-                        ((aa != hole_) or (!det.get_beta_bit(aa)))) {
-                        double HIJ = fci_ints_->slater_rules_single_alpha(det, ii, aa);
-                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-                            //      if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
-                            new_det = det;
-                            new_det.set_alfa_bit(ii, false);
-                            new_det.set_alfa_bit(aa, true);
-                            if (!(P_space.has_det(new_det))) {
-                                std::vector<double> coupling(nroot, 0.0);
-                                for (int n = 0; n < nroot; ++n) {
-                                    coupling[n] += HIJ * evecs->get(P, n);
-                                }
-                                // thread_ex_dets[i * noalpha + a] =
-                                // std::make_pair(new_det,coupling);
-                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-                            }
-                        }
-                    }
-                }
-            }
-            // Generate beta excitations
-            for (int i = 0; i < nobeta; ++i) {
-                int ii = bocc[i];
-                for (int a = 0; a < nvbeta; ++a) {
-                    int aa = bvir[a];
-                    if (((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) and
-                        ((aa != hole_) or (!det.get_alfa_bit(aa)))) {
-                        double HIJ = fci_ints_->slater_rules_single_beta(det, ii, aa);
-                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-                            // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
-                            new_det = det;
-                            new_det.set_beta_bit(ii, false);
-                            new_det.set_beta_bit(aa, true);
-                            if (!(P_space.has_det(new_det))) {
-                                std::vector<double> coupling(nroot, 0.0);
-                                for (int n = 0; n < nroot; ++n) {
-                                    coupling[n] += HIJ * evecs->get(P, n);
-                                }
-                                // thread_ex_dets[i * nobeta + a] =
-                                // std::make_pair(new_det,coupling);
-                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Generate aa excitations
-            for (int i = 0; i < noalpha; ++i) {
-                int ii = aocc[i];
-                for (int j = i + 1; j < noalpha; ++j) {
-                    int jj = aocc[j];
-                    for (int a = 0; a < nvalpha; ++a) {
-                        int aa = avir[a];
-                        for (int b = a + 1; b < nvalpha; ++b) {
-                            int bb = avir[b];
-                            if (((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
-                                  mo_symmetry_[bb]) == 0) and
-                                (aa != hole_ and bb != hole_)) {
-                                double HIJ = fci_ints_->tei_aa(ii, jj, aa, bb);
-                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-                                    new_det = det;
-                                    HIJ *= new_det.double_excitation_aa(ii, jj, aa, bb);
-                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
-
-                                    if (!(P_space.has_det(new_det))) {
-                                        std::vector<double> coupling(nroot, 0.0);
-                                        for (int n = 0; n < nroot; ++n) {
-                                            coupling[n] += HIJ * evecs->get(P, n);
-                                        }
-                                        // thread_ex_dets[i *
-                                        // noalpha*noalpha*nvalpha +
-                                        // j*nvalpha*noalpha +  a*nvalpha + b ]
-                                        // = std::make_pair(new_det,coupling);
-                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Generate ab excitations
-            for (int i = 0; i < noalpha; ++i) {
-                int ii = aocc[i];
-                for (int j = 0; j < nobeta; ++j) {
-                    int jj = bocc[j];
-                    for (int a = 0; a < nvalpha; ++a) {
-                        int aa = avir[a];
-                        for (int b = 0; b < nvbeta; ++b) {
-                            int bb = bvir[b];
-                            if (((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
-                                  mo_symmetry_[bb]) == 0) and
-                                (aa != hole_ and bb != hole_)) {
-                                double HIJ = fci_ints_->tei_ab(ii, jj, aa, bb);
-                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-                                    new_det = det;
-                                    HIJ *= new_det.double_excitation_ab(ii, jj, aa, bb);
-                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
-
-                                    if (!(P_space.has_det(new_det))) {
-                                        std::vector<double> coupling(nroot, 0.0);
-                                        for (int n = 0; n < nroot; ++n) {
-                                            coupling[n] += HIJ * evecs->get(P, n);
-                                        }
-                                        // thread_ex_dets[i * nobeta * nvalpha
-                                        // *nvbeta + j * bvalpha * nvbeta + a *
-                                        // nvalpha]
-                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Generate bb excitations
-            for (int i = 0; i < nobeta; ++i) {
-                int ii = bocc[i];
-                for (int j = i + 1; j < nobeta; ++j) {
-                    int jj = bocc[j];
-                    for (int a = 0; a < nvbeta; ++a) {
-                        int aa = bvir[a];
-                        for (int b = a + 1; b < nvbeta; ++b) {
-                            int bb = bvir[b];
-                            if (((mo_symmetry_[ii] ^
-                                  (mo_symmetry_[jj] ^ (mo_symmetry_[aa] ^ mo_symmetry_[bb]))) ==
-                                 0) and
-                                (aa != hole_ and bb != hole_)) {
-                                double HIJ = fci_ints_->tei_bb(ii, jj, aa, bb);
-                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-                                    // if( std::abs(HIJ * evecs->get(0, P)) >= screen_thresh_ ){
-                                    new_det = det;
-                                    HIJ *= new_det.double_excitation_bb(ii, jj, aa, bb);
-
-                                    if (!(P_space.has_det(new_det))) {
-                                        std::vector<double> coupling(nroot, 0.0);
-                                        for (int n = 0; n < nroot; ++n) {
-                                            coupling[n] += HIJ * evecs->get(P, n);
-                                        }
-                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-#pragma omp critical
-        {
-            for (size_t I = 0, maxI = thread_ex_dets.size(); I < maxI; ++I) {
-                std::vector<double>& coupling = thread_ex_dets[I].second;
-                Determinant& det = thread_ex_dets[I].first;
-                if (V_hash.count(det) != 0) {
-                    for (int n = 0; n < nroot; ++n) {
-                        V_hash[det][n] += coupling[n];
-                    }
-                } else {
-                    V_hash[det] = coupling;
-                }
-            }
-        }
-    } // Close threads
-}
-
-double
-AdaptiveCI::get_excited_determinants_batch_old(SharedMatrix evecs, SharedVector evals,
-                                           DeterminantHashVec& P_space,
-                                           std::vector<std::pair<double, Determinant>>& F_space) {
-    const size_t n_dets = P_space.size();
-
-    int nmo = fci_ints_->nmo();
-    double max_mem = options_.get_double("ACI_MAX_MEM");
-    double aci_scale = options_.get_double("ACI_SCALE_SIGMA");
-
-    size_t guess_size = n_dets * nmo * nmo;
-    double guess_mem = guess_size * 400.0e-7; // Est of map size in MB
-    int nruns = static_cast<int>(std::ceil(guess_mem / max_mem));
-
-    double total_excluded = 0.0;
-
-#pragma omp parallel
-    {
-        int thread_id = omp_get_thread_num();
-        int n_threads = omp_get_max_threads();
-        int nbin = nruns * n_threads;
-        if (thread_id == 0) {
-            outfile->Printf("\n  Setting nbin to %d based on estimated memory (%6.3f MB)", nbin,
-                            guess_mem);
-        }
-
-        if (n_threads >= nbin) {
-            nbin = n_threads;
-            if (thread_id == 0) {
-                outfile->Printf("\n  WARNING: Batching not required, use another algorithm");
-            }
-        }
-
-        if (options_["ACI_NBATCH"].has_changed()) {
-            nbin = options_.get_int("ACI_NBATCH");
-            if (thread_id == 0) {
-                outfile->Printf("\n  Overwriting nbin to %d based on user input", nbin);
-            }
-        }
-        std::vector<std::pair<double, Determinant>> F_td;
-
-        int bin_size = nbin / n_threads;
-        bin_size += (thread_id < (nbin % n_threads)) ? 1 : 0;
-        int start_idx =
-            (thread_id < (nbin % n_threads))
-                ? thread_id * bin_size
-                : (nbin % n_threads) * (bin_size + 1) + (thread_id - (nbin % n_threads)) * bin_size;
-        int end_idx = start_idx + bin_size;
-
-        if (thread_id == 0) {
-            outfile->Printf("\n  Number of bins for exitation space:  %d", nbin);
-            outfile->Printf("\n  Number of threads: %d", n_threads);
-        }
-
-        // Loop over bins
-        for (int bin = start_idx; bin < end_idx; ++bin) {
-
-            Timer sp;
-            // 1. Build the full bin-subset
-            det_hash<double> A_b = get_bin_F_space_old(bin, nbin, evecs, P_space);
-            outfile->Printf("\n  F subspace (bin %d) takes %1.6f s", bin, sp.get());
-
-            // 2. Put the dets/vals in a sortable list (F_tmp)
-            std::vector<std::pair<double, Determinant>> F_tmp;
-            for (auto& det_p : A_b) {
-                auto& det = det_p.first;
-                double& V = det_p.second;
-
-                double delta = fci_ints_->energy(det) - evals->get(0);
-
-                F_tmp.push_back(std::make_pair(
-                    std::fabs(0.5 * (delta - sqrt(delta * delta + V * V * 4.0))), det));
-            }
-            A_b.clear();
-            outfile->Printf("\n  Size of F subspace: %zu dets (bin %d)", F_tmp.size(), bin);
-
-            // 3. Sort the list
-            std::sort(F_tmp.begin(), F_tmp.end(), pair_comp);
-
-            // 4. Screen subspaces
-            double b_sigma = sigma_ * (aci_scale / nbin);
-            //            outfile->Printf("\n  Using sigma = %1.5f", b_sigma);
-            double excluded = 0.0;
-            size_t ndet = 0;
-            for (size_t I = 0, max_I = F_tmp.size(); I < max_I; ++I) {
-                double en = F_tmp[I].first;
-                Determinant& det = F_tmp[I].second;
-                if (excluded + en < b_sigma) {
-                    excluded += en;
-                } else {
-                    F_td.push_back(std::make_pair(en, det));
-                    ndet++;
-                }
-            }
-            outfile->Printf("\n  Added %zu dets from bin %d, (td %d)", ndet, bin, thread_id);
-            total_excluded += excluded;
-
-        } // End iteration over bins
-
-// 6. Merge thread spaces
-#pragma omp critical
-        {
-            for (auto& pair : F_td) {
-                F_space.push_back(pair);
-            }
-        }
-    } // close threads
-
-    outfile->Printf("\n  Screened out %1.10f Eh of correlation", total_excluded);
-    return total_excluded;
-}
-
-det_hash<double> AdaptiveCI::get_bin_F_space_old(int bin, int nbin, SharedMatrix evecs,
-                                             DeterminantHashVec& P_space) {
-
-    const size_t n_dets = P_space.size();
-    const det_hashvec& dets = P_space.wfn_hash();
-    int nmo = fci_ints_->nmo();
-    std::vector<int> act_mo = mo_space_info_->get_dimension("ACTIVE").blocks();
-    det_hash<double> A_b;
-
-    // Loop over P space determinants
-    for (size_t I = 0; I < n_dets; ++I) {
-        double c_I = evecs->get(I, 0);
-        const Determinant& det = dets[I];
-        std::vector<std::vector<int>> noalpha = det.get_asym_occ(nmo, act_mo);
-        std::vector<std::vector<int>> nobeta = det.get_bsym_occ(nmo, act_mo);
-        std::vector<std::vector<int>> nvalpha = det.get_asym_vir(nmo, act_mo);
-        std::vector<std::vector<int>> nvbeta = det.get_bsym_vir(nmo, act_mo);
-
-        Determinant new_det(det);
-        // Generate alpha excitations
-        for (int h = 0; h < nirrep_; ++h) {
-
-            // Precompute indices
-            const auto& noalpha_h = noalpha[h];
-            const auto& nvalpha_h = nvalpha[h];
-
-            for (auto& ii : noalpha_h) {
-                for (auto& aa : nvalpha_h) {
-                    new_det = det;
-                    new_det.set_alfa_bit(ii, false);
-                    new_det.set_alfa_bit(aa, true);
-                    size_t hash_val = Determinant::Hash()(new_det);
-                    if ((hash_val % nbin) == bin) {
-                        double HIJ = fci_ints_->slater_rules_single_alpha(det, ii, aa) * c_I;
-                        if ((std::fabs(HIJ) >= screen_thresh_)) {
-                            A_b[new_det] += HIJ;
-                        }
-                    }
-                }
-            }
-            // Generate beta excitations
-            const auto& nobeta_h = nobeta[h];
-            const auto& nvbeta_h = nvbeta[h];
-            for (auto& ii : nobeta_h) {
-                for (auto& aa : nvbeta_h) {
-                    // Check if the determinant goes in this bin
-                    new_det = det;
-                    new_det.set_beta_bit(ii, false);
-                    new_det.set_beta_bit(aa, true);
-                    size_t hash_val = Determinant::Hash()(new_det);
-                    if ((hash_val % nbin) == bin) {
-                        double HIJ = fci_ints_->slater_rules_single_beta(det, ii, aa) * c_I;
-                        if ((std::fabs(HIJ) >= screen_thresh_)) {
-                            A_b[new_det] += HIJ;
-                        }
-                    }
-                }
-            }
-        }
-        for (int p = 0; p < nirrep_; ++p) {
-            for (int q = p; q < nirrep_; ++q) {
-                for (int r = 0; r < nirrep_; ++r) {
-                    int sp = p ^ q ^ r;
-                    if (sp < r)
-                        continue;
-
-                    // Precompute index lists
-                    const auto& noalpha_p = noalpha[p];
-                    const auto& noalpha_q = noalpha[q];
-                    const auto& nvalpha_r = nvalpha[r];
-                    const auto& nvalpha_s = nvalpha[sp];
-
-                    int max_i = noalpha_p.size();
-                    int max_j = noalpha_q.size();
-                    int max_a = nvalpha_r.size();
-                    int max_b = nvalpha_s.size();
-
-                    // Generate aa excitations
-                    for (int i = 0; i < max_i; ++i) {
-                        int ii = noalpha_p[i];
-                        for (int j = (p == q ? i + 1 : 0); j < max_j; ++j) {
-                            int jj = noalpha_q[j];
-                            for (int a = 0; a < max_a; ++a) {
-                                int aa = nvalpha_r[a];
-                                for (int b = (r == sp ? a + 1 : 0); b < max_b; ++b) {
-                                    int bb = nvalpha_s[b];
-
-                                    // Check if the determinant goes in this bin
-                                    new_det = det;
-                                    double sign = new_det.double_excitation_aa(ii, jj, aa, bb);
-                                    size_t hash_val = Determinant::Hash()(new_det);
-                                    if ((hash_val % nbin) == bin) {
-                                        double HIJ = fci_ints_->tei_aa(ii, jj, aa, bb) * sign * c_I;
-                                        if ((std::fabs(HIJ) >= screen_thresh_)) {
-                                            A_b[new_det] += HIJ;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    // Generate bb excitations
-                    const auto& nobeta_p = nobeta[p];
-                    const auto& nobeta_q = nobeta[q];
-                    const auto& nvbeta_r = nvbeta[r];
-                    const auto& nvbeta_s = nvbeta[sp];
-
-                    max_i = nobeta_p.size();
-                    max_j = nobeta_q.size();
-                    max_a = nvbeta_r.size();
-                    max_b = nvbeta_s.size();
-
-                    for (int i = 0; i < max_i; ++i) {
-                        int ii = nobeta_p[i];
-                        for (int j = (p == q ? i + 1 : 0); j < max_j; ++j) {
-                            int jj = nobeta_q[j];
-                            for (int a = 0; a < max_a; ++a) {
-                                int aa = nvbeta_r[a];
-                                for (int b = (r == sp ? a + 1 : 0); b < max_b; ++b) {
-                                    int bb = nvbeta_s[b];
-                                    // Check if the determinant goes in this bin
-                                    new_det = det;
-                                    double sign = new_det.double_excitation_bb(ii, jj, aa, bb);
-                                    size_t hash_val = Determinant::Hash()(new_det);
-                                    if ((hash_val % nbin) == bin) {
-                                        double HIJ = fci_ints_->tei_bb(ii, jj, aa, bb) * sign * c_I;
-                                        if ((std::fabs(HIJ) >= screen_thresh_)) {
-                                            A_b[new_det] += HIJ;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        for (int p = 0; p < nirrep_; ++p) {
-            for (int q = 0; q < nirrep_; ++q) {
-                for (int r = 0; r < nirrep_; ++r) {
-                    int sp = p ^ q ^ r;
-                    const auto& noalpha_p = noalpha[p];
-                    const auto& nobeta_q = nobeta[q];
-                    const auto& nvalpha_r = nvalpha[r];
-                    const auto& nvbeta_s = nvbeta[sp];
-                    // Generate ab excitations
-                    for (auto& ii : noalpha_p) {
-                        for (auto& jj : nobeta_q) {
-                            for (auto& aa : nvalpha_r) {
-                                for (auto& bb : nvbeta_s) {
-                                    new_det = det;
-                                    double sign = new_det.double_excitation_ab(ii, jj, aa, bb);
-                                    size_t hash_val = Determinant::Hash()(new_det);
-                                    if ((hash_val % nbin) == bin) {
-                                        double HIJ = fci_ints_->tei_ab(ii, jj, aa, bb) * sign * c_I;
-                                        if ((std::fabs(HIJ) >= screen_thresh_)) {
-                                            A_b[new_det] += HIJ;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    } // end loop over reference
-
-    // Remove duplicates
-    for (det_hashvec::iterator it = dets.begin(), endit = dets.end(); it != endit; ++it) {
-        A_b[*it] = 0.0;
-    }
-
-    return A_b;
-}
+//void AdaptiveCI::get_excited_determinants_avg(int nroot, SharedMatrix evecs,
+//                                          SharedMatrix evals,
+//                                          DeterminantHashVec& P_space,
+//                                          det_hash<std::vector<double>>& V_hash) {
+//    size_t max_P = P_space.size();
+//    const det_hashvec& P_dets = P_space.wfn_hash();
+//
+//// Loop over reference determinants
+//#pragma omp parallel
+//    {
+//        int num_thread = omp_get_num_threads();
+//        int tid = omp_get_thread_num();
+//        size_t bin_size = max_P / num_thread;
+//        bin_size += (tid < (max_P % num_thread)) ? 1 : 0;
+//        size_t start_idx =
+//            (tid < (max_P % num_thread))
+//                ? tid * bin_size
+//                : (max_P % num_thread) * (bin_size + 1) + (tid - (max_P % num_thread)) * bin_size;
+//        size_t end_idx = start_idx + bin_size;
+//
+//        if (omp_get_thread_num() == 0 and !quiet_mode_) {
+//            outfile->Printf("\n  Using %d threads.", num_thread);
+//        }
+//        // This will store the excited determinant info for each thread
+//        std::vector<std::pair<Determinant, std::vector<double>>>
+//            thread_ex_dets; //( noalpha * nvalpha  );
+//
+//        for (size_t P = start_idx; P < end_idx; ++P) {
+//            const Determinant& det(P_dets[P]);
+//            double evecs_P_row_norm = evecs->get_row(0, P)->norm();
+//
+//            std::vector<int> aocc = det.get_alfa_occ(nact_);
+//            std::vector<int> bocc = det.get_beta_occ(nact_);
+//            std::vector<int> avir = det.get_alfa_vir(nact_);
+//            std::vector<int> bvir = det.get_beta_vir(nact_);
+//
+//            int noalpha = aocc.size();
+//            int nobeta = bocc.size();
+//            int nvalpha = avir.size();
+//            int nvbeta = bvir.size();
+//            Determinant new_det(det);
+//
+//            // Generate alpha excitations
+//            for (int i = 0; i < noalpha; ++i) {
+//                int ii = aocc[i];
+//                for (int a = 0; a < nvalpha; ++a) {
+//                    int aa = avir[a];
+//                    if ((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) {
+//                        double HIJ = fci_ints_->slater_rules_single_alpha(det, ii, aa);
+//                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+//                            //      if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+//                            new_det = det;
+//                            new_det.set_alfa_bit(ii, false);
+//                            new_det.set_alfa_bit(aa, true);
+//                            if (!(P_space.has_det(new_det))) {
+//                                std::vector<double> coupling(nroot, 0.0);
+//                                for (int n = 0; n < nroot; ++n) {
+//                                    coupling[n] += HIJ * evecs->get(P, n);
+//                                }
+//                                // thread_ex_dets[i * noalpha + a] =
+//                                // std::make_pair(new_det,coupling);
+//                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//
+//            // Generate beta excitations
+//            for (int i = 0; i < nobeta; ++i) {
+//                int ii = bocc[i];
+//                for (int a = 0; a < nvbeta; ++a) {
+//                    int aa = bvir[a];
+//                    if ((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) {
+//                        double HIJ = fci_ints_->slater_rules_single_beta(det, ii, aa);
+//                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+//                            // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+//                            new_det = det;
+//                            new_det.set_beta_bit(ii, false);
+//                            new_det.set_beta_bit(aa, true);
+//                            if (!(P_space.has_det(new_det))) {
+//                                std::vector<double> coupling(nroot, 0.0);
+//                                for (int n = 0; n < nroot; ++n) {
+//                                    coupling[n] += HIJ * evecs->get(P, n);
+//                                }
+//                                // thread_ex_dets[i * nobeta + a] =
+//                                // std::make_pair(new_det,coupling);
+//                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//
+//            // Generate aa excitations
+//            for (int i = 0; i < noalpha; ++i) {
+//                int ii = aocc[i];
+//                for (int j = i + 1; j < noalpha; ++j) {
+//                    int jj = aocc[j];
+//                    for (int a = 0; a < nvalpha; ++a) {
+//                        int aa = avir[a];
+//                        for (int b = a + 1; b < nvalpha; ++b) {
+//                            int bb = avir[b];
+//                            if ((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
+//                                 mo_symmetry_[bb]) == 0) {
+//                                double HIJ = fci_ints_->tei_aa(ii, jj, aa, bb);
+//                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+//                                    new_det = det;
+//                                    HIJ *= new_det.double_excitation_aa(ii, jj, aa, bb);
+//                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+//
+//                                    if (!(P_space.has_det(new_det))) {
+//                                        std::vector<double> coupling(nroot, 0.0);
+//                                        for (int n = 0; n < nroot; ++n) {
+//                                            coupling[n] += HIJ * evecs->get(P, n);
+//                                        }
+//                                        // thread_ex_dets[i *
+//                                        // noalpha*noalpha*nvalpha +
+//                                        // j*nvalpha*noalpha +  a*nvalpha + b ]
+//                                        // = std::make_pair(new_det,coupling);
+//                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+//                                    }
+//                                }
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//
+//            // Generate ab excitations
+//            for (int i = 0; i < noalpha; ++i) {
+//                int ii = aocc[i];
+//                for (int j = 0; j < nobeta; ++j) {
+//                    int jj = bocc[j];
+//                    for (int a = 0; a < nvalpha; ++a) {
+//                        int aa = avir[a];
+//                        for (int b = 0; b < nvbeta; ++b) {
+//                            int bb = bvir[b];
+//                            if ((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
+//                                 mo_symmetry_[bb]) == 0) {
+//                                double HIJ = fci_ints_->tei_ab(ii, jj, aa, bb);
+//                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+//                                    new_det = det;
+//                                    HIJ *= new_det.double_excitation_ab(ii, jj, aa, bb);
+//                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+//
+//                                    if (!(P_space.has_det(new_det))) {
+//                                        std::vector<double> coupling(nroot, 0.0);
+//                                        for (int n = 0; n < nroot; ++n) {
+//                                            coupling[n] += HIJ * evecs->get(P, n);
+//                                        }
+//                                        // thread_ex_dets[i * nobeta * nvalpha
+//                                        // *nvbeta + j * bvalpha * nvbeta + a *
+//                                        // nvalpha]
+//                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+//                                    }
+//                                }
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//
+//            // Generate bb excitations
+//            for (int i = 0; i < nobeta; ++i) {
+//                int ii = bocc[i];
+//                for (int j = i + 1; j < nobeta; ++j) {
+//                    int jj = bocc[j];
+//                    for (int a = 0; a < nvbeta; ++a) {
+//                        int aa = bvir[a];
+//                        for (int b = a + 1; b < nvbeta; ++b) {
+//                            int bb = bvir[b];
+//                            if ((mo_symmetry_[ii] ^
+//                                 (mo_symmetry_[jj] ^ (mo_symmetry_[aa] ^ mo_symmetry_[bb]))) == 0) {
+//                                double HIJ = fci_ints_->tei_bb(ii, jj, aa, bb);
+//                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+//                                    // if( std::abs(HIJ * evecs->get(0, P)) >= screen_thresh_ ){
+//                                    new_det = det;
+//                                    HIJ *= new_det.double_excitation_bb(ii, jj, aa, bb);
+//
+//                                    if (!(P_space.has_det(new_det))) {
+//                                        std::vector<double> coupling(nroot, 0.0);
+//                                        for (int n = 0; n < nroot; ++n) {
+//                                            coupling[n] += HIJ * evecs->get(P, n);
+//                                        }
+//                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+//                                    }
+//                                }
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//
+//#pragma omp critical
+//        {
+//            for (size_t I = 0, maxI = thread_ex_dets.size(); I < maxI; ++I) {
+//                std::vector<double>& coupling = thread_ex_dets[I].second;
+//                Determinant& det = thread_ex_dets[I].first;
+//                if (V_hash.count(det) != 0) {
+//                    for (int n = 0; n < nroot; ++n) {
+//                        V_hash[det][n] += coupling[n];
+//                    }
+//                } else {
+//                    V_hash[det] = coupling;
+//                }
+//            }
+//        }
+//    } // Close threads
+//}
+//
+//void AdaptiveCI::get_excited_determinants_restrict(SharedMatrix evecs, SharedVector evals,DeterminantHashVec& P_space,
+//                                                    std::vector<std::pair<double,Determinant>>& F_space);
+//    size_t max_P = P_space.size();
+//    const det_hashvec& P_dets = P_space.wfn_hash();
+//    int nroot = 1;
+//
+//// Loop over reference determinants
+//#pragma omp parallel
+//    {
+//        int num_thread = omp_get_num_threads();
+//        int tid = omp_get_thread_num();
+//        size_t bin_size = max_P / num_thread;
+//        bin_size += (tid < (max_P % num_thread)) ? 1 : 0;
+//        size_t start_idx =
+//            (tid < (max_P % num_thread))
+//                ? tid * bin_size
+//                : (max_P % num_thread) * (bin_size + 1) + (tid - (max_P % num_thread)) * bin_size;
+//        size_t end_idx = start_idx + bin_size;
+//
+//        if (omp_get_thread_num() == 0 and !quiet_mode_) {
+//            outfile->Printf("\n  Using %d threads.", num_thread);
+//        }
+//        // This will store the excited determinant info for each thread
+//        std::vector<std::pair<Determinant, std::vector<double>>>
+//            thread_ex_dets; //( noalpha * nvalpha  );
+//
+//        for (size_t P = start_idx; P < end_idx; ++P) {
+//            const Determinant& det(P_dets[P]);
+//            double evecs_P_row_norm = evecs->get_row(0, P)->norm();
+//
+//            std::vector<int> aocc = det.get_alfa_occ(nact_); // TODO check size
+//            std::vector<int> bocc = det.get_beta_occ(nact_); // TODO check size
+//            std::vector<int> avir = det.get_alfa_vir(nact_); // TODO check size
+//            std::vector<int> bvir = det.get_beta_vir(nact_); // TODO check size
+//
+//            int noalpha = aocc.size();
+//            int nobeta = bocc.size();
+//            int nvalpha = avir.size();
+//            int nvbeta = bvir.size();
+//            Determinant new_det(det);
+//
+//            // Generate alpha excitations
+//            for (int i = 0; i < noalpha; ++i) {
+//                int ii = aocc[i];
+//                for (int a = 0; a < nvalpha; ++a) {
+//                    int aa = avir[a];
+//                    if (((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) and
+//                        ((aa != hole_) or (!det.get_beta_bit(aa)))) {
+//                        double HIJ = fci_ints_->slater_rules_single_alpha(det, ii, aa);
+//                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+//                            //      if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+//                            new_det = det;
+//                            new_det.set_alfa_bit(ii, false);
+//                            new_det.set_alfa_bit(aa, true);
+//                            if (!(P_space.has_det(new_det))) {
+//                                std::vector<double> coupling(nroot, 0.0);
+//                                for (int n = 0; n < nroot; ++n) {
+//                                    coupling[n] += HIJ * evecs->get(P, n);
+//                                }
+//                                // thread_ex_dets[i * noalpha + a] =
+//                                // std::make_pair(new_det,coupling);
+//                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//            // Generate beta excitations
+//            for (int i = 0; i < nobeta; ++i) {
+//                int ii = bocc[i];
+//                for (int a = 0; a < nvbeta; ++a) {
+//                    int aa = bvir[a];
+//                    if (((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) and
+//                        ((aa != hole_) or (!det.get_alfa_bit(aa)))) {
+//                        double HIJ = fci_ints_->slater_rules_single_beta(det, ii, aa);
+//                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+//                            // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+//                            new_det = det;
+//                            new_det.set_beta_bit(ii, false);
+//                            new_det.set_beta_bit(aa, true);
+//                            if (!(P_space.has_det(new_det))) {
+//                                std::vector<double> coupling(nroot, 0.0);
+//                                for (int n = 0; n < nroot; ++n) {
+//                                    coupling[n] += HIJ * evecs->get(P, n);
+//                                }
+//                                // thread_ex_dets[i * nobeta + a] =
+//                                // std::make_pair(new_det,coupling);
+//                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//
+//            // Generate aa excitations
+//            for (int i = 0; i < noalpha; ++i) {
+//                int ii = aocc[i];
+//                for (int j = i + 1; j < noalpha; ++j) {
+//                    int jj = aocc[j];
+//                    for (int a = 0; a < nvalpha; ++a) {
+//                        int aa = avir[a];
+//                        for (int b = a + 1; b < nvalpha; ++b) {
+//                            int bb = avir[b];
+//                            if (((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
+//                                  mo_symmetry_[bb]) == 0) and
+//                                (aa != hole_ and bb != hole_)) {
+//                                double HIJ = fci_ints_->tei_aa(ii, jj, aa, bb);
+//                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+//                                    new_det = det;
+//                                    HIJ *= new_det.double_excitation_aa(ii, jj, aa, bb);
+//                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+//
+//                                    if (!(P_space.has_det(new_det))) {
+//                                        std::vector<double> coupling(nroot, 0.0);
+//                                        for (int n = 0; n < nroot; ++n) {
+//                                            coupling[n] += HIJ * evecs->get(P, n);
+//                                        }
+//                                        // thread_ex_dets[i *
+//                                        // noalpha*noalpha*nvalpha +
+//                                        // j*nvalpha*noalpha +  a*nvalpha + b ]
+//                                        // = std::make_pair(new_det,coupling);
+//                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+//                                    }
+//                                }
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//
+//            // Generate ab excitations
+//            for (int i = 0; i < noalpha; ++i) {
+//                int ii = aocc[i];
+//                for (int j = 0; j < nobeta; ++j) {
+//                    int jj = bocc[j];
+//                    for (int a = 0; a < nvalpha; ++a) {
+//                        int aa = avir[a];
+//                        for (int b = 0; b < nvbeta; ++b) {
+//                            int bb = bvir[b];
+//                            if (((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
+//                                  mo_symmetry_[bb]) == 0) and
+//                                (aa != hole_ and bb != hole_)) {
+//                                double HIJ = fci_ints_->tei_ab(ii, jj, aa, bb);
+//                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+//                                    new_det = det;
+//                                    HIJ *= new_det.double_excitation_ab(ii, jj, aa, bb);
+//                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+//
+//                                    if (!(P_space.has_det(new_det))) {
+//                                        std::vector<double> coupling(nroot, 0.0);
+//                                        for (int n = 0; n < nroot; ++n) {
+//                                            coupling[n] += HIJ * evecs->get(P, n);
+//                                        }
+//                                        // thread_ex_dets[i * nobeta * nvalpha
+//                                        // *nvbeta + j * bvalpha * nvbeta + a *
+//                                        // nvalpha]
+//                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+//                                    }
+//                                }
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//
+//            // Generate bb excitations
+//            for (int i = 0; i < nobeta; ++i) {
+//                int ii = bocc[i];
+//                for (int j = i + 1; j < nobeta; ++j) {
+//                    int jj = bocc[j];
+//                    for (int a = 0; a < nvbeta; ++a) {
+//                        int aa = bvir[a];
+//                        for (int b = a + 1; b < nvbeta; ++b) {
+//                            int bb = bvir[b];
+//                            if (((mo_symmetry_[ii] ^
+//                                  (mo_symmetry_[jj] ^ (mo_symmetry_[aa] ^ mo_symmetry_[bb]))) ==
+//                                 0) and
+//                                (aa != hole_ and bb != hole_)) {
+//                                double HIJ = fci_ints_->tei_bb(ii, jj, aa, bb);
+//                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+//                                    // if( std::abs(HIJ * evecs->get(0, P)) >= screen_thresh_ ){
+//                                    new_det = det;
+//                                    HIJ *= new_det.double_excitation_bb(ii, jj, aa, bb);
+//
+//                                    if (!(P_space.has_det(new_det))) {
+//                                        std::vector<double> coupling(nroot, 0.0);
+//                                        for (int n = 0; n < nroot; ++n) {
+//                                            coupling[n] += HIJ * evecs->get(P, n);
+//                                        }
+//                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+//                                    }
+//                                }
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//#pragma omp critical
+//        {
+//            for (size_t I = 0, maxI = thread_ex_dets.size(); I < maxI; ++I) {
+//                std::vector<double>& coupling = thread_ex_dets[I].second;
+//                Determinant& det = thread_ex_dets[I].first;
+//                if (V_hash.count(det) != 0) {
+//                    for (int n = 0; n < nroot; ++n) {
+//                        V_hash[det][n] += coupling[n];
+//                    }
+//                } else {
+//                    V_hash[det] = coupling;
+//                }
+//            }
+//        }
+//    } // Close threads
+//}
 
 // New threading strategy
 double

--- a/src/aci/aci_build_F.cc
+++ b/src/aci/aci_build_F.cc
@@ -441,7 +441,7 @@ void AdaptiveCI::get_excited_determinants_avg(int nroot, SharedMatrix evecs,
 
 }
 
-void AdaptiveCI::get_excited_determinants_restrict(SharedMatrix evecs, SharedVector evals,DeterminantHashVec& P_space,
+void AdaptiveCI::get_excited_determinants_core(SharedMatrix evecs, SharedVector evals,DeterminantHashVec& P_space,
                                                     std::vector<std::pair<double,Determinant>>& F_space)
 {
     size_t max_P = P_space.size();
@@ -655,6 +655,37 @@ void AdaptiveCI::get_excited_determinants_restrict(SharedMatrix evecs, SharedVec
             }
         }
     } // Close threads
+    Timer convert;
+
+    size_t max = V_hash.size();
+
+    F_space.resize(max);
+
+    #pragma omp parallel
+    {
+        int tid = omp_get_thread_num();
+        int ntd = omp_get_num_threads();
+    
+        size_t N = 0;
+        for( const auto& detpair : V_hash ){
+            if( (N%ntd) == tid ){
+                double EI = fci_ints_->energy(detpair.first);
+                std::vector<double> criteria(nroot, 0.0);
+                for( int n = 0; n < nroot; ++n ){
+                    double V = detpair.second[n];
+                    double delta = EI - evals->get(n);
+                    double criterion = 0.5 * (delta - sqrt(delta*delta + V*V*4.0));
+                    criteria[n] = std::fabs(criterion);
+                }
+                double value = average_q_values( nroot, criteria );
+
+                F_space[N] = std::make_pair( value, detpair.first );
+            }
+            N++;
+        }
+    }   
+    outfile->Printf("\n  Time spent building sorting list: %1.6f", convert.get());
+    outfile->Printf("\n  Size of F space: %zu", F_space.size());
 }
 
 // New threading strategy
@@ -1895,6 +1926,291 @@ outfile->Printf("\n  Inter-thread merge: %1.6f", merget.get());
     return std::make_pair(vec_A_b_t, dets_t);
 }
 
+std::vector<std::pair<int, Determinant>> AdaptiveCI::ras_masks() {
+
+    // Get the number of masks;
+    // Input => [ <irrep>, <min mo>, <max mo>, <ndiff>, ... ] 
+    std::vector<int> ras_spaces = options_.get_int_vector("ACI_RAS_SPACES");
+    size_t total_size = ras_spaces.size();
+
+    if( (total_size % 3) != 0 ){
+        outfile->Printf("\n  RAS space has the wrong dimension!");
+        exit(0);
+    }
+
+    std::vector<std::pair<int, Determinant>> ras_pairs;
+
+    int n_mask = total_size / 3;
+
+    std::vector<size_t> active_mos = mo_space_info_->get_corr_abs_mo("ACTIVE");
+
+    for( int m = 0; m < n_mask; ++m ){
+        uint64_t mask;
+        UI64Determinant tmp_det;
+            
+        int min = ras_spaces[m*3];
+        int max = ras_spaces[m*3 +1];
+        int r = ras_spaces[m*3 +2];
+
+        // Build det;
+        for( int n = min; n <= max; ++n ){
+            tmp_det.set_alfa_bit(n, true);
+            tmp_det.set_beta_bit(n, true);
+        }
+        ras_pairs.push_back(std::make_pair(r, tmp_det));
+    } 
+
+    return ras_pairs;
+
+}
+
+void AdaptiveCI::get_excited_determinants_restrict(int nroot, SharedMatrix evecs,
+                                          SharedVector evals,
+                                          DeterminantHashVec& P_space,
+                                          std::vector<std::pair<double,Determinant>>& F_space) {
+    size_t max_P = P_space.size();
+    const det_hashvec& P_dets = P_space.wfn_hash();
+
+    auto mask_pairs = ras_masks();
+
+    det_hash<std::vector<double>> V_hash;
+// Loop over reference determinants
+#pragma omp parallel
+    {
+        int num_thread = omp_get_num_threads();
+        int tid = omp_get_thread_num();
+        size_t bin_size = max_P / num_thread;
+        bin_size += (tid < (max_P % num_thread)) ? 1 : 0;
+        size_t start_idx =
+            (tid < (max_P % num_thread))
+                ? tid * bin_size
+                : (max_P % num_thread) * (bin_size + 1) + (tid - (max_P % num_thread)) * bin_size;
+        size_t end_idx = start_idx + bin_size;
+
+        if (omp_get_thread_num() == 0 and !quiet_mode_) {
+            outfile->Printf("\n  Using %d threads.", num_thread);
+        }
+        // This will store the excited determinant info for each thread
+        std::vector<std::pair<Determinant, std::vector<double>>>
+            thread_ex_dets; //( noalpha * nvalpha  );
+
+        for (size_t P = start_idx; P < end_idx; ++P) {
+            const Determinant& det(P_dets[P]);
+            double evecs_P_row_norm = evecs->get_row(0, P)->norm();
+
+            std::vector<int> aocc = det.get_alfa_occ(nact_);
+            std::vector<int> bocc = det.get_beta_occ(nact_);
+            std::vector<int> avir = det.get_alfa_vir(nact_);
+            std::vector<int> bvir = det.get_beta_vir(nact_);
+
+            int noalpha = aocc.size();
+            int nobeta = bocc.size();
+            int nvalpha = avir.size();
+            int nvbeta = bvir.size();
+            Determinant new_det(det);
+
+            // Generate alpha excitations
+            for (int i = 0; i < noalpha; ++i) {
+                int ii = aocc[i];
+                for (int a = 0; a < nvalpha; ++a) {
+                    int aa = avir[a];
+                    if ((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) {
+                        double HIJ = fci_ints_->slater_rules_single_alpha(det, ii, aa);
+                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+                            //      if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+                            new_det = det;
+                            new_det.set_alfa_bit(ii, false);
+                            new_det.set_alfa_bit(aa, true);
+                            if (!(P_space.has_det(new_det))) {
+                                std::vector<double> coupling(nroot, 0.0);
+                                for (int n = 0; n < nroot; ++n) {
+                                    coupling[n] += HIJ * evecs->get(P, n);
+                                }
+                                // thread_ex_dets[i * noalpha + a] =
+                                // std::make_pair(new_det,coupling);
+                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Generate beta excitations
+            for (int i = 0; i < nobeta; ++i) {
+                int ii = bocc[i];
+                for (int a = 0; a < nvbeta; ++a) {
+                    int aa = bvir[a];
+                    if ((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) {
+                        double HIJ = fci_ints_->slater_rules_single_beta(det, ii, aa);
+                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+                            // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+                            new_det = det;
+                            new_det.set_beta_bit(ii, false);
+                            new_det.set_beta_bit(aa, true);
+                            if (!(P_space.has_det(new_det))) {
+                                std::vector<double> coupling(nroot, 0.0);
+                                for (int n = 0; n < nroot; ++n) {
+                                    coupling[n] += HIJ * evecs->get(P, n);
+                                }
+                                // thread_ex_dets[i * nobeta + a] =
+                                // std::make_pair(new_det,coupling);
+                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Generate aa excitations
+            for (int i = 0; i < noalpha; ++i) {
+                int ii = aocc[i];
+                for (int j = i + 1; j < noalpha; ++j) {
+                    int jj = aocc[j];
+                    for (int a = 0; a < nvalpha; ++a) {
+                        int aa = avir[a];
+                        for (int b = a + 1; b < nvalpha; ++b) {
+                            int bb = avir[b];
+                            if ((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
+                                 mo_symmetry_[bb]) == 0) {
+                                double HIJ = fci_ints_->tei_aa(ii, jj, aa, bb);
+                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+                                    new_det = det;
+                                    HIJ *= new_det.double_excitation_aa(ii, jj, aa, bb);
+                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+
+                                    if (!(P_space.has_det(new_det))) {
+                                        std::vector<double> coupling(nroot, 0.0);
+                                        for (int n = 0; n < nroot; ++n) {
+                                            coupling[n] += HIJ * evecs->get(P, n);
+                                        }
+                                        // thread_ex_dets[i *
+                                        // noalpha*noalpha*nvalpha +
+                                        // j*nvalpha*noalpha +  a*nvalpha + b ]
+                                        // = std::make_pair(new_det,coupling);
+                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Generate ab excitations
+            for (int i = 0; i < noalpha; ++i) {
+                int ii = aocc[i];
+                for (int j = 0; j < nobeta; ++j) {
+                    int jj = bocc[j];
+                    for (int a = 0; a < nvalpha; ++a) {
+                        int aa = avir[a];
+                        for (int b = 0; b < nvbeta; ++b) {
+                            int bb = bvir[b];
+                            if ((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
+                                 mo_symmetry_[bb]) == 0) {
+                                double HIJ = fci_ints_->tei_ab(ii, jj, aa, bb);
+                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+                                    new_det = det;
+                                    HIJ *= new_det.double_excitation_ab(ii, jj, aa, bb);
+                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+
+                                    if (!(P_space.has_det(new_det))) {
+                                        std::vector<double> coupling(nroot, 0.0);
+                                        for (int n = 0; n < nroot; ++n) {
+                                            coupling[n] += HIJ * evecs->get(P, n);
+                                        }
+                                        // thread_ex_dets[i * nobeta * nvalpha
+                                        // *nvbeta + j * bvalpha * nvbeta + a *
+                                        // nvalpha]
+                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Generate bb excitations
+            for (int i = 0; i < nobeta; ++i) {
+                int ii = bocc[i];
+                for (int j = i + 1; j < nobeta; ++j) {
+                    int jj = bocc[j];
+                    for (int a = 0; a < nvbeta; ++a) {
+                        int aa = bvir[a];
+                        for (int b = a + 1; b < nvbeta; ++b) {
+                            int bb = bvir[b];
+                            if ((mo_symmetry_[ii] ^
+                                 (mo_symmetry_[jj] ^ (mo_symmetry_[aa] ^ mo_symmetry_[bb]))) == 0) {
+                                double HIJ = fci_ints_->tei_bb(ii, jj, aa, bb);
+                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+                                    // if( std::abs(HIJ * evecs->get(0, P)) >= screen_thresh_ ){
+                                    new_det = det;
+                                    HIJ *= new_det.double_excitation_bb(ii, jj, aa, bb);
+
+                                    if (!(P_space.has_det(new_det))) {
+                                        std::vector<double> coupling(nroot, 0.0);
+                                        for (int n = 0; n < nroot; ++n) {
+                                            coupling[n] += HIJ * evecs->get(P, n);
+                                        }
+                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        #pragma omp critical
+        {
+            for (size_t I = 0, maxI = thread_ex_dets.size(); I < maxI; ++I) {
+                std::vector<double>& coupling = thread_ex_dets[I].second;
+                Determinant& det = thread_ex_dets[I].first;
+                if (V_hash.count(det) != 0) {
+                    for (int n = 0; n < nroot; ++n) {
+                        V_hash[det][n] += coupling[n];
+                    }
+                } else {
+                    V_hash[det] = coupling;
+                }
+            }
+        }
+    } // Close threads
+
+    Timer convert;
+
+    size_t max = V_hash.size();
+
+    F_space.resize(max);
+
+    #pragma omp parallel
+    {
+        int tid = omp_get_thread_num();
+        int ntd = omp_get_num_threads();
+    
+        size_t N = 0;
+        for( const auto& detpair : V_hash ){
+            if( (N%ntd) == tid ){
+                double EI = fci_ints_->energy(detpair.first);
+                std::vector<double> criteria(nroot, 0.0);
+                for( int n = 0; n < nroot; ++n ){
+                    double V = detpair.second[n];
+                    double delta = EI - evals->get(n);
+                    double criterion = 0.5 * (delta - sqrt(delta*delta + V*V*4.0));
+                    criteria[n] = std::fabs(criterion);
+                }
+                double value = average_q_values( nroot, criteria );
+
+                F_space[N] = std::make_pair( value, detpair.first );
+            }
+            N++;
+        }
+    }   
+    outfile->Printf("\n  Time spent building sorting list: %1.6f", convert.get());
+    outfile->Printf("\n  Size of F space: %zu", F_space.size());
+
+}
 
 } // namespace forte
 } // namespace psi

--- a/src/aci/aci_build_F.cc
+++ b/src/aci/aci_build_F.cc
@@ -1182,7 +1182,7 @@ AdaptiveCI::get_excited_determinants_batch_vecsort(SharedMatrix evecs, SharedVec
                 double& V = pair.second;
                 if (V != 0.0) {
                     auto& det = pair.first;
-                    double delta = fci_ints_->energy_bit(det) - E0;
+                    double delta = fci_ints_->energy(det) - E0;
                     V = std::fabs(0.5 * (delta - sqrt(delta * delta + V * V * 4.0)));
                 }
             }
@@ -1399,7 +1399,7 @@ AdaptiveCI::get_excited_determinants_batch(SharedMatrix evecs, SharedVector eval
                     double& V = pair.second;
 
                     //double delta = fci_ints_->energy(det) - E0;
-                    double delta = fci_ints_->energy_bit(det) - E0;
+                    double delta = fci_ints_->energy(det) - E0;
 
                     F_tmp[idx] = std::make_pair(
                         std::fabs(0.5 * (delta - sqrt(delta * delta + V * V * 4.0))), det);

--- a/src/aci/aci_build_F.cc
+++ b/src/aci/aci_build_F.cc
@@ -37,7 +37,7 @@ void AdaptiveCI::get_excited_determinants_sr(SharedMatrix evecs, SharedVector ev
         det_hash<double> V_hash_t;
         for (size_t P = start_idx; P < end_idx; ++P) {
             const Determinant& det(P_dets[P]);
-            double Cp = evecs->get(P, 0);
+            double Cp = evecs->get(P, ref_root_);
 
             std::vector<int> aocc = det.get_alfa_occ(nact_); // TODO check size
             std::vector<int> bocc = det.get_beta_occ(nact_); // TODO check size
@@ -162,434 +162,500 @@ void AdaptiveCI::get_excited_determinants_sr(SharedMatrix evecs, SharedVector ev
         if (tid == 0)
             outfile->Printf("\n  Time spent merging thread F spaces: %20.6f", merge_t.get());
     } // Close threads
+
+    // Remove P space 
+    const det_hashvec& pdets = P_space.wfn_hash();
+    for( det_hashvec::iterator it = pdets.begin(), endit = pdets.end(); it != endit; ++it ){
+        V_hash.erase(*it);
+    }
+
+
+    // Loop through hash, compute criteria
+    Timer convert;
+
+    size_t max = V_hash.size();
+    outfile->Printf("\n  size of hash: %zu", max);
+    F_space.resize( max );
+    #pragma omp parallel
+    {
+        int num_thread = omp_get_num_threads();
+        int tid = omp_get_thread_num();
+        size_t N = 0;
+        for( const auto& I : V_hash ){
+            if( (N%num_thread) == tid ) {
+                double delta = fci_ints_->energy(I.first) - evals->get(ref_root_);
+                double V = I.second;
+                double criteria = 0.5 * (delta - sqrt(delta*delta + V*V*4.0));
+                F_space[N] = std::make_pair(std::fabs(criteria), I.first);
+            }
+            N++;
+        }
+    }
+    outfile->Printf("\n  Time spent building sorting list: %1.6f", convert.get());
+    outfile->Printf("\n  Size of F space: %zu", F_space.size());
 }
 
-//void AdaptiveCI::get_excited_determinants_avg(int nroot, SharedMatrix evecs,
-//                                          SharedMatrix evals,
-//                                          DeterminantHashVec& P_space,
-//                                          det_hash<std::vector<double>>& V_hash) {
-//    size_t max_P = P_space.size();
-//    const det_hashvec& P_dets = P_space.wfn_hash();
-//
-//// Loop over reference determinants
-//#pragma omp parallel
-//    {
-//        int num_thread = omp_get_num_threads();
-//        int tid = omp_get_thread_num();
-//        size_t bin_size = max_P / num_thread;
-//        bin_size += (tid < (max_P % num_thread)) ? 1 : 0;
-//        size_t start_idx =
-//            (tid < (max_P % num_thread))
-//                ? tid * bin_size
-//                : (max_P % num_thread) * (bin_size + 1) + (tid - (max_P % num_thread)) * bin_size;
-//        size_t end_idx = start_idx + bin_size;
-//
-//        if (omp_get_thread_num() == 0 and !quiet_mode_) {
-//            outfile->Printf("\n  Using %d threads.", num_thread);
-//        }
-//        // This will store the excited determinant info for each thread
-//        std::vector<std::pair<Determinant, std::vector<double>>>
-//            thread_ex_dets; //( noalpha * nvalpha  );
-//
-//        for (size_t P = start_idx; P < end_idx; ++P) {
-//            const Determinant& det(P_dets[P]);
-//            double evecs_P_row_norm = evecs->get_row(0, P)->norm();
-//
-//            std::vector<int> aocc = det.get_alfa_occ(nact_);
-//            std::vector<int> bocc = det.get_beta_occ(nact_);
-//            std::vector<int> avir = det.get_alfa_vir(nact_);
-//            std::vector<int> bvir = det.get_beta_vir(nact_);
-//
-//            int noalpha = aocc.size();
-//            int nobeta = bocc.size();
-//            int nvalpha = avir.size();
-//            int nvbeta = bvir.size();
-//            Determinant new_det(det);
-//
-//            // Generate alpha excitations
-//            for (int i = 0; i < noalpha; ++i) {
-//                int ii = aocc[i];
-//                for (int a = 0; a < nvalpha; ++a) {
-//                    int aa = avir[a];
-//                    if ((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) {
-//                        double HIJ = fci_ints_->slater_rules_single_alpha(det, ii, aa);
-//                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-//                            //      if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
-//                            new_det = det;
-//                            new_det.set_alfa_bit(ii, false);
-//                            new_det.set_alfa_bit(aa, true);
-//                            if (!(P_space.has_det(new_det))) {
-//                                std::vector<double> coupling(nroot, 0.0);
-//                                for (int n = 0; n < nroot; ++n) {
-//                                    coupling[n] += HIJ * evecs->get(P, n);
-//                                }
-//                                // thread_ex_dets[i * noalpha + a] =
-//                                // std::make_pair(new_det,coupling);
-//                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-//                            }
-//                        }
-//                    }
-//                }
-//            }
-//
-//            // Generate beta excitations
-//            for (int i = 0; i < nobeta; ++i) {
-//                int ii = bocc[i];
-//                for (int a = 0; a < nvbeta; ++a) {
-//                    int aa = bvir[a];
-//                    if ((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) {
-//                        double HIJ = fci_ints_->slater_rules_single_beta(det, ii, aa);
-//                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-//                            // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
-//                            new_det = det;
-//                            new_det.set_beta_bit(ii, false);
-//                            new_det.set_beta_bit(aa, true);
-//                            if (!(P_space.has_det(new_det))) {
-//                                std::vector<double> coupling(nroot, 0.0);
-//                                for (int n = 0; n < nroot; ++n) {
-//                                    coupling[n] += HIJ * evecs->get(P, n);
-//                                }
-//                                // thread_ex_dets[i * nobeta + a] =
-//                                // std::make_pair(new_det,coupling);
-//                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-//                            }
-//                        }
-//                    }
-//                }
-//            }
-//
-//            // Generate aa excitations
-//            for (int i = 0; i < noalpha; ++i) {
-//                int ii = aocc[i];
-//                for (int j = i + 1; j < noalpha; ++j) {
-//                    int jj = aocc[j];
-//                    for (int a = 0; a < nvalpha; ++a) {
-//                        int aa = avir[a];
-//                        for (int b = a + 1; b < nvalpha; ++b) {
-//                            int bb = avir[b];
-//                            if ((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
-//                                 mo_symmetry_[bb]) == 0) {
-//                                double HIJ = fci_ints_->tei_aa(ii, jj, aa, bb);
-//                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-//                                    new_det = det;
-//                                    HIJ *= new_det.double_excitation_aa(ii, jj, aa, bb);
-//                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
-//
-//                                    if (!(P_space.has_det(new_det))) {
-//                                        std::vector<double> coupling(nroot, 0.0);
-//                                        for (int n = 0; n < nroot; ++n) {
-//                                            coupling[n] += HIJ * evecs->get(P, n);
-//                                        }
-//                                        // thread_ex_dets[i *
-//                                        // noalpha*noalpha*nvalpha +
-//                                        // j*nvalpha*noalpha +  a*nvalpha + b ]
-//                                        // = std::make_pair(new_det,coupling);
-//                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-//                                    }
-//                                }
-//                            }
-//                        }
-//                    }
-//                }
-//            }
-//
-//            // Generate ab excitations
-//            for (int i = 0; i < noalpha; ++i) {
-//                int ii = aocc[i];
-//                for (int j = 0; j < nobeta; ++j) {
-//                    int jj = bocc[j];
-//                    for (int a = 0; a < nvalpha; ++a) {
-//                        int aa = avir[a];
-//                        for (int b = 0; b < nvbeta; ++b) {
-//                            int bb = bvir[b];
-//                            if ((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
-//                                 mo_symmetry_[bb]) == 0) {
-//                                double HIJ = fci_ints_->tei_ab(ii, jj, aa, bb);
-//                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-//                                    new_det = det;
-//                                    HIJ *= new_det.double_excitation_ab(ii, jj, aa, bb);
-//                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
-//
-//                                    if (!(P_space.has_det(new_det))) {
-//                                        std::vector<double> coupling(nroot, 0.0);
-//                                        for (int n = 0; n < nroot; ++n) {
-//                                            coupling[n] += HIJ * evecs->get(P, n);
-//                                        }
-//                                        // thread_ex_dets[i * nobeta * nvalpha
-//                                        // *nvbeta + j * bvalpha * nvbeta + a *
-//                                        // nvalpha]
-//                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-//                                    }
-//                                }
-//                            }
-//                        }
-//                    }
-//                }
-//            }
-//
-//            // Generate bb excitations
-//            for (int i = 0; i < nobeta; ++i) {
-//                int ii = bocc[i];
-//                for (int j = i + 1; j < nobeta; ++j) {
-//                    int jj = bocc[j];
-//                    for (int a = 0; a < nvbeta; ++a) {
-//                        int aa = bvir[a];
-//                        for (int b = a + 1; b < nvbeta; ++b) {
-//                            int bb = bvir[b];
-//                            if ((mo_symmetry_[ii] ^
-//                                 (mo_symmetry_[jj] ^ (mo_symmetry_[aa] ^ mo_symmetry_[bb]))) == 0) {
-//                                double HIJ = fci_ints_->tei_bb(ii, jj, aa, bb);
-//                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-//                                    // if( std::abs(HIJ * evecs->get(0, P)) >= screen_thresh_ ){
-//                                    new_det = det;
-//                                    HIJ *= new_det.double_excitation_bb(ii, jj, aa, bb);
-//
-//                                    if (!(P_space.has_det(new_det))) {
-//                                        std::vector<double> coupling(nroot, 0.0);
-//                                        for (int n = 0; n < nroot; ++n) {
-//                                            coupling[n] += HIJ * evecs->get(P, n);
-//                                        }
-//                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-//                                    }
-//                                }
-//                            }
-//                        }
-//                    }
-//                }
-//            }
-//        }
-//
-//#pragma omp critical
-//        {
-//            for (size_t I = 0, maxI = thread_ex_dets.size(); I < maxI; ++I) {
-//                std::vector<double>& coupling = thread_ex_dets[I].second;
-//                Determinant& det = thread_ex_dets[I].first;
-//                if (V_hash.count(det) != 0) {
-//                    for (int n = 0; n < nroot; ++n) {
-//                        V_hash[det][n] += coupling[n];
-//                    }
-//                } else {
-//                    V_hash[det] = coupling;
-//                }
-//            }
-//        }
-//    } // Close threads
-//}
-//
-//void AdaptiveCI::get_excited_determinants_restrict(SharedMatrix evecs, SharedVector evals,DeterminantHashVec& P_space,
-//                                                    std::vector<std::pair<double,Determinant>>& F_space);
-//    size_t max_P = P_space.size();
-//    const det_hashvec& P_dets = P_space.wfn_hash();
-//    int nroot = 1;
-//
-//// Loop over reference determinants
-//#pragma omp parallel
-//    {
-//        int num_thread = omp_get_num_threads();
-//        int tid = omp_get_thread_num();
-//        size_t bin_size = max_P / num_thread;
-//        bin_size += (tid < (max_P % num_thread)) ? 1 : 0;
-//        size_t start_idx =
-//            (tid < (max_P % num_thread))
-//                ? tid * bin_size
-//                : (max_P % num_thread) * (bin_size + 1) + (tid - (max_P % num_thread)) * bin_size;
-//        size_t end_idx = start_idx + bin_size;
-//
-//        if (omp_get_thread_num() == 0 and !quiet_mode_) {
-//            outfile->Printf("\n  Using %d threads.", num_thread);
-//        }
-//        // This will store the excited determinant info for each thread
-//        std::vector<std::pair<Determinant, std::vector<double>>>
-//            thread_ex_dets; //( noalpha * nvalpha  );
-//
-//        for (size_t P = start_idx; P < end_idx; ++P) {
-//            const Determinant& det(P_dets[P]);
-//            double evecs_P_row_norm = evecs->get_row(0, P)->norm();
-//
-//            std::vector<int> aocc = det.get_alfa_occ(nact_); // TODO check size
-//            std::vector<int> bocc = det.get_beta_occ(nact_); // TODO check size
-//            std::vector<int> avir = det.get_alfa_vir(nact_); // TODO check size
-//            std::vector<int> bvir = det.get_beta_vir(nact_); // TODO check size
-//
-//            int noalpha = aocc.size();
-//            int nobeta = bocc.size();
-//            int nvalpha = avir.size();
-//            int nvbeta = bvir.size();
-//            Determinant new_det(det);
-//
-//            // Generate alpha excitations
-//            for (int i = 0; i < noalpha; ++i) {
-//                int ii = aocc[i];
-//                for (int a = 0; a < nvalpha; ++a) {
-//                    int aa = avir[a];
-//                    if (((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) and
-//                        ((aa != hole_) or (!det.get_beta_bit(aa)))) {
-//                        double HIJ = fci_ints_->slater_rules_single_alpha(det, ii, aa);
-//                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-//                            //      if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
-//                            new_det = det;
-//                            new_det.set_alfa_bit(ii, false);
-//                            new_det.set_alfa_bit(aa, true);
-//                            if (!(P_space.has_det(new_det))) {
-//                                std::vector<double> coupling(nroot, 0.0);
-//                                for (int n = 0; n < nroot; ++n) {
-//                                    coupling[n] += HIJ * evecs->get(P, n);
-//                                }
-//                                // thread_ex_dets[i * noalpha + a] =
-//                                // std::make_pair(new_det,coupling);
-//                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-//                            }
-//                        }
-//                    }
-//                }
-//            }
-//            // Generate beta excitations
-//            for (int i = 0; i < nobeta; ++i) {
-//                int ii = bocc[i];
-//                for (int a = 0; a < nvbeta; ++a) {
-//                    int aa = bvir[a];
-//                    if (((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) and
-//                        ((aa != hole_) or (!det.get_alfa_bit(aa)))) {
-//                        double HIJ = fci_ints_->slater_rules_single_beta(det, ii, aa);
-//                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-//                            // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
-//                            new_det = det;
-//                            new_det.set_beta_bit(ii, false);
-//                            new_det.set_beta_bit(aa, true);
-//                            if (!(P_space.has_det(new_det))) {
-//                                std::vector<double> coupling(nroot, 0.0);
-//                                for (int n = 0; n < nroot; ++n) {
-//                                    coupling[n] += HIJ * evecs->get(P, n);
-//                                }
-//                                // thread_ex_dets[i * nobeta + a] =
-//                                // std::make_pair(new_det,coupling);
-//                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-//                            }
-//                        }
-//                    }
-//                }
-//            }
-//
-//            // Generate aa excitations
-//            for (int i = 0; i < noalpha; ++i) {
-//                int ii = aocc[i];
-//                for (int j = i + 1; j < noalpha; ++j) {
-//                    int jj = aocc[j];
-//                    for (int a = 0; a < nvalpha; ++a) {
-//                        int aa = avir[a];
-//                        for (int b = a + 1; b < nvalpha; ++b) {
-//                            int bb = avir[b];
-//                            if (((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
-//                                  mo_symmetry_[bb]) == 0) and
-//                                (aa != hole_ and bb != hole_)) {
-//                                double HIJ = fci_ints_->tei_aa(ii, jj, aa, bb);
-//                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-//                                    new_det = det;
-//                                    HIJ *= new_det.double_excitation_aa(ii, jj, aa, bb);
-//                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
-//
-//                                    if (!(P_space.has_det(new_det))) {
-//                                        std::vector<double> coupling(nroot, 0.0);
-//                                        for (int n = 0; n < nroot; ++n) {
-//                                            coupling[n] += HIJ * evecs->get(P, n);
-//                                        }
-//                                        // thread_ex_dets[i *
-//                                        // noalpha*noalpha*nvalpha +
-//                                        // j*nvalpha*noalpha +  a*nvalpha + b ]
-//                                        // = std::make_pair(new_det,coupling);
-//                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-//                                    }
-//                                }
-//                            }
-//                        }
-//                    }
-//                }
-//            }
-//
-//            // Generate ab excitations
-//            for (int i = 0; i < noalpha; ++i) {
-//                int ii = aocc[i];
-//                for (int j = 0; j < nobeta; ++j) {
-//                    int jj = bocc[j];
-//                    for (int a = 0; a < nvalpha; ++a) {
-//                        int aa = avir[a];
-//                        for (int b = 0; b < nvbeta; ++b) {
-//                            int bb = bvir[b];
-//                            if (((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
-//                                  mo_symmetry_[bb]) == 0) and
-//                                (aa != hole_ and bb != hole_)) {
-//                                double HIJ = fci_ints_->tei_ab(ii, jj, aa, bb);
-//                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-//                                    new_det = det;
-//                                    HIJ *= new_det.double_excitation_ab(ii, jj, aa, bb);
-//                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
-//
-//                                    if (!(P_space.has_det(new_det))) {
-//                                        std::vector<double> coupling(nroot, 0.0);
-//                                        for (int n = 0; n < nroot; ++n) {
-//                                            coupling[n] += HIJ * evecs->get(P, n);
-//                                        }
-//                                        // thread_ex_dets[i * nobeta * nvalpha
-//                                        // *nvbeta + j * bvalpha * nvbeta + a *
-//                                        // nvalpha]
-//                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-//                                    }
-//                                }
-//                            }
-//                        }
-//                    }
-//                }
-//            }
-//
-//            // Generate bb excitations
-//            for (int i = 0; i < nobeta; ++i) {
-//                int ii = bocc[i];
-//                for (int j = i + 1; j < nobeta; ++j) {
-//                    int jj = bocc[j];
-//                    for (int a = 0; a < nvbeta; ++a) {
-//                        int aa = bvir[a];
-//                        for (int b = a + 1; b < nvbeta; ++b) {
-//                            int bb = bvir[b];
-//                            if (((mo_symmetry_[ii] ^
-//                                  (mo_symmetry_[jj] ^ (mo_symmetry_[aa] ^ mo_symmetry_[bb]))) ==
-//                                 0) and
-//                                (aa != hole_ and bb != hole_)) {
-//                                double HIJ = fci_ints_->tei_bb(ii, jj, aa, bb);
-//                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
-//                                    // if( std::abs(HIJ * evecs->get(0, P)) >= screen_thresh_ ){
-//                                    new_det = det;
-//                                    HIJ *= new_det.double_excitation_bb(ii, jj, aa, bb);
-//
-//                                    if (!(P_space.has_det(new_det))) {
-//                                        std::vector<double> coupling(nroot, 0.0);
-//                                        for (int n = 0; n < nroot; ++n) {
-//                                            coupling[n] += HIJ * evecs->get(P, n);
-//                                        }
-//                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
-//                                    }
-//                                }
-//                            }
-//                        }
-//                    }
-//                }
-//            }
-//        }
-//#pragma omp critical
-//        {
-//            for (size_t I = 0, maxI = thread_ex_dets.size(); I < maxI; ++I) {
-//                std::vector<double>& coupling = thread_ex_dets[I].second;
-//                Determinant& det = thread_ex_dets[I].first;
-//                if (V_hash.count(det) != 0) {
-//                    for (int n = 0; n < nroot; ++n) {
-//                        V_hash[det][n] += coupling[n];
-//                    }
-//                } else {
-//                    V_hash[det] = coupling;
-//                }
-//            }
-//        }
-//    } // Close threads
-//}
+void AdaptiveCI::get_excited_determinants_avg(int nroot, SharedMatrix evecs,
+                                          SharedVector evals,
+                                          DeterminantHashVec& P_space,
+                                          std::vector<std::pair<double,Determinant>>& F_space) {
+    size_t max_P = P_space.size();
+    const det_hashvec& P_dets = P_space.wfn_hash();
+
+    det_hash<std::vector<double>> V_hash;
+// Loop over reference determinants
+#pragma omp parallel
+    {
+        int num_thread = omp_get_num_threads();
+        int tid = omp_get_thread_num();
+        size_t bin_size = max_P / num_thread;
+        bin_size += (tid < (max_P % num_thread)) ? 1 : 0;
+        size_t start_idx =
+            (tid < (max_P % num_thread))
+                ? tid * bin_size
+                : (max_P % num_thread) * (bin_size + 1) + (tid - (max_P % num_thread)) * bin_size;
+        size_t end_idx = start_idx + bin_size;
+
+        if (omp_get_thread_num() == 0 and !quiet_mode_) {
+            outfile->Printf("\n  Using %d threads.", num_thread);
+        }
+        // This will store the excited determinant info for each thread
+        std::vector<std::pair<Determinant, std::vector<double>>>
+            thread_ex_dets; //( noalpha * nvalpha  );
+
+        for (size_t P = start_idx; P < end_idx; ++P) {
+            const Determinant& det(P_dets[P]);
+            double evecs_P_row_norm = evecs->get_row(0, P)->norm();
+
+            std::vector<int> aocc = det.get_alfa_occ(nact_);
+            std::vector<int> bocc = det.get_beta_occ(nact_);
+            std::vector<int> avir = det.get_alfa_vir(nact_);
+            std::vector<int> bvir = det.get_beta_vir(nact_);
+
+            int noalpha = aocc.size();
+            int nobeta = bocc.size();
+            int nvalpha = avir.size();
+            int nvbeta = bvir.size();
+            Determinant new_det(det);
+
+            // Generate alpha excitations
+            for (int i = 0; i < noalpha; ++i) {
+                int ii = aocc[i];
+                for (int a = 0; a < nvalpha; ++a) {
+                    int aa = avir[a];
+                    if ((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) {
+                        double HIJ = fci_ints_->slater_rules_single_alpha(det, ii, aa);
+                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+                            //      if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+                            new_det = det;
+                            new_det.set_alfa_bit(ii, false);
+                            new_det.set_alfa_bit(aa, true);
+                            if (!(P_space.has_det(new_det))) {
+                                std::vector<double> coupling(nroot, 0.0);
+                                for (int n = 0; n < nroot; ++n) {
+                                    coupling[n] += HIJ * evecs->get(P, n);
+                                }
+                                // thread_ex_dets[i * noalpha + a] =
+                                // std::make_pair(new_det,coupling);
+                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Generate beta excitations
+            for (int i = 0; i < nobeta; ++i) {
+                int ii = bocc[i];
+                for (int a = 0; a < nvbeta; ++a) {
+                    int aa = bvir[a];
+                    if ((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) {
+                        double HIJ = fci_ints_->slater_rules_single_beta(det, ii, aa);
+                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+                            // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+                            new_det = det;
+                            new_det.set_beta_bit(ii, false);
+                            new_det.set_beta_bit(aa, true);
+                            if (!(P_space.has_det(new_det))) {
+                                std::vector<double> coupling(nroot, 0.0);
+                                for (int n = 0; n < nroot; ++n) {
+                                    coupling[n] += HIJ * evecs->get(P, n);
+                                }
+                                // thread_ex_dets[i * nobeta + a] =
+                                // std::make_pair(new_det,coupling);
+                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Generate aa excitations
+            for (int i = 0; i < noalpha; ++i) {
+                int ii = aocc[i];
+                for (int j = i + 1; j < noalpha; ++j) {
+                    int jj = aocc[j];
+                    for (int a = 0; a < nvalpha; ++a) {
+                        int aa = avir[a];
+                        for (int b = a + 1; b < nvalpha; ++b) {
+                            int bb = avir[b];
+                            if ((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
+                                 mo_symmetry_[bb]) == 0) {
+                                double HIJ = fci_ints_->tei_aa(ii, jj, aa, bb);
+                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+                                    new_det = det;
+                                    HIJ *= new_det.double_excitation_aa(ii, jj, aa, bb);
+                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+
+                                    if (!(P_space.has_det(new_det))) {
+                                        std::vector<double> coupling(nroot, 0.0);
+                                        for (int n = 0; n < nroot; ++n) {
+                                            coupling[n] += HIJ * evecs->get(P, n);
+                                        }
+                                        // thread_ex_dets[i *
+                                        // noalpha*noalpha*nvalpha +
+                                        // j*nvalpha*noalpha +  a*nvalpha + b ]
+                                        // = std::make_pair(new_det,coupling);
+                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Generate ab excitations
+            for (int i = 0; i < noalpha; ++i) {
+                int ii = aocc[i];
+                for (int j = 0; j < nobeta; ++j) {
+                    int jj = bocc[j];
+                    for (int a = 0; a < nvalpha; ++a) {
+                        int aa = avir[a];
+                        for (int b = 0; b < nvbeta; ++b) {
+                            int bb = bvir[b];
+                            if ((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
+                                 mo_symmetry_[bb]) == 0) {
+                                double HIJ = fci_ints_->tei_ab(ii, jj, aa, bb);
+                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+                                    new_det = det;
+                                    HIJ *= new_det.double_excitation_ab(ii, jj, aa, bb);
+                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+
+                                    if (!(P_space.has_det(new_det))) {
+                                        std::vector<double> coupling(nroot, 0.0);
+                                        for (int n = 0; n < nroot; ++n) {
+                                            coupling[n] += HIJ * evecs->get(P, n);
+                                        }
+                                        // thread_ex_dets[i * nobeta * nvalpha
+                                        // *nvbeta + j * bvalpha * nvbeta + a *
+                                        // nvalpha]
+                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Generate bb excitations
+            for (int i = 0; i < nobeta; ++i) {
+                int ii = bocc[i];
+                for (int j = i + 1; j < nobeta; ++j) {
+                    int jj = bocc[j];
+                    for (int a = 0; a < nvbeta; ++a) {
+                        int aa = bvir[a];
+                        for (int b = a + 1; b < nvbeta; ++b) {
+                            int bb = bvir[b];
+                            if ((mo_symmetry_[ii] ^
+                                 (mo_symmetry_[jj] ^ (mo_symmetry_[aa] ^ mo_symmetry_[bb]))) == 0) {
+                                double HIJ = fci_ints_->tei_bb(ii, jj, aa, bb);
+                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+                                    // if( std::abs(HIJ * evecs->get(0, P)) >= screen_thresh_ ){
+                                    new_det = det;
+                                    HIJ *= new_det.double_excitation_bb(ii, jj, aa, bb);
+
+                                    if (!(P_space.has_det(new_det))) {
+                                        std::vector<double> coupling(nroot, 0.0);
+                                        for (int n = 0; n < nroot; ++n) {
+                                            coupling[n] += HIJ * evecs->get(P, n);
+                                        }
+                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        #pragma omp critical
+        {
+            for (size_t I = 0, maxI = thread_ex_dets.size(); I < maxI; ++I) {
+                std::vector<double>& coupling = thread_ex_dets[I].second;
+                Determinant& det = thread_ex_dets[I].first;
+                if (V_hash.count(det) != 0) {
+                    for (int n = 0; n < nroot; ++n) {
+                        V_hash[det][n] += coupling[n];
+                    }
+                } else {
+                    V_hash[det] = coupling;
+                }
+            }
+        }
+    } // Close threads
+
+    Timer convert;
+
+    size_t max = V_hash.size();
+
+    F_space.resize(max);
+
+    #pragma omp parallel
+    {
+        int tid = omp_get_thread_num();
+        int ntd = omp_get_num_threads();
+    
+        size_t N = 0;
+        for( const auto& detpair : V_hash ){
+            if( (N%ntd) == tid ){
+                double EI = fci_ints_->energy(detpair.first);
+                std::vector<double> criteria(nroot, 0.0);
+                for( int n = 0; n < nroot; ++n ){
+                    double V = detpair.second[n];
+                    double delta = EI - evals->get(n);
+                    double criterion = 0.5 * (delta - sqrt(delta*delta + V*V*4.0));
+                    criteria[n] = std::fabs(criterion);
+                }
+                double value = average_q_values( nroot, criteria );
+
+                F_space[N] = std::make_pair( value, detpair.first );
+            }
+            N++;
+        }
+    }   
+    outfile->Printf("\n  Time spent building sorting list: %1.6f", convert.get());
+    outfile->Printf("\n  Size of F space: %zu", F_space.size());
+
+}
+
+void AdaptiveCI::get_excited_determinants_restrict(SharedMatrix evecs, SharedVector evals,DeterminantHashVec& P_space,
+                                                    std::vector<std::pair<double,Determinant>>& F_space)
+{
+    size_t max_P = P_space.size();
+    const det_hashvec& P_dets = P_space.wfn_hash();
+    int nroot = 1;
+    det_hash<std::vector<double>> V_hash; 
+// Loop over reference determinants
+#pragma omp parallel
+    {
+        int num_thread = omp_get_num_threads();
+        int tid = omp_get_thread_num();
+        size_t bin_size = max_P / num_thread;
+        bin_size += (tid < (max_P % num_thread)) ? 1 : 0;
+        size_t start_idx =
+            (tid < (max_P % num_thread))
+                ? tid * bin_size
+                : (max_P % num_thread) * (bin_size + 1) + (tid - (max_P % num_thread)) * bin_size;
+        size_t end_idx = start_idx + bin_size;
+
+        if (omp_get_thread_num() == 0 and !quiet_mode_) {
+            outfile->Printf("\n  Using %d threads.", num_thread);
+        }
+        // This will store the excited determinant info for each thread
+        std::vector<std::pair<Determinant, std::vector<double>>>
+            thread_ex_dets; //( noalpha * nvalpha  );
+
+        for (size_t P = start_idx; P < end_idx; ++P) {
+            const Determinant& det(P_dets[P]);
+            double evecs_P_row_norm = evecs->get_row(0, P)->norm();
+
+            std::vector<int> aocc = det.get_alfa_occ(nact_); // TODO check size
+            std::vector<int> bocc = det.get_beta_occ(nact_); // TODO check size
+            std::vector<int> avir = det.get_alfa_vir(nact_); // TODO check size
+            std::vector<int> bvir = det.get_beta_vir(nact_); // TODO check size
+
+            int noalpha = aocc.size();
+            int nobeta = bocc.size();
+            int nvalpha = avir.size();
+            int nvbeta = bvir.size();
+            Determinant new_det(det);
+
+            // Generate alpha excitations
+            for (int i = 0; i < noalpha; ++i) {
+                int ii = aocc[i];
+                for (int a = 0; a < nvalpha; ++a) {
+                    int aa = avir[a];
+                    if (((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) and
+                        ((aa != hole_) or (!det.get_beta_bit(aa)))) {
+                        double HIJ = fci_ints_->slater_rules_single_alpha(det, ii, aa);
+                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+                            //      if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+                            new_det = det;
+                            new_det.set_alfa_bit(ii, false);
+                            new_det.set_alfa_bit(aa, true);
+                            if (!(P_space.has_det(new_det))) {
+                                std::vector<double> coupling(nroot, 0.0);
+                                for (int n = 0; n < nroot; ++n) {
+                                    coupling[n] += HIJ * evecs->get(P, n);
+                                }
+                                // thread_ex_dets[i * noalpha + a] =
+                                // std::make_pair(new_det,coupling);
+                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+                            }
+                        }
+                    }
+                }
+            }
+            // Generate beta excitations
+            for (int i = 0; i < nobeta; ++i) {
+                int ii = bocc[i];
+                for (int a = 0; a < nvbeta; ++a) {
+                    int aa = bvir[a];
+                    if (((mo_symmetry_[ii] ^ mo_symmetry_[aa]) == 0) and
+                        ((aa != hole_) or (!det.get_alfa_bit(aa)))) {
+                        double HIJ = fci_ints_->slater_rules_single_beta(det, ii, aa);
+                        if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+                            // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+                            new_det = det;
+                            new_det.set_beta_bit(ii, false);
+                            new_det.set_beta_bit(aa, true);
+                            if (!(P_space.has_det(new_det))) {
+                                std::vector<double> coupling(nroot, 0.0);
+                                for (int n = 0; n < nroot; ++n) {
+                                    coupling[n] += HIJ * evecs->get(P, n);
+                                }
+                                // thread_ex_dets[i * nobeta + a] =
+                                // std::make_pair(new_det,coupling);
+                                thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Generate aa excitations
+            for (int i = 0; i < noalpha; ++i) {
+                int ii = aocc[i];
+                for (int j = i + 1; j < noalpha; ++j) {
+                    int jj = aocc[j];
+                    for (int a = 0; a < nvalpha; ++a) {
+                        int aa = avir[a];
+                        for (int b = a + 1; b < nvalpha; ++b) {
+                            int bb = avir[b];
+                            if (((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
+                                  mo_symmetry_[bb]) == 0) and
+                                (aa != hole_ and bb != hole_)) {
+                                double HIJ = fci_ints_->tei_aa(ii, jj, aa, bb);
+                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+                                    new_det = det;
+                                    HIJ *= new_det.double_excitation_aa(ii, jj, aa, bb);
+                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+
+                                    if (!(P_space.has_det(new_det))) {
+                                        std::vector<double> coupling(nroot, 0.0);
+                                        for (int n = 0; n < nroot; ++n) {
+                                            coupling[n] += HIJ * evecs->get(P, n);
+                                        }
+                                        // thread_ex_dets[i *
+                                        // noalpha*noalpha*nvalpha +
+                                        // j*nvalpha*noalpha +  a*nvalpha + b ]
+                                        // = std::make_pair(new_det,coupling);
+                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Generate ab excitations
+            for (int i = 0; i < noalpha; ++i) {
+                int ii = aocc[i];
+                for (int j = 0; j < nobeta; ++j) {
+                    int jj = bocc[j];
+                    for (int a = 0; a < nvalpha; ++a) {
+                        int aa = avir[a];
+                        for (int b = 0; b < nvbeta; ++b) {
+                            int bb = bvir[b];
+                            if (((mo_symmetry_[ii] ^ mo_symmetry_[jj] ^ mo_symmetry_[aa] ^
+                                  mo_symmetry_[bb]) == 0) and
+                                (aa != hole_ and bb != hole_)) {
+                                double HIJ = fci_ints_->tei_ab(ii, jj, aa, bb);
+                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+                                    new_det = det;
+                                    HIJ *= new_det.double_excitation_ab(ii, jj, aa, bb);
+                                    // if( std::abs(HIJ * evecs->get(0, P)) > screen_thresh_ ){
+
+                                    if (!(P_space.has_det(new_det))) {
+                                        std::vector<double> coupling(nroot, 0.0);
+                                        for (int n = 0; n < nroot; ++n) {
+                                            coupling[n] += HIJ * evecs->get(P, n);
+                                        }
+                                        // thread_ex_dets[i * nobeta * nvalpha
+                                        // *nvbeta + j * bvalpha * nvbeta + a *
+                                        // nvalpha]
+                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Generate bb excitations
+            for (int i = 0; i < nobeta; ++i) {
+                int ii = bocc[i];
+                for (int j = i + 1; j < nobeta; ++j) {
+                    int jj = bocc[j];
+                    for (int a = 0; a < nvbeta; ++a) {
+                        int aa = bvir[a];
+                        for (int b = a + 1; b < nvbeta; ++b) {
+                            int bb = bvir[b];
+                            if (((mo_symmetry_[ii] ^
+                                  (mo_symmetry_[jj] ^ (mo_symmetry_[aa] ^ mo_symmetry_[bb]))) ==
+                                 0) and
+                                (aa != hole_ and bb != hole_)) {
+                                double HIJ = fci_ints_->tei_bb(ii, jj, aa, bb);
+                                if ((std::fabs(HIJ) * evecs_P_row_norm >= screen_thresh_)) {
+                                    // if( std::abs(HIJ * evecs->get(0, P)) >= screen_thresh_ ){
+                                    new_det = det;
+                                    HIJ *= new_det.double_excitation_bb(ii, jj, aa, bb);
+
+                                    if (!(P_space.has_det(new_det))) {
+                                        std::vector<double> coupling(nroot, 0.0);
+                                        for (int n = 0; n < nroot; ++n) {
+                                            coupling[n] += HIJ * evecs->get(P, n);
+                                        }
+                                        thread_ex_dets.push_back(std::make_pair(new_det, coupling));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+#pragma omp critical
+        {
+            for (size_t I = 0, maxI = thread_ex_dets.size(); I < maxI; ++I) {
+                std::vector<double>& coupling = thread_ex_dets[I].second;
+                Determinant& det = thread_ex_dets[I].first;
+                if (V_hash.count(det) != 0) {
+                    for (int n = 0; n < nroot; ++n) {
+                        V_hash[det][n] += coupling[n];
+                    }
+                } else {
+                    V_hash[det] = coupling;
+                }
+            }
+        }
+    } // Close threads
+}
 
 // New threading strategy
 double

--- a/src/fci/fci_integrals.h
+++ b/src/fci/fci_integrals.h
@@ -31,7 +31,6 @@
 
 #include "../integrals/integrals.h"
 #include "../sparse_ci/determinant.h"
-#include "../sparse_ci/ui64_determinant.h"
 #include "string_lists.h"
 
 namespace psi {
@@ -73,11 +72,7 @@ class FCIIntegrals {
     //    Determinant determinant();
 
     /// Compute a determinant's energy
-    double energy(Determinant& det);
     double energy(const Determinant& det) const;
-
-    /// Using bit operations
-    double energy_bit(const Determinant& det) const;
 
     /// Compute the matrix element of the Hamiltonian between this determinant
     /// and a given one

--- a/src/fci/fci_solver.cc
+++ b/src/fci/fci_solver.cc
@@ -301,8 +301,8 @@ double FCISolver::compute_energy() {
                 if (ci_abs < 0.1)
                     continue;
 
-                std::bitset<128> Ia_v = lists_->alfa_str(h, add_Ia);
-                std::bitset<128> Ib_v = lists_->beta_str(h ^ symmetry_, add_Ib);
+                std::bitset<Determinant::num_str_bits> Ia_v = lists_->alfa_str(h, add_Ia);
+                std::bitset<Determinant::num_str_bits> Ib_v = lists_->beta_str(h ^ symmetry_, add_Ib);
 
                 outfile->Printf("\n    ");
                 size_t offset = 0;
@@ -411,8 +411,8 @@ FCISolver::initial_guess(FCIWfn& diag, size_t n, size_t multiplicity,
         double e;
         size_t h, add_Ia, add_Ib;
         std::tie(e, h, add_Ia, add_Ib) = det;
-        std::bitset<128> Ia_v = lists_->alfa_str(h, add_Ia);
-        std::bitset<128> Ib_v = lists_->beta_str(h ^ symmetry_, add_Ib);
+        std::bitset<Determinant::num_str_bits> Ia_v = lists_->alfa_str(h, add_Ia);
+        std::bitset<Determinant::num_str_bits> Ib_v = lists_->beta_str(h ^ symmetry_, add_Ib);
 
         std::vector<bool> Ia(nact, false);
         std::vector<bool> Ib(nact, false);

--- a/src/fci/string_lists.cc
+++ b/src/fci/string_lists.cc
@@ -218,7 +218,7 @@ void StringLists::make_pair_list(NNList& list) {
 
 void StringLists::make_strings(GraphPtr graph, StringList& list) {
     for (int h = 0; h < nirrep_; ++h) {
-        list.push_back(std::vector<std::bitset<128>>(graph->strpi(h)));
+        list.push_back(std::vector<std::bitset<Determinant::num_str_bits>>(graph->strpi(h)));
     }
 
     int n = graph->nbits();
@@ -226,7 +226,7 @@ void StringLists::make_strings(GraphPtr graph, StringList& list) {
 
     if ((k >= 0) and (k <= n)) { // check that (n > 0) makes sense.
         bool* I = new bool[n];
-        std::bitset<128> I_bs(n);
+        std::bitset<Determinant::num_str_bits> I_bs(n);
 
         // Generate the strings 1111100000
         //                      { k }{n-k}

--- a/src/fci/string_lists.h
+++ b/src/fci/string_lists.h
@@ -87,7 +87,7 @@ struct H3StringSubstitution {
 };
 
 typedef std::shared_ptr<BinaryGraph> GraphPtr;
-typedef std::vector<std::vector<std::bitset<128>>> StringList;
+typedef std::vector<std::vector<std::bitset<Determinant::num_str_bits>>> StringList;
 typedef std::map<std::tuple<size_t, size_t, int>, std::vector<StringSubstitution>> VOList;
 typedef std::map<std::tuple<size_t, size_t, size_t, size_t, int>, std::vector<StringSubstitution>>
     VOVOList;
@@ -143,8 +143,8 @@ class StringLists {
     GraphPtr alfa_graph_3h() { return alfa_graph_3h_; }
     GraphPtr beta_graph_3h() { return beta_graph_3h_; }
 
-    std::bitset<128> alfa_str(size_t h, size_t I) const { return alfa_list_[h][I]; }
-    std::bitset<128> beta_str(size_t h, size_t I) const { return beta_list_[h][I]; }
+    std::bitset<Determinant::num_str_bits> alfa_str(size_t h, size_t I) const { return alfa_list_[h][I]; }
+    std::bitset<Determinant::num_str_bits> beta_str(size_t h, size_t I) const { return beta_list_[h][I]; }
 
     std::vector<StringSubstitution>& get_alfa_vo_list(size_t p, size_t q, int h);
     std::vector<StringSubstitution>& get_beta_vo_list(size_t p, size_t q, int h);

--- a/src/main.cc
+++ b/src/main.cc
@@ -114,6 +114,14 @@ extern "C" PSI_API SharedWavefunction forte(SharedWavefunction ref_wfn, Options&
         exit(1);
     }
 
+    if( ( (options.get_str("DIAG_ALGORITHM") == "DYNAMIC") or (options.get_bool("ACI_DIRECT_RDMS") == true) ) 
+        and ( mo_space_info->size("ACTIVE") > 64 ) ) {
+    
+        outfile->Printf("\n  FATAL:  Dynamic diagonalization or dynamic RDM builds cannot be used for active spaces larger than 64 orbitals!");  
+
+        exit(1);
+    }
+
     // Make a subspace object
     SharedMatrix Ps = make_aosubspace_projector(ref_wfn, options);
 

--- a/src/sparse_ci/sigma_vector.h
+++ b/src/sparse_ci/sigma_vector.h
@@ -34,7 +34,7 @@
 #include "../determinant_hashvector.h"
 #include "../fci/fci_integrals.h"
 #include "../operator.h"
-#include "stl_bitset_determinant.h"
+#include "determinant.h"
 
 #ifdef HAVE_MPI
 #include <mpi.h>

--- a/src/sparse_ci/sorted_string_list.h
+++ b/src/sparse_ci/sorted_string_list.h
@@ -31,10 +31,10 @@
 #define _sorted_string_list_h_
 
 #include "stl_bitset_string.h"
-#include "stl_bitset_determinant.h"
-#include "ui64_determinant.h"
+#include "determinant.h"
 #include "../determinant_hashvector.h"
 #include "../fci/fci_integrals.h"
+#include "../sparse_ci/ui64_determinant.h"
 
 namespace psi {
 namespace forte {

--- a/src/sparse_ci/sparse_ci_solver.h
+++ b/src/sparse_ci/sparse_ci_solver.h
@@ -34,7 +34,7 @@
 #include "../operator.h"
 #include "../helpers.h"
 
-#include "stl_bitset_determinant.h"
+#include "determinant.h"
 #include "sigma_vector.h"
 
 #ifdef HAVE_MPI

--- a/src/sparse_ci/stl_bitset_determinant.h
+++ b/src/sparse_ci/stl_bitset_determinant.h
@@ -29,6 +29,10 @@
 #ifndef _stl_determinant_h_
 #define _stl_determinant_h_
 
+#ifndef MAX_DET_ORB
+#define MAX_DET_ORB 128
+#endif
+
 #include <bitset>
 #include <unordered_map>
 #include <algorithm>
@@ -57,7 +61,7 @@ namespace forte {
 class STLBitsetDeterminant {
   public:
     /// The number of bits used to represent a string (half a determinant)
-    static constexpr int num_str_bits = 128;
+    static constexpr int num_str_bits = MAX_DET_ORB;
     /// The number of bits used to represent a determinant
     static constexpr int num_det_bits = 2 * num_str_bits;
 

--- a/src/sparse_ci/stl_bitset_string.cc
+++ b/src/sparse_ci/stl_bitset_string.cc
@@ -59,7 +59,7 @@ STLBitsetString::STLBitsetString(const std::vector<bool>& occupation) {
     }
 }
 
-STLBitsetString::STLBitsetString(const std::bitset<128>& bits) { bits_ = bits; }
+STLBitsetString::STLBitsetString(const bit_t& bits) { bits_ = bits; }
 
 bool STLBitsetString::operator==(const STLBitsetString& lhs) const { return (bits_ == lhs.bits_); }
 
@@ -78,7 +78,7 @@ STLBitsetString STLBitsetString::operator^(const STLBitsetString& lhs) const {
     return ndet;
 }
 
-const std::bitset<128>& STLBitsetString::bits() const { return bits_; }
+const STLBitsetString::bit_t& STLBitsetString::bits() const { return bits_; }
 
 bool STLBitsetString::get_bit(int n) const { return bits_[n]; }
 

--- a/src/sparse_ci/stl_bitset_string.h
+++ b/src/sparse_ci/stl_bitset_string.h
@@ -34,6 +34,7 @@
 
 #include "../integrals/integrals.h"
 #include "../fci/fci_integrals.h"
+#include "../sparse_ci/determinant.h"
 
 namespace psi {
 namespace forte {
@@ -54,7 +55,7 @@ namespace forte {
  */
 class STLBitsetString {
   public:
-    using bit_t = std::bitset<128>;
+    using bit_t = std::bitset<Determinant::num_str_bits>;
 
     // Class Constructor and Destructor
     /// Construct an empty occupation string
@@ -64,7 +65,7 @@ class STLBitsetString {
     explicit STLBitsetString(const std::vector<int>& occupation);
     explicit STLBitsetString(const std::vector<bool>& occupation);
     /// Construnct a determinant from a bitset object
-    explicit STLBitsetString(const std::bitset<128>& bits);
+    explicit STLBitsetString(const bit_t& bits);
 
     /// Equal operator
     bool operator==(const STLBitsetString& lhs) const;
@@ -77,7 +78,7 @@ class STLBitsetString {
     void set_nmo(int nmo);
 
     /// Get a pointer to the alpha bits
-    const std::bitset<128>& bits() const;
+    const bit_t& bits() const;
 
     /// Return the value of a bit
     bool get_bit(int n) const;

--- a/src/sparse_ci/ui64_determinant.cc
+++ b/src/sparse_ci/ui64_determinant.cc
@@ -31,7 +31,7 @@
 #include <nmmintrin.h>
 #endif
 
-#include "stl_bitset_determinant.h"
+#include <string>
 #include "ui64_determinant.h"
 
 namespace psi {

--- a/src/sparse_ci/ui64_determinant.h
+++ b/src/sparse_ci/ui64_determinant.h
@@ -33,7 +33,6 @@
 #include <cstdint>
 #include <memory>
 #include <vector>
-//#include <bitset>
 
 #include "determinant_common.h"
 

--- a/tests/large_det/aci-1/input.dat
+++ b/tests/large_det/aci-1/input.dat
@@ -1,0 +1,48 @@
+#! Generated using commit GITCOMMIT 
+# Basic ACI calculation with energy threshold selection
+
+import forte
+
+refscf = -14.8435208330370827 #TEST
+refaci = -14.880521233114 #TEST
+refacipt2 = -14.880583937553 #TEST
+
+molecule li2{
+   Li
+   Li 1 2.0000
+}
+
+set {
+  basis cc-pcvtz
+  e_convergence 10
+  d_convergence 10
+  r_convergence 10
+}
+
+set scf {
+  scf_type pk
+  reference rhf
+  docc = [2,0,0,0,0,1,0,0]
+}
+
+set forte {
+  job_type = aci
+  frozen_docc [1,0,0,0,0,1,0,0]
+  ACI_SELECT_TYPE aimed_energy
+  diag_algorithm davidsonliulist
+  sigma 0.0015
+  gamma 0.0015
+  nroot 1
+  charge 0
+  aci_enforce_spin_complete true
+}
+
+E, wfn = energy('scf', return_wfn=True)
+
+compare_values(refscf, get_variable("CURRENT ENERGY"),9,"SCF energy")
+
+energy('forte', ref_wfn=wfn)
+
+compare_values(refaci, get_variable("ACI ENERGY"),9,"ACI energy")
+compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),9,"ACI+PT2 energy")
+

--- a/tests/large_det/aci-1/output.ref
+++ b/tests/large_det/aci-1/output.ref
@@ -1,0 +1,2270 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.3a1.dev284 
+
+                         Git: Rev {master} 17a6314 dirty
+
+
+    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
+    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
+    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
+    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
+    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
+    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
+    (doi: 10.1021/acs.jctc.7b00174)
+
+
+                         Additional Contributions by
+    P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, and R. A. Shaw
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Monday, 10 September 2018 04:52PM
+
+    Process ID: 86998
+    Host:       tianyuans-air.wireless.emory.edu
+    PSIDATADIR: /Users/tianyuanzhang/Documents/Source/psi4_2018/psi4-bin-clang-debug/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! Generated using commit GITCOMMIT 
+# Basic ACI calculation with energy threshold selection
+
+import forte
+
+refscf = -14.8435208330370827 #TEST
+refaci = -14.880521233114 #TEST
+refacipt2 = -14.880583937553 #TEST
+
+molecule li2{
+   Li
+   Li 1 2.0000
+}
+
+set {
+  basis cc-pcvtz
+  e_convergence 10
+  d_convergence 10
+  r_convergence 10
+}
+
+set scf {
+  scf_type pk
+  reference rhf
+  docc = [2,0,0,0,0,1,0,0]
+}
+
+set forte {
+  job_type = aci
+  frozen_docc [1,0,0,0,0,1,0,0]
+  ACI_SELECT_TYPE aimed_energy
+  diag_algorithm davidsonliulist
+  sigma 0.0015
+  gamma 0.0015
+  nroot 1
+  charge 0
+  aci_enforce_spin_complete true
+}
+
+E, wfn = energy('scf', return_wfn=True)
+
+compare_values(refscf, get_variable("CURRENT ENERGY"),9,"SCF energy")
+
+energy('forte', ref_wfn=wfn)
+
+compare_values(refaci, get_variable("ACI ENERGY"),9,"ACI energy")
+compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),9,"ACI+PT2 energy")
+
+--------------------------------------------------------------------------
+
+*** tstart() called on tianyuans-air.wireless.emory.edu
+*** at Mon Sep 10 16:52:03 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PCVTZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry LI         line    75 file /Users/tianyuanzhang/Documents/Source/psi4_2018/psi4-bin-clang-debug/share/psi4/basis/cc-pcvtz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         LI           0.000000000000     0.000000000000    -1.000000000000     7.016004548000
+         LI           0.000000000000     0.000000000000     1.000000000000     7.016004548000
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      1.20137  C =      1.20137 [cm^-1]
+  Rotational constants: A = ************  B =  36016.15432  C =  36016.15432 [MHz]
+  Nuclear repulsion =    2.381297438654999
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 6
+  Nalpha       = 3
+  Nbeta        = 3
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PCVTZ
+    Blend: CC-PCVTZ
+    Number of shells: 30
+    Number of basis function: 86
+    Number of Cartesian functions: 98
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: (CC-PCVTZ AUX)
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry LI         line    59 file /Users/tianyuanzhang/Documents/Source/psi4_2018/psi4-bin-clang-debug/share/psi4/basis/def2-qzvpp-jkfit.gbs 
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag        19      19       2       2       2       0
+     B1g        4       4       0       0       0       0
+     B2g       10      10       0       0       0       0
+     B3g       10      10       0       0       0       0
+     Au         4       4       0       0       0       0
+     B1u       19      19       1       1       1       0
+     B2u       10      10       0       0       0       0
+     B3u       10      10       0       0       0       0
+   -------------------------------------------------------
+    Total      86      86       3       3       3       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              30
+      Number of primitives:             78
+      Number of atomic orbitals:        98
+      Number of basis functions:        86
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 13998822 doubles for integral storage.
+  We computed 106428 shell quartets total.
+  Whereas there are 108345 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 8.5811173799E-06.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF.
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter   0:   -14.84696231171916   -1.48470e+01   8.92224e-03 
+   @DF-RHF iter   1:   -14.84151570344062    5.44661e-03   8.75079e-04 
+   @DF-RHF iter   2:   -14.84313792099090   -1.62222e-03   3.70417e-04 DIIS
+   @DF-RHF iter   3:   -14.84351195618754   -3.74035e-04   4.50469e-05 DIIS
+   @DF-RHF iter   4:   -14.84352024267411   -8.28649e-06   9.71232e-06 DIIS
+   @DF-RHF iter   5:   -14.84352082265731   -5.79983e-07   1.26186e-06 DIIS
+   @DF-RHF iter   6:   -14.84352083297177   -1.03145e-08   1.20564e-07 DIIS
+   @DF-RHF iter   7:   -14.84352083303573   -6.39560e-11   1.42314e-08 DIIS
+   @DF-RHF iter   8:   -14.84352083303704   -1.30917e-12   2.87005e-09 DIIS
+   @DF-RHF iter   9:   -14.84352083303712   -8.34888e-14   2.86400e-10 DIIS
+   @DF-RHF iter  10:   -14.84352083303708    3.90799e-14   2.52002e-11 DIIS
+  Energy converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag    -2.463591     1B1u   -2.458417     2Ag    -0.194917  
+
+    Virtual:                                                              
+
+       2B1u    0.011590     1B3u    0.022925     1B2u    0.022925  
+       3Ag     0.041409     1B2g    0.057488     1B3g    0.057488  
+       3B1u    0.064743     4Ag     0.101756     2B3u    0.104596  
+       2B2u    0.104596     5Ag     0.136800     4B1u    0.162161  
+       2B2g    0.167618     2B3g    0.167618     1B1g    0.199834  
+       6Ag     0.199834     5B1u    0.251532     3B3u    0.256653  
+       3B2u    0.256653     6B1u    0.268793     1Au     0.268793  
+       7Ag     0.304748     3B2g    0.327326     3B3g    0.327326  
+       7B1u    0.390942     8Ag     0.415139     4B3u    0.422181  
+       4B2u    0.422181     4B2g    0.438696     4B3g    0.438696  
+       5B3u    0.505942     5B2u    0.505942     9Ag     0.568912  
+       2B1g    0.578159    10Ag     0.578159     5B2g    0.615789  
+       5B3g    0.615789     8B1u    0.642512     9B1u    0.672111  
+       2Au     0.672111     6B2u    0.692374     6B3u    0.692374  
+      11Ag     0.694293     3B1g    0.694293    10B1u    0.756796  
+       6B2g    0.779554     6B3g    0.779554     7B2u    0.804739  
+       7B3u    0.804739    12Ag     0.808064     3Au     0.866936  
+      11B1u    0.866936     7B2g    1.039735     7B3g    1.039735  
+      12B1u    1.045545    13Ag     1.450001    13B1u    1.471275  
+       8B2u    3.465489     8B3u    3.465489    14Ag     3.553119  
+       8B2g    3.852510     8B3g    3.852510    14B1u    3.870679  
+      15Ag     4.000247    15B1u    4.544765    16B1u   14.864988  
+      16Ag    14.871421     4B1g   14.871421     9B3u   14.876067  
+       9B2u   14.876067    17B1u   14.877283     4Au    14.877283  
+       9B2g   14.881108     9B3g   14.881108    17Ag    14.896458  
+      18B1u   16.177676    18Ag    16.236068    10B3u   18.268991  
+      10B2u   18.268991    19Ag    18.331682    10B2g   18.541113  
+      10B3g   18.541113    19B1u   18.965867  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     2,    0,    0,    0,    0,    1,    0,    0 ]
+
+  @DF-RHF Final Energy:   -14.84352083303708
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              2.3812974386549994
+    One-Electron Energy =                 -24.2157861918057620
+    Two-Electron Energy =                   6.9909679201136781
+    Total Energy =                        -14.8435208330370827
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
+
+
+*** tstop() called on tianyuans-air.wireless.emory.edu at Mon Sep 10 16:52:08 2018
+Module time:
+	user time   =       4.76 seconds =       0.08 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+Total time:
+	user time   =       4.76 seconds =       0.08 minutes
+	system time =       0.13 seconds =       0.00 minutes
+	total time  =          5 seconds =       0.08 minutes
+	SCF energy........................................................PASSED
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: MINAO_BASIS
+    atoms 1-2 entry LI         line    31 file /Users/tianyuanzhang/Documents/Source/psi4_2018/psi4-bin-clang-debug/share/psi4/basis/sto-3g.gbs 
+
+
+Reading options from the FORTE block
+Calling plugin forte.so.
+
+
+
+  Forte
+  ----------------------------------------------------------------------------
+  A suite of quantum chemistry methods for strongly correlated electrons
+
+    git branch: travis_det_size - git commit: 005f93c0
+
+  Developed by:
+    Francesco A. Evangelista, Chenyang Li, Kevin P. Hannon,
+    Jeffrey B. Schriber, Tianyuan Zhang, Chenxi Cai
+  ----------------------------------------------------------------------------
+
+  Size of Determinant class: 32
+
+  ==> MO Space Information <==
+
+  Read options for space FROZEN_DOCC
+  -------------------------------------------------------------------------
+                       Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u   Sum
+  -------------------------------------------------------------------------
+    FROZEN_DOCC         1     0     0     0     0     1     0     0     2
+    RESTRICTED_DOCC     0     0     0     0     0     0     0     0     0
+    ACTIVE             18     4    10    10     4    18    10    10    84
+    RESTRICTED_UOCC     0     0     0     0     0     0     0     0     0
+    FROZEN_UOCC         0     0     0     0     0     0     0     0     0
+    Total              19     4    10    10     4    19    10    10    86
+  -------------------------------------------------------------------------
+
+  ==> Integral Transformation <==
+
+  Number of molecular orbitals:                    86
+  Number of correlated molecular orbitals:         84
+  Number of frozen occupied orbitals:               2
+  Number of frozen unoccupied orbitals:             0
+  Two-electron integral type:              Conventional
+
+
+  Overall Conventional Integrals timings
+
+	Presorting SO-basis two-electron integrals.
+	Sorting File: SO Ints (nn|nn) nbuckets = 1
+	Transforming the one-electron integrals and constructing Fock matrices
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+
+  Integral transformation done. 1.20153801 s
+  Reading the two-electron integrals from disk
+  Size of two-electron integrals:   1.222659 GB  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              30
+      Number of primitives:             78
+      Number of atomic orbitals:        98
+      Number of basis functions:        86
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 13998822 doubles for integral storage.
+  We computed 106428 shell quartets total.
+  Whereas there are 108345 unique shell quartets.
+
+
+  Frozen-core energy            -16.589219133178 a.u.
+  Timing for frozen one-body operator:                        3.956 s.
+  Resorting integrals after freezing core.
+  Timing for freezing core and virtual orbitals:             11.263 s.
+  Conventional integrals take 22.89763818 s
+  Number of active alpha electrons: 1
+  Number of active beta electrons: 1
+  Maximum reference space size: 1000
+  Number of reference determinants: 972
+  Reference generated from 82 MOs
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 2 frozen orbitals.
+  There are 84 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 0    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Sigma (Eh)                               1.50e-03
+    Gamma (Eh^(-1))                          1.50e-03
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                DAVIDSONLIULIST
+    Determinant selection criterion          Second-order Energy
+    Selection criterion                      Aimed selection
+    Excited Algorithm                        ROOT_ORTHOGONALIZE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+  -----------------------------------------------------------------
+  Using 1 threads
+  Computing wavefunction for root 0
+  Using streamlined Q-space builder.
+
+  ==> Cycle 0 <==
+
+  Initial P space dimension: 972
+  Spin-complete dimension of the P space: 972 determinants
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.002023 s
+        β          0.002070 s
+        αα         0.001197 s
+        ββ         0.001233 s
+        αβ         0.002321 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 59 solutions with 2S+1 = 1 *
+  Initial guess found 42 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.258542440219  -1.726e+01
+      2      -17.261616819213  -3.074e-03
+      3      -17.261848047823  -2.312e-04
+      4      -17.261872994917  -2.495e-05
+      5      -17.261878238158  -5.243e-06
+      6      -17.261878732589  -4.944e-07
+      7      -17.261878801217  -6.863e-08
+      8      -17.261878813060  -1.184e-08
+      9      -17.261878816161  -3.101e-09
+     10      -17.261878816659  -4.974e-10
+     11      -17.261878816753  -9.467e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  1.108814 s
+  Time spent diagonalizing H:   1.113476 s
+
+    P-space  CI Energy Root   0        = -14.880581378098 Eh =   0.0000 eV
+
+  Time spent forming F space:             0.857798
+  Time spent merging thread F spaces:             0.000614
+  Time spent preparing PQ_space: 0.000514
+  Dimension of the SD space: 108 determinants
+  Time spent building the external space (default): 0.859138 s
+
+  Time spent building sorting list: 0.000518
+  Time spent sorting: 0.000031
+  Time spent selecting: 0.000001
+  Dimension of the P + Q space: 972 determinants
+  Time spent screening the model space: 0.000605 s
+  Time spent building the model space: 0.859809
+  Spin-complete dimension of the PQ space: 972
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.004178 s
+        β          0.002551 s
+        αα         0.001192 s
+        ββ         0.001305 s
+        αβ         0.002412 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 59 solutions with 2S+1 = 1 *
+  Initial guess found 42 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.258542440219  -1.726e+01
+      2      -17.261616819213  -3.074e-03
+      3      -17.261848047823  -2.312e-04
+      4      -17.261872994917  -2.495e-05
+      5      -17.261878238158  -5.243e-06
+      6      -17.261878732589  -4.944e-07
+      7      -17.261878801217  -6.863e-08
+      8      -17.261878813060  -1.184e-08
+      9      -17.261878816161  -3.101e-09
+     10      -17.261878816659  -4.974e-10
+     11      -17.261878816753  -9.467e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  1.169321 s
+  Total time spent diagonalizing H:   1.174035 s
+
+    PQ-space CI Energy Root   0        = -14.880581378098 Eh =   0.0000 eV
+    PQ-space CI Energy + EPT2 Root   0 = -14.880583042415 Eh =   0.0000 eV
+
+
+  Most important contributions to root   0:
+    0  -0.937869 0.879598676         971 |200000000000000000000000000000000000000000000000000000000000000000000000000000000000>
+    1   0.123056 0.015142853         937 |000000000000000000000000000000000000000000000000000000000000000000000000002000000000>
+    2   0.123056 0.015142853         927 |000000000000000000000000000000000000000000000000000000000000000020000000000000000000>
+    3   0.101378 0.010277596         936 |00000000000000000000000000000000000000000000000000000000000000000000000000+-00000000>
+    4   0.101378 0.010277596         848 |00000000000000000000000000000000000000000000000000000000000000000000000000-+00000000>
+    5   0.101378 0.010277596         926 |0000000000000000000000000000000000000000000000000000000000000000+-000000000000000000>
+    6   0.101378 0.010277596         838 |0000000000000000000000000000000000000000000000000000000000000000-+000000000000000000>
+    7   0.084238 0.007096018         837 |000000000000000000000000000000000000000000000000000000000000000002000000000000000000>
+    8   0.084238 0.007096018         847 |000000000000000000000000000000000000000000000000000000000000000000000000000200000000>
+    9   0.045060 0.002030436         954 |000000000000000000000000000000000000000000000020000000000000000000000000000000000000>
+
+  Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
+  Cycle 0 took: 3.244357 s
+
+  ==> Cycle 1 <==
+
+  Initial P space dimension: 355
+  Spin-complete dimension of the P space: 355 determinants
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000798 s
+        β          0.000823 s
+        αα         0.000454 s
+        ββ         0.000455 s
+        αβ         0.000844 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 39 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259147294815  -1.726e+01
+      2      -17.261691963265  -2.545e-03
+      3      -17.261849560861  -1.576e-04
+      4      -17.261864431236  -1.487e-05
+      5      -17.261867680272  -3.249e-06
+      6      -17.261867947533  -2.673e-07
+      7      -17.261867980430  -3.290e-08
+      8      -17.261867986035  -5.605e-09
+      9      -17.261867987542  -1.506e-09
+     10      -17.261867987767  -2.257e-10
+     11      -17.261867987808  -4.091e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.350468 s
+  Time spent diagonalizing H:   0.352328 s
+
+    P-space  CI Energy Root   0        = -14.880570549153 Eh =   0.0000 eV
+
+  Time spent forming F space:             0.473371
+  Time spent merging thread F spaces:             0.000611
+  Time spent preparing PQ_space: 0.000223
+  Dimension of the SD space: 725 determinants
+  Time spent building the external space (default): 0.474419 s
+
+  Time spent building sorting list: 0.003340
+  Time spent sorting: 0.000141
+  Time spent selecting: 0.000005
+  Dimension of the P + Q space: 355 determinants
+  Time spent screening the model space: 0.003548 s
+  Time spent building the model space: 0.478106
+  Spin-complete dimension of the PQ space: 355
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.001525 s
+        β          0.000968 s
+        αα         0.000461 s
+        ββ         0.000455 s
+        αβ         0.000851 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 39 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259147294815  -1.726e+01
+      2      -17.261691963265  -2.545e-03
+      3      -17.261849560861  -1.576e-04
+      4      -17.261864431236  -1.487e-05
+      5      -17.261867680272  -3.249e-06
+      6      -17.261867947533  -2.673e-07
+      7      -17.261867980430  -3.290e-08
+      8      -17.261867986035  -5.605e-09
+      9      -17.261867987542  -1.506e-09
+     10      -17.261867987767  -2.257e-10
+     11      -17.261867987808  -4.091e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.457669 s
+  Total time spent diagonalizing H:   0.459628 s
+
+    PQ-space CI Energy Root   0        = -14.880570549153 Eh =   0.0000 eV
+    PQ-space CI Energy + EPT2 Root   0 = -14.880583628240 Eh =   0.0000 eV
+
+  Added 1 missing determinants in aimed selection.
+
+  Most important contributions to root   0:
+    0   0.937828 0.879520431         354 |200000000000000000000000000000000000000000000000000000000000000000000000000000000000>
+    1  -0.123092 0.015151658         353 |000000000000000000000000000000000000000000000000000000000000000000000000002000000000>
+    2  -0.123092 0.015151658         352 |000000000000000000000000000000000000000000000000000000000000000020000000000000000000>
+    3  -0.101415 0.010284961         351 |00000000000000000000000000000000000000000000000000000000000000000000000000+-00000000>
+    4  -0.101415 0.010284961         350 |00000000000000000000000000000000000000000000000000000000000000000000000000-+00000000>
+    5  -0.101415 0.010284961         349 |0000000000000000000000000000000000000000000000000000000000000000+-000000000000000000>
+    6  -0.101415 0.010284961         348 |0000000000000000000000000000000000000000000000000000000000000000-+000000000000000000>
+    7  -0.084280 0.007103143         347 |000000000000000000000000000000000000000000000000000000000000000002000000000000000000>
+    8  -0.084280 0.007103143         346 |000000000000000000000000000000000000000000000000000000000000000000000000000200000000>
+    9  -0.045085 0.002032689         345 |000000000000000000000000000000000000000000000020000000000000000000000000000000000000>
+
+  Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
+  Cycle 1 took: 1.319164 s
+
+  ==> Cycle 2 <==
+
+  Initial P space dimension: 333
+  Spin-complete dimension of the P space: 333 determinants
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.001280 s
+        β          0.001318 s
+        αα         0.000748 s
+        ββ         0.000722 s
+        αβ         0.001541 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 62 solutions with 2S+1 = 1 *
+  Initial guess found 39 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259236628439  -1.726e+01
+      2      -17.261701901056  -2.465e-03
+      3      -17.261846631816  -1.447e-04
+      4      -17.261860420882  -1.379e-05
+      5      -17.261863430315  -3.009e-06
+      6      -17.261863673462  -2.431e-07
+      7      -17.261863702474  -2.901e-08
+      8      -17.261863707325  -4.851e-09
+      9      -17.261863708583  -1.258e-09
+     10      -17.261863708762  -1.792e-10
+     11      -17.261863708794  -3.183e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.367752 s
+  Time spent diagonalizing H:   0.370430 s
+
+    P-space  CI Energy Root   0        = -14.880566270139 Eh =   0.0000 eV
+
+  Time spent forming F space:             0.447243
+  Time spent merging thread F spaces:             0.000732
+  Time spent preparing PQ_space: 0.000216
+  Dimension of the SD space: 747 determinants
+  Time spent building the external space (default): 0.448495 s
+
+  Time spent building sorting list: 0.003923
+  Time spent sorting: 0.000162
+  Time spent selecting: 0.000006
+  Dimension of the P + Q space: 333 determinants
+  Time spent screening the model space: 0.004193 s
+  Time spent building the model space: 0.452827
+  Spin-complete dimension of the PQ space: 333
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.001686 s
+        β          0.001892 s
+        αα         0.001129 s
+        ββ         0.000551 s
+        αβ         0.001071 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 62 solutions with 2S+1 = 1 *
+  Initial guess found 39 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259236628439  -1.726e+01
+      2      -17.261701901056  -2.465e-03
+      3      -17.261846631816  -1.447e-04
+      4      -17.261860420882  -1.379e-05
+      5      -17.261863430315  -3.009e-06
+      6      -17.261863673462  -2.431e-07
+      7      -17.261863702474  -2.901e-08
+      8      -17.261863707325  -4.851e-09
+      9      -17.261863708583  -1.258e-09
+     10      -17.261863708762  -1.792e-10
+     11      -17.261863708794  -3.183e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.346244 s
+  Total time spent diagonalizing H:   0.348225 s
+
+    PQ-space CI Energy Root   0        = -14.880566270139 Eh =   0.0000 eV
+    PQ-space CI Energy + EPT2 Root   0 = -14.880583773897 Eh =   0.0000 eV
+
+  Added 1 missing determinants in aimed selection.
+
+  Most important contributions to root   0:
+    0  -0.937799 0.879467613         331 |200000000000000000000000000000000000000000000000000000000000000000000000000000000000>
+    1   0.123122 0.015158939         330 |000000000000000000000000000000000000000000000000000000000000000000000000002000000000>
+    2   0.123122 0.015158939         329 |000000000000000000000000000000000000000000000000000000000000000020000000000000000000>
+    3   0.101442 0.010290523         328 |00000000000000000000000000000000000000000000000000000000000000000000000000+-00000000>
+    4   0.101442 0.010290523         327 |00000000000000000000000000000000000000000000000000000000000000000000000000-+00000000>
+    5   0.101442 0.010290523         326 |0000000000000000000000000000000000000000000000000000000000000000+-000000000000000000>
+    6   0.101442 0.010290523         325 |0000000000000000000000000000000000000000000000000000000000000000-+000000000000000000>
+    7   0.084306 0.007107566         324 |000000000000000000000000000000000000000000000000000000000000000002000000000000000000>
+    8   0.084306 0.007107566         323 |000000000000000000000000000000000000000000000000000000000000000000000000000200000000>
+    9   0.045103 0.002034255         322 |000000000000000000000000000000000000000000000020000000000000000000000000000000000000>
+
+  Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
+  Cycle 2 took: 1.203816 s
+
+  ==> Cycle 3 <==
+
+  Initial P space dimension: 318
+  Spin-complete dimension of the P space: 318 determinants
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000963 s
+        β          0.000735 s
+        αα         0.000408 s
+        ββ         0.000407 s
+        αβ         0.000767 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 62 solutions with 2S+1 = 1 *
+  Initial guess found 39 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259236628439  -1.726e+01
+      2      -17.261695576816  -2.459e-03
+      3      -17.261839032928  -1.435e-04
+      4      -17.261852775021  -1.374e-05
+      5      -17.261855771601  -2.997e-06
+      6      -17.261856013524  -2.419e-07
+      7      -17.261856042397  -2.887e-08
+      8      -17.261856047215  -4.818e-09
+      9      -17.261856048465  -1.250e-09
+     10      -17.261856048643  -1.778e-10
+     11      -17.261856048675  -3.160e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.400840 s
+  Time spent diagonalizing H:   0.402592 s
+
+    P-space  CI Energy Root   0        = -14.880558610020 Eh =   0.0000 eV
+
+  Time spent forming F space:             0.428815
+  Time spent merging thread F spaces:             0.000596
+  Time spent preparing PQ_space: 0.000201
+  Dimension of the SD space: 762 determinants
+  Time spent building the external space (default): 0.429823 s
+
+  Time spent building sorting list: 0.006208
+  Time spent sorting: 0.000147
+  Time spent selecting: 0.000006
+  Dimension of the P + Q space: 318 determinants
+  Time spent screening the model space: 0.006433 s
+  Time spent building the model space: 0.436378
+  Spin-complete dimension of the PQ space: 318
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000746 s
+        β          0.000734 s
+        αα         0.000410 s
+        ββ         0.000408 s
+        αβ         0.000773 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 62 solutions with 2S+1 = 1 *
+  Initial guess found 39 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259236628439  -1.726e+01
+      2      -17.261695576816  -2.459e-03
+      3      -17.261839032928  -1.435e-04
+      4      -17.261852775021  -1.374e-05
+      5      -17.261855771601  -2.997e-06
+      6      -17.261856013524  -2.419e-07
+      7      -17.261856042397  -2.887e-08
+      8      -17.261856047215  -4.818e-09
+      9      -17.261856048465  -1.250e-09
+     10      -17.261856048643  -1.778e-10
+     11      -17.261856048675  -3.160e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.330672 s
+  Total time spent diagonalizing H:   0.332471 s
+
+    PQ-space CI Energy Root   0        = -14.880558610020 Eh =   0.0000 eV
+    PQ-space CI Energy + EPT2 Root   0 = -14.880584026967 Eh =   0.0000 eV
+
+  Added 3 missing determinants in aimed selection.
+
+  Most important contributions to root   0:
+    0  -0.937801 0.879469803         316 |200000000000000000000000000000000000000000000000000000000000000000000000000000000000>
+    1   0.123122 0.015159037         315 |000000000000000000000000000000000000000000000000000000000000000000000000002000000000>
+    2   0.123122 0.015159037         314 |000000000000000000000000000000000000000000000000000000000000000020000000000000000000>
+    3   0.101439 0.010289785         313 |00000000000000000000000000000000000000000000000000000000000000000000000000+-00000000>
+    4   0.101439 0.010289785         312 |00000000000000000000000000000000000000000000000000000000000000000000000000-+00000000>
+    5   0.101439 0.010289785         311 |0000000000000000000000000000000000000000000000000000000000000000+-000000000000000000>
+    6   0.101439 0.010289785         310 |0000000000000000000000000000000000000000000000000000000000000000-+000000000000000000>
+    7   0.084298 0.007106189         309 |000000000000000000000000000000000000000000000000000000000000000002000000000000000000>
+    8   0.084298 0.007106189         308 |000000000000000000000000000000000000000000000000000000000000000000000000000200000000>
+    9   0.045119 0.002035680         307 |000000000000000000000000000000000000000000000020000000000000000000000000000000000000>
+
+  Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
+  Cycle 3 took: 1.191659 s
+
+  ==> Cycle 4 <==
+
+  Initial P space dimension: 309
+  Spin-complete dimension of the P space: 309 determinants
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.001176 s
+        β          0.000811 s
+        αα         0.000481 s
+        ββ         0.000426 s
+        αβ         0.000852 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 62 solutions with 2S+1 = 1 *
+  Initial guess found 39 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259236628439  -1.726e+01
+      2      -17.261691196259  -2.455e-03
+      3      -17.261834137631  -1.429e-04
+      4      -17.261847792857  -1.366e-05
+      5      -17.261850770067  -2.977e-06
+      6      -17.261851009681  -2.396e-07
+      7      -17.261851038171  -2.849e-08
+      8      -17.261851042910  -4.739e-09
+      9      -17.261851044134  -1.223e-09
+     10      -17.261851044307  -1.731e-10
+     11      -17.261851044338  -3.067e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.369659 s
+  Time spent diagonalizing H:   0.371962 s
+
+    P-space  CI Energy Root   0        = -14.880553605683 Eh =   0.0000 eV
+
+  Time spent forming F space:             0.426639
+  Time spent merging thread F spaces:             0.000594
+  Time spent preparing PQ_space: 0.000510
+  Dimension of the SD space: 771 determinants
+  Time spent building the external space (default): 0.428003 s
+
+  Time spent building sorting list: 0.005881
+  Time spent sorting: 0.000251
+  Time spent selecting: 0.000006
+  Dimension of the P + Q space: 309 determinants
+  Time spent screening the model space: 0.006289 s
+  Time spent building the model space: 0.434470
+  Spin-complete dimension of the PQ space: 309
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000700 s
+        β          0.000717 s
+        αα         0.000396 s
+        ββ         0.000396 s
+        αβ         0.000742 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 62 solutions with 2S+1 = 1 *
+  Initial guess found 39 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259236628439  -1.726e+01
+      2      -17.261691196259  -2.455e-03
+      3      -17.261834137631  -1.429e-04
+      4      -17.261847792857  -1.366e-05
+      5      -17.261850770067  -2.977e-06
+      6      -17.261851009681  -2.396e-07
+      7      -17.261851038171  -2.849e-08
+      8      -17.261851042910  -4.739e-09
+      9      -17.261851044134  -1.223e-09
+     10      -17.261851044307  -1.731e-10
+     11      -17.261851044338  -3.067e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.296470 s
+  Total time spent diagonalizing H:   0.298091 s
+
+    PQ-space CI Energy Root   0        = -14.880553605683 Eh =   0.0000 eV
+    PQ-space CI Energy + EPT2 Root   0 = -14.880584052021 Eh =   0.0000 eV
+
+
+  Most important contributions to root   0:
+    0  -0.937797 0.879462683         305 |200000000000000000000000000000000000000000000000000000000000000000000000000000000000>
+    1   0.123126 0.015160109         304 |000000000000000000000000000000000000000000000000000000000000000000000000002000000000>
+    2   0.123126 0.015160109         303 |000000000000000000000000000000000000000000000000000000000000000020000000000000000000>
+    3   0.101441 0.010290323         302 |00000000000000000000000000000000000000000000000000000000000000000000000000+-00000000>
+    4   0.101441 0.010290323         301 |00000000000000000000000000000000000000000000000000000000000000000000000000-+00000000>
+    5   0.101441 0.010290323         300 |0000000000000000000000000000000000000000000000000000000000000000+-000000000000000000>
+    6   0.101441 0.010290323         299 |0000000000000000000000000000000000000000000000000000000000000000-+000000000000000000>
+    7   0.084299 0.007106313         298 |000000000000000000000000000000000000000000000000000000000000000002000000000000000000>
+    8   0.084299 0.007106313         297 |000000000000000000000000000000000000000000000000000000000000000000000000000200000000>
+    9   0.045124 0.002036178         296 |000000000000000000000000000000000000000000000020000000000000000000000000000000000000>
+
+  Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
+  Cycle 4 took: 1.126066 s
+
+  ==> Cycle 5 <==
+
+  Initial P space dimension: 298
+  Spin-complete dimension of the P space: 298 determinants
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000938 s
+        β          0.000728 s
+        αα         0.000385 s
+        ββ         0.000382 s
+        αβ         0.000716 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261691753406  -2.408e-03
+      3      -17.261830062891  -1.383e-04
+      4      -17.261843571216  -1.351e-05
+      5      -17.261846534085  -2.963e-06
+      6      -17.261846784092  -2.500e-07
+      7      -17.261846815685  -3.159e-08
+      8      -17.261846821170  -5.486e-09
+      9      -17.261846822669  -1.499e-09
+     10      -17.261846822892  -2.234e-10
+     11      -17.261846822932  -3.952e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.299957 s
+  Time spent diagonalizing H:   0.301561 s
+
+    P-space  CI Energy Root   0        = -14.880549384277 Eh =   0.0000 eV
+
+  Time spent forming F space:             0.372853
+  Time spent merging thread F spaces:             0.000604
+  Time spent preparing PQ_space: 0.000199
+  Dimension of the SD space: 782 determinants
+  Time spent building the external space (default): 0.373868 s
+
+  Time spent building sorting list: 0.003633
+  Time spent sorting: 0.000153
+  Time spent selecting: 0.000006
+  Dimension of the P + Q space: 298 determinants
+  Time spent screening the model space: 0.003854 s
+  Time spent building the model space: 0.377846
+  Spin-complete dimension of the PQ space: 298
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000722 s
+        β          0.001062 s
+        αα         0.000414 s
+        ββ         0.000383 s
+        αβ         0.000714 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261691753406  -2.408e-03
+      3      -17.261830062891  -1.383e-04
+      4      -17.261843571216  -1.351e-05
+      5      -17.261846534085  -2.963e-06
+      6      -17.261846784092  -2.500e-07
+      7      -17.261846815685  -3.159e-08
+      8      -17.261846821170  -5.486e-09
+      9      -17.261846822669  -1.499e-09
+     10      -17.261846822892  -2.234e-10
+     11      -17.261846822932  -3.952e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.303819 s
+  Total time spent diagonalizing H:   0.305385 s
+
+    PQ-space CI Energy Root   0        = -14.880549384277 Eh =   0.0000 eV
+    PQ-space CI Energy + EPT2 Root   0 = -14.880583980179 Eh =   0.0000 eV
+
+  Added 1 missing determinants in aimed selection.
+
+  Most important contributions to root   0:
+    0   0.937778 0.879428011         297 |200000000000000000000000000000000000000000000000000000000000000000000000000000000000>
+    1  -0.123159 0.015168087         296 |000000000000000000000000000000000000000000000000000000000000000000000000002000000000>
+    2  -0.123159 0.015168087         295 |000000000000000000000000000000000000000000000000000000000000000020000000000000000000>
+    3  -0.101441 0.010290296         294 |00000000000000000000000000000000000000000000000000000000000000000000000000+-00000000>
+    4  -0.101441 0.010290296         293 |00000000000000000000000000000000000000000000000000000000000000000000000000-+00000000>
+    5  -0.101441 0.010290296         292 |0000000000000000000000000000000000000000000000000000000000000000+-000000000000000000>
+    6  -0.101441 0.010290296         291 |0000000000000000000000000000000000000000000000000000000000000000-+000000000000000000>
+    7  -0.084305 0.007107306         290 |000000000000000000000000000000000000000000000000000000000000000002000000000000000000>
+    8  -0.084305 0.007107306         289 |000000000000000000000000000000000000000000000000000000000000000000000000000200000000>
+    9  -0.045228 0.002045548         288 |000000000000000000000000000000000000000000000020000000000000000000000000000000000000>
+
+  Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
+  Cycle 5 took: 1.002855 s
+
+  ==> Cycle 6 <==
+
+  Initial P space dimension: 290
+  Spin-complete dimension of the P space: 290 determinants
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000661 s
+        β          0.000682 s
+        αα         0.000372 s
+        ββ         0.000373 s
+        αβ         0.000692 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261686376008  -2.403e-03
+      3      -17.261823925283  -1.375e-04
+      4      -17.261837387504  -1.346e-05
+      5      -17.261840342486  -2.955e-06
+      6      -17.261840591239  -2.488e-07
+      7      -17.261840622588  -3.135e-08
+      8      -17.261840628028  -5.440e-09
+      9      -17.261840629514  -1.486e-09
+     10      -17.261840629735  -2.210e-10
+     11      -17.261840629774  -3.904e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.318574 s
+  Time spent diagonalizing H:   0.320162 s
+
+    P-space  CI Energy Root   0        = -14.880543191119 Eh =   0.0000 eV
+
+  Time spent forming F space:             0.379541
+  Time spent merging thread F spaces:             0.001517
+  Time spent preparing PQ_space: 0.000223
+  Dimension of the SD space: 790 determinants
+  Time spent building the external space (default): 0.381608 s
+
+  Time spent building sorting list: 0.003677
+  Time spent sorting: 0.000169
+  Time spent selecting: 0.000006
+  Dimension of the P + Q space: 290 determinants
+  Time spent screening the model space: 0.003922 s
+  Time spent building the model space: 0.385665
+  Spin-complete dimension of the PQ space: 290
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000682 s
+        β          0.000682 s
+        αα         0.000374 s
+        ββ         0.000373 s
+        αβ         0.000694 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261686376008  -2.403e-03
+      3      -17.261823925283  -1.375e-04
+      4      -17.261837387504  -1.346e-05
+      5      -17.261840342486  -2.955e-06
+      6      -17.261840591239  -2.488e-07
+      7      -17.261840622588  -3.135e-08
+      8      -17.261840628028  -5.440e-09
+      9      -17.261840629514  -1.486e-09
+     10      -17.261840629735  -2.210e-10
+     11      -17.261840629774  -3.904e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.314997 s
+  Total time spent diagonalizing H:   0.316554 s
+
+    PQ-space CI Energy Root   0        = -14.880543191119 Eh =   0.0000 eV
+    PQ-space CI Energy + EPT2 Root   0 = -14.880583880330 Eh =   0.0000 eV
+
+  Added 2 missing determinants in aimed selection.
+
+  Most important contributions to root   0:
+    0   0.937774 0.879420732         288 |200000000000000000000000000000000000000000000000000000000000000000000000000000000000>
+    1  -0.123164 0.015169376         287 |000000000000000000000000000000000000000000000000000000000000000000000000002000000000>
+    2  -0.123164 0.015169376         286 |000000000000000000000000000000000000000000000000000000000000000020000000000000000000>
+    3  -0.101445 0.010291018         284 |00000000000000000000000000000000000000000000000000000000000000000000000000-+00000000>
+    4  -0.101445 0.010291018         285 |00000000000000000000000000000000000000000000000000000000000000000000000000+-00000000>
+    5  -0.101445 0.010291018         282 |0000000000000000000000000000000000000000000000000000000000000000-+000000000000000000>
+    6  -0.101445 0.010291018         283 |0000000000000000000000000000000000000000000000000000000000000000+-000000000000000000>
+    7  -0.084307 0.007107700         281 |000000000000000000000000000000000000000000000000000000000000000002000000000000000000>
+    8  -0.084307 0.007107700         280 |000000000000000000000000000000000000000000000000000000000000000000000000000200000000>
+    9  -0.045230 0.002045709         279 |000000000000000000000000000000000000000000000020000000000000000000000000000000000000>
+
+  Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
+  Cycle 6 took: 1.039846 s
+
+  ==> Cycle 7 <==
+
+  Initial P space dimension: 284
+  Spin-complete dimension of the P space: 284 determinants
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000702 s
+        β          0.000707 s
+        αα         0.000390 s
+        ββ         0.000389 s
+        αβ         0.000702 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261684124390  -2.400e-03
+      3      -17.261820639318  -1.365e-04
+      4      -17.261833824820  -1.319e-05
+      5      -17.261836726236  -2.901e-06
+      6      -17.261836969810  -2.436e-07
+      7      -17.261837000571  -3.076e-08
+      8      -17.261837005935  -5.364e-09
+      9      -17.261837007411  -1.476e-09
+     10      -17.261837007631  -2.197e-10
+     11      -17.261837007669  -3.838e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.320631 s
+  Time spent diagonalizing H:   0.322154 s
+
+    P-space  CI Energy Root   0        = -14.880539569014 Eh =   0.0000 eV
+
+  Time spent forming F space:             0.382154
+  Time spent merging thread F spaces:             0.001099
+  Time spent preparing PQ_space: 0.000435
+  Dimension of the SD space: 796 determinants
+  Time spent building the external space (default): 0.384123 s
+
+  Time spent building sorting list: 0.005327
+  Time spent sorting: 0.000160
+  Time spent selecting: 0.000006
+  Dimension of the P + Q space: 284 determinants
+  Time spent screening the model space: 0.005573 s
+  Time spent building the model space: 0.389837
+  Spin-complete dimension of the PQ space: 284
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000648 s
+        β          0.000665 s
+        αα         0.000368 s
+        ββ         0.000365 s
+        αβ         0.000679 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261684124390  -2.400e-03
+      3      -17.261820639318  -1.365e-04
+      4      -17.261833824820  -1.319e-05
+      5      -17.261836726236  -2.901e-06
+      6      -17.261836969810  -2.436e-07
+      7      -17.261837000571  -3.076e-08
+      8      -17.261837005935  -5.364e-09
+      9      -17.261837007411  -1.476e-09
+     10      -17.261837007631  -2.197e-10
+     11      -17.261837007669  -3.838e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.353738 s
+  Total time spent diagonalizing H:   0.355289 s
+
+    PQ-space CI Energy Root   0        = -14.880539569014 Eh =   0.0000 eV
+    PQ-space CI Energy + EPT2 Root   0 = -14.880583980109 Eh =   0.0000 eV
+
+  Added 3 missing determinants in aimed selection.
+
+  Most important contributions to root   0:
+    0   0.937756 0.879386238         281 |200000000000000000000000000000000000000000000000000000000000000000000000000000000000>
+    1  -0.123176 0.015172403         280 |000000000000000000000000000000000000000000000000000000000000000000000000002000000000>
+    2  -0.123176 0.015172403         279 |000000000000000000000000000000000000000000000000000000000000000020000000000000000000>
+    3  -0.101456 0.010293383         278 |00000000000000000000000000000000000000000000000000000000000000000000000000-+00000000>
+    4  -0.101456 0.010293383         277 |00000000000000000000000000000000000000000000000000000000000000000000000000+-00000000>
+    5  -0.101456 0.010293383         276 |0000000000000000000000000000000000000000000000000000000000000000-+000000000000000000>
+    6  -0.101456 0.010293383         275 |0000000000000000000000000000000000000000000000000000000000000000+-000000000000000000>
+    7  -0.084319 0.007109680         274 |000000000000000000000000000000000000000000000000000000000000000002000000000000000000>
+    8  -0.084319 0.007109680         273 |000000000000000000000000000000000000000000000000000000000000000000000000000200000000>
+    9  -0.045249 0.002047476         272 |000000000000000000000000000000000000000000000020000000000000000000000000000000000000>
+
+  Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
+  Cycle 7 took: 1.087529 s
+
+  ==> Cycle 8 <==
+
+  Initial P space dimension: 280
+  Spin-complete dimension of the P space: 280 determinants
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000728 s
+        β          0.000784 s
+        αα         0.000373 s
+        ββ         0.000360 s
+        αβ         0.000672 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261679611371  -2.396e-03
+      3      -17.261815803748  -1.362e-04
+      4      -17.261828888998  -1.309e-05
+      5      -17.261831772208  -2.883e-06
+      6      -17.261832013813  -2.416e-07
+      7      -17.261832044348  -3.053e-08
+      8      -17.261832049675  -5.327e-09
+      9      -17.261832051142  -1.467e-09
+     10      -17.261832051361  -2.185e-10
+     11      -17.261832051399  -3.814e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.403781 s
+  Time spent diagonalizing H:   0.405562 s
+
+    P-space  CI Energy Root   0        = -14.880534612744 Eh =   0.0000 eV
+
+  Time spent forming F space:             0.355736
+  Time spent merging thread F spaces:             0.000598
+  Time spent preparing PQ_space: 0.000192
+  Dimension of the SD space: 800 determinants
+  Time spent building the external space (default): 0.356745 s
+
+  Time spent building sorting list: 0.003786
+  Time spent sorting: 0.000162
+  Time spent selecting: 0.000006
+  Dimension of the P + Q space: 280 determinants
+  Time spent screening the model space: 0.004025 s
+  Time spent building the model space: 0.360896
+  Spin-complete dimension of the PQ space: 280
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000638 s
+        β          0.000651 s
+        αα         0.000360 s
+        ββ         0.000474 s
+        αβ         0.001521 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261679611371  -2.396e-03
+      3      -17.261815803748  -1.362e-04
+      4      -17.261828888998  -1.309e-05
+      5      -17.261831772208  -2.883e-06
+      6      -17.261832013813  -2.416e-07
+      7      -17.261832044348  -3.053e-08
+      8      -17.261832049675  -5.327e-09
+      9      -17.261832051142  -1.467e-09
+     10      -17.261832051361  -2.185e-10
+     11      -17.261832051399  -3.814e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.304113 s
+  Total time spent diagonalizing H:   0.305641 s
+
+    PQ-space CI Energy Root   0        = -14.880534612744 Eh =   0.0000 eV
+    PQ-space CI Energy + EPT2 Root   0 = -14.880583929490 Eh =   0.0000 eV
+
+
+  Most important contributions to root   0:
+    0   0.937749 0.879373667         276 |200000000000000000000000000000000000000000000000000000000000000000000000000000000000>
+    1  -0.123183 0.015173972         275 |000000000000000000000000000000000000000000000000000000000000000000000000002000000000>
+    2  -0.123183 0.015173972         274 |000000000000000000000000000000000000000000000000000000000000000020000000000000000000>
+    3  -0.101461 0.010294354         273 |00000000000000000000000000000000000000000000000000000000000000000000000000+-00000000>
+    4  -0.101461 0.010294354         272 |00000000000000000000000000000000000000000000000000000000000000000000000000-+00000000>
+    5  -0.101461 0.010294354         271 |0000000000000000000000000000000000000000000000000000000000000000+-000000000000000000>
+    6  -0.101461 0.010294354         270 |0000000000000000000000000000000000000000000000000000000000000000-+000000000000000000>
+    7  -0.084323 0.007110293         269 |000000000000000000000000000000000000000000000000000000000000000002000000000000000000>
+    8  -0.084323 0.007110293         268 |000000000000000000000000000000000000000000000000000000000000000000000000000200000000>
+    9  -0.045257 0.002048177         267 |000000000000000000000000000000000000000000000020000000000000000000000000000000000000>
+
+  Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
+  Cycle 8 took: 1.089670 s
+
+  ==> Cycle 9 <==
+
+  Initial P space dimension: 274
+  Spin-complete dimension of the P space: 274 determinants
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000653 s
+        β          0.000750 s
+        αα         0.000353 s
+        ββ         0.000353 s
+        αβ         0.000660 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261675799560  -2.392e-03
+      3      -17.261811828163  -1.360e-04
+      4      -17.261824890318  -1.306e-05
+      5      -17.261827769265  -2.879e-06
+      6      -17.261828010436  -2.412e-07
+      7      -17.261828040900  -3.046e-08
+      8      -17.261828046217  -5.317e-09
+      9      -17.261828047683  -1.466e-09
+     10      -17.261828047902  -2.183e-10
+     11      -17.261828047940  -3.805e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.290050 s
+  Time spent diagonalizing H:   0.291492 s
+
+    P-space  CI Energy Root   0        = -14.880530609285 Eh =   0.0000 eV
+
+  Time spent forming F space:             0.341758
+  Time spent merging thread F spaces:             0.000594
+  Time spent preparing PQ_space: 0.000417
+  Dimension of the SD space: 806 determinants
+  Time spent building the external space (default): 0.343074 s
+
+  Time spent building sorting list: 0.006069
+  Time spent sorting: 0.000168
+  Time spent selecting: 0.000006
+  Dimension of the P + Q space: 274 determinants
+  Time spent screening the model space: 0.006326 s
+  Time spent building the model space: 0.349541
+  Spin-complete dimension of the PQ space: 274
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000670 s
+        β          0.000721 s
+        αα         0.000353 s
+        ββ         0.000352 s
+        αβ         0.000799 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261675799560  -2.392e-03
+      3      -17.261811828163  -1.360e-04
+      4      -17.261824890318  -1.306e-05
+      5      -17.261827769265  -2.879e-06
+      6      -17.261828010436  -2.412e-07
+      7      -17.261828040900  -3.046e-08
+      8      -17.261828046217  -5.317e-09
+      9      -17.261828047683  -1.466e-09
+     10      -17.261828047902  -2.183e-10
+     11      -17.261828047940  -3.805e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.286428 s
+  Total time spent diagonalizing H:   0.288030 s
+
+    PQ-space CI Energy Root   0        = -14.880530609285 Eh =   0.0000 eV
+    PQ-space CI Energy + EPT2 Root   0 = -14.880583945259 Eh =   0.0000 eV
+
+  Added 3 missing determinants in aimed selection.
+
+  Most important contributions to root   0:
+    0   0.937744 0.879363132         273 |200000000000000000000000000000000000000000000000000000000000000000000000000000000000>
+    1  -0.123186 0.015174765         272 |000000000000000000000000000000000000000000000000000000000000000000000000002000000000>
+    2  -0.123186 0.015174765         271 |000000000000000000000000000000000000000000000000000000000000000020000000000000000000>
+    3  -0.101470 0.010296163         270 |00000000000000000000000000000000000000000000000000000000000000000000000000+-00000000>
+    4  -0.101470 0.010296163         269 |00000000000000000000000000000000000000000000000000000000000000000000000000-+00000000>
+    5  -0.101470 0.010296163         267 |0000000000000000000000000000000000000000000000000000000000000000-+000000000000000000>
+    6  -0.101470 0.010296163         268 |0000000000000000000000000000000000000000000000000000000000000000+-000000000000000000>
+    7  -0.084325 0.007110641         266 |000000000000000000000000000000000000000000000000000000000000000002000000000000000000>
+    8  -0.084325 0.007110641         265 |000000000000000000000000000000000000000000000000000000000000000000000000000200000000>
+    9  -0.045265 0.002048908         264 |000000000000000000000000000000000000000000000020000000000000000000000000000000000000>
+
+  Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
+  Cycle 9 took: 0.944545 s
+
+  ==> Cycle 10 <==
+
+  Initial P space dimension: 272
+  Spin-complete dimension of the P space: 272 determinants
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000622 s
+        β          0.000636 s
+        αα         0.000349 s
+        ββ         0.000349 s
+        αβ         0.000661 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261675630411  -2.392e-03
+      3      -17.261811293392  -1.357e-04
+      4      -17.261824187942  -1.289e-05
+      5      -17.261827004745  -2.817e-06
+      6      -17.261827241942  -2.372e-07
+      7      -17.261827271694  -2.975e-08
+      8      -17.261827276858  -5.164e-09
+      9      -17.261827278261  -1.403e-09
+     10      -17.261827278470  -2.088e-10
+     11      -17.261827278506  -3.649e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.278306 s
+  Time spent diagonalizing H:   0.279716 s
+
+    P-space  CI Energy Root   0        = -14.880529839851 Eh =   0.0000 eV
+
+  Time spent forming F space:             0.331739
+  Time spent merging thread F spaces:             0.000595
+  Time spent preparing PQ_space: 0.000182
+  Dimension of the SD space: 808 determinants
+  Time spent building the external space (default): 0.332720 s
+
+  Time spent building sorting list: 0.003784
+  Time spent sorting: 0.000168
+  Time spent selecting: 0.000006
+  Dimension of the P + Q space: 272 determinants
+  Time spent screening the model space: 0.004021 s
+  Time spent building the model space: 0.336894
+  Spin-complete dimension of the PQ space: 272
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000625 s
+        β          0.000636 s
+        αα         0.000350 s
+        ββ         0.000350 s
+        αβ         0.000655 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261675630411  -2.392e-03
+      3      -17.261811293392  -1.357e-04
+      4      -17.261824187942  -1.289e-05
+      5      -17.261827004745  -2.817e-06
+      6      -17.261827241942  -2.372e-07
+      7      -17.261827271694  -2.975e-08
+      8      -17.261827276858  -5.164e-09
+      9      -17.261827278261  -1.403e-09
+     10      -17.261827278470  -2.088e-10
+     11      -17.261827278506  -3.649e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.279822 s
+  Total time spent diagonalizing H:   0.281253 s
+
+    PQ-space CI Energy Root   0        = -14.880529839851 Eh =   0.0000 eV
+    PQ-space CI Energy + EPT2 Root   0 = -14.880583964722 Eh =   0.0000 eV
+
+
+  Most important contributions to root   0:
+    0   0.937746 0.879367036         268 |200000000000000000000000000000000000000000000000000000000000000000000000000000000000>
+    1  -0.123187 0.015175044         267 |000000000000000000000000000000000000000000000000000000000000000000000000002000000000>
+    2  -0.123187 0.015175044         266 |000000000000000000000000000000000000000000000000000000000000000020000000000000000000>
+    3  -0.101470 0.010296183         265 |00000000000000000000000000000000000000000000000000000000000000000000000000+-00000000>
+    4  -0.101470 0.010296183         264 |00000000000000000000000000000000000000000000000000000000000000000000000000-+00000000>
+    5  -0.101470 0.010296183         263 |0000000000000000000000000000000000000000000000000000000000000000-+000000000000000000>
+    6  -0.101470 0.010296183         262 |0000000000000000000000000000000000000000000000000000000000000000+-000000000000000000>
+    7  -0.084321 0.007110034         261 |000000000000000000000000000000000000000000000000000000000000000002000000000000000000>
+    8  -0.084321 0.007110034         260 |000000000000000000000000000000000000000000000000000000000000000000000000000200000000>
+    9  -0.045261 0.002048578         259 |000000000000000000000000000000000000000000000020000000000000000000000000000000000000>
+
+  Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
+  Cycle 10 took: 0.915479 s
+
+  ==> Cycle 11 <==
+
+  Initial P space dimension: 267
+  Spin-complete dimension of the P space: 267 determinants
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000612 s
+        β          0.000624 s
+        αα         0.000577 s
+        ββ         0.000785 s
+        αβ         0.001463 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261673580672  -2.390e-03
+      3      -17.261808954399  -1.354e-04
+      4      -17.261821692482  -1.274e-05
+      5      -17.261824471382  -2.779e-06
+      6      -17.261824705089  -2.337e-07
+      7      -17.261824734147  -2.906e-08
+      8      -17.261824739214  -5.068e-09
+      9      -17.261824740593  -1.379e-09
+     10      -17.261824740798  -2.048e-10
+     11      -17.261824740833  -3.549e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.270484 s
+  Time spent diagonalizing H:   0.272952 s
+
+    P-space  CI Energy Root   0        = -14.880527302178 Eh =   0.0000 eV
+
+  Time spent forming F space:             0.328962
+  Time spent merging thread F spaces:             0.000609
+  Time spent preparing PQ_space: 0.000181
+  Dimension of the SD space: 813 determinants
+  Time spent building the external space (default): 0.329962 s
+
+  Time spent building sorting list: 0.003762
+  Time spent sorting: 0.000168
+  Time spent selecting: 0.000006
+  Dimension of the P + Q space: 267 determinants
+  Time spent screening the model space: 0.003999 s
+  Time spent building the model space: 0.334088
+  Spin-complete dimension of the PQ space: 267
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000611 s
+        β          0.000624 s
+        αα         0.000344 s
+        ββ         0.000343 s
+        αβ         0.000647 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261673580672  -2.390e-03
+      3      -17.261808954399  -1.354e-04
+      4      -17.261821692482  -1.274e-05
+      5      -17.261824471382  -2.779e-06
+      6      -17.261824705089  -2.337e-07
+      7      -17.261824734147  -2.906e-08
+      8      -17.261824739214  -5.068e-09
+      9      -17.261824740593  -1.379e-09
+     10      -17.261824740798  -2.048e-10
+     11      -17.261824740833  -3.549e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.268057 s
+  Total time spent diagonalizing H:   0.269491 s
+
+    PQ-space CI Energy Root   0        = -14.880527302178 Eh =   0.0000 eV
+    PQ-space CI Energy + EPT2 Root   0 = -14.880583979713 Eh =   0.0000 eV
+
+
+  Most important contributions to root   0:
+    0   0.937722 0.879321627         266 |200000000000000000000000000000000000000000000000000000000000000000000000000000000000>
+    1  -0.123212 0.015181125         265 |000000000000000000000000000000000000000000000000000000000000000000000000002000000000>
+    2  -0.123212 0.015181125         264 |000000000000000000000000000000000000000000000000000000000000000020000000000000000000>
+    3  -0.101494 0.010301017         263 |00000000000000000000000000000000000000000000000000000000000000000000000000+-00000000>
+    4  -0.101494 0.010301017         262 |00000000000000000000000000000000000000000000000000000000000000000000000000-+00000000>
+    5  -0.101494 0.010301017         261 |0000000000000000000000000000000000000000000000000000000000000000+-000000000000000000>
+    6  -0.101494 0.010301017         260 |0000000000000000000000000000000000000000000000000000000000000000-+000000000000000000>
+    7  -0.084342 0.007113588         259 |000000000000000000000000000000000000000000000000000000000000000002000000000000000000>
+    8  -0.084342 0.007113588         258 |000000000000000000000000000000000000000000000000000000000000000000000000000200000000>
+    9  -0.045265 0.002048942         257 |000000000000000000000000000000000000000000000020000000000000000000000000000000000000>
+
+  Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
+  Cycle 11 took: 0.895156 s
+
+  ==> Cycle 12 <==
+
+  Initial P space dimension: 263
+  Spin-complete dimension of the P space: 263 determinants
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000620 s
+        β          0.000911 s
+        αα         0.000390 s
+        ββ         0.000370 s
+        αβ         0.000669 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261672809191  -2.389e-03
+      3      -17.261807502995  -1.347e-04
+      4      -17.261819878404  -1.238e-05
+      5      -17.261822560203  -2.682e-06
+      6      -17.261822784159  -2.240e-07
+      7      -17.261822812042  -2.788e-08
+      8      -17.261822816895  -4.852e-09
+      9      -17.261822818217  -1.322e-09
+     10      -17.261822818414  -1.968e-10
+     11      -17.261822818448  -3.392e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.265453 s
+  Time spent diagonalizing H:   0.266863 s
+
+    P-space  CI Energy Root   0        = -14.880525379793 Eh =   0.0000 eV
+
+  Time spent forming F space:             0.316288
+  Time spent merging thread F spaces:             0.000592
+  Time spent preparing PQ_space: 0.000179
+  Dimension of the SD space: 817 determinants
+  Time spent building the external space (default): 0.317270 s
+
+  Time spent building sorting list: 0.003769
+  Time spent sorting: 0.000168
+  Time spent selecting: 0.000006
+  Dimension of the P + Q space: 263 determinants
+  Time spent screening the model space: 0.004006 s
+  Time spent building the model space: 0.321402
+  Spin-complete dimension of the PQ space: 263
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000667 s
+        β          0.000675 s
+        αα         0.000342 s
+        ββ         0.000338 s
+        αβ         0.000635 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261672809191  -2.389e-03
+      3      -17.261807502995  -1.347e-04
+      4      -17.261819878404  -1.238e-05
+      5      -17.261822560203  -2.682e-06
+      6      -17.261822784159  -2.240e-07
+      7      -17.261822812042  -2.788e-08
+      8      -17.261822816895  -4.852e-09
+      9      -17.261822818217  -1.322e-09
+     10      -17.261822818414  -1.968e-10
+     11      -17.261822818448  -3.392e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.262610 s
+  Total time spent diagonalizing H:   0.264182 s
+
+    PQ-space CI Energy Root   0        = -14.880525379793 Eh =   0.0000 eV
+    PQ-space CI Energy + EPT2 Root   0 = -14.880583972627 Eh =   0.0000 eV
+
+  Added 1 missing determinants in aimed selection.
+
+  Most important contributions to root   0:
+    0   0.937680 0.879243851         262 |200000000000000000000000000000000000000000000000000000000000000000000000000000000000>
+    1  -0.123242 0.015188518         261 |000000000000000000000000000000000000000000000000000000000000000000000000002000000000>
+    2  -0.123242 0.015188518         260 |000000000000000000000000000000000000000000000000000000000000000020000000000000000000>
+    3  -0.101529 0.010308215         259 |00000000000000000000000000000000000000000000000000000000000000000000000000+-00000000>
+    4  -0.101529 0.010308215         258 |00000000000000000000000000000000000000000000000000000000000000000000000000-+00000000>
+    5  -0.101529 0.010308215         257 |0000000000000000000000000000000000000000000000000000000000000000+-000000000000000000>
+    6  -0.101529 0.010308215         256 |0000000000000000000000000000000000000000000000000000000000000000-+000000000000000000>
+    7  -0.084383 0.007120418         255 |000000000000000000000000000000000000000000000000000000000000000002000000000000000000>
+    8  -0.084383 0.007120418         254 |000000000000000000000000000000000000000000000000000000000000000000000000000200000000>
+    9  -0.045288 0.002050981         253 |000000000000000000000000000000000000000000000020000000000000000000000000000000000000>
+
+  Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
+  Cycle 12 took: 0.868229 s
+
+  ==> Cycle 13 <==
+
+  Initial P space dimension: 261
+  Spin-complete dimension of the P space: 261 determinants
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000628 s
+        β          0.000612 s
+        αα         0.000336 s
+        ββ         0.000335 s
+        αβ         0.000651 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261668820130  -2.385e-03
+      3      -17.261803383007  -1.346e-04
+      4      -17.261815738024  -1.236e-05
+      5      -17.261818414130  -2.676e-06
+      6      -17.261818637577  -2.234e-07
+      7      -17.261818665385  -2.781e-08
+      8      -17.261818670222  -4.837e-09
+      9      -17.261818671539  -1.317e-09
+     10      -17.261818671735  -1.961e-10
+     11      -17.261818671769  -3.380e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.272760 s
+  Time spent diagonalizing H:   0.274137 s
+
+    P-space  CI Energy Root   0        = -14.880521233114 Eh =   0.0000 eV
+
+  Time spent forming F space:             0.347773
+  Time spent merging thread F spaces:             0.000599
+  Time spent preparing PQ_space: 0.000178
+  Dimension of the SD space: 819 determinants
+  Time spent building the external space (default): 0.348765 s
+
+  Time spent building sorting list: 0.004559
+  Time spent sorting: 0.000172
+  Time spent selecting: 0.000006
+  Dimension of the P + Q space: 261 determinants
+  Time spent screening the model space: 0.004820 s
+  Time spent building the model space: 0.353712
+  Spin-complete dimension of the PQ space: 261
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000603 s
+        β          0.000612 s
+        αα         0.000431 s
+        ββ         0.000336 s
+        αβ         0.000633 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261668820130  -2.385e-03
+      3      -17.261803383007  -1.346e-04
+      4      -17.261815738024  -1.236e-05
+      5      -17.261818414130  -2.676e-06
+      6      -17.261818637577  -2.234e-07
+      7      -17.261818665385  -2.781e-08
+      8      -17.261818670222  -4.837e-09
+      9      -17.261818671539  -1.317e-09
+     10      -17.261818671735  -1.961e-10
+     11      -17.261818671769  -3.380e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.293442 s
+  Total time spent diagonalizing H:   0.294840 s
+
+    PQ-space CI Energy Root   0        = -14.880521233114 Eh =   0.0000 eV
+    PQ-space CI Energy + EPT2 Root   0 = -14.880583937553 Eh =   0.0000 eV
+
+  Added 2 missing determinants in aimed selection.
+
+  Most important contributions to root   0:
+    0   0.937674 0.879232327         259 |200000000000000000000000000000000000000000000000000000000000000000000000000000000000>
+    1  -0.123247 0.015189861         258 |000000000000000000000000000000000000000000000000000000000000000000000000002000000000>
+    2  -0.123247 0.015189861         257 |000000000000000000000000000000000000000000000000000000000000000020000000000000000000>
+    3  -0.101534 0.010309181         255 |00000000000000000000000000000000000000000000000000000000000000000000000000-+00000000>
+    4  -0.101534 0.010309181         256 |00000000000000000000000000000000000000000000000000000000000000000000000000+-00000000>
+    5  -0.101534 0.010309181         254 |0000000000000000000000000000000000000000000000000000000000000000+-000000000000000000>
+    6  -0.101534 0.010309181         253 |0000000000000000000000000000000000000000000000000000000000000000-+000000000000000000>
+    7  -0.084388 0.007121366         252 |000000000000000000000000000000000000000000000000000000000000000002000000000000000000>
+    8  -0.084388 0.007121366         251 |000000000000000000000000000000000000000000000000000000000000000000000000000200000000>
+    9  -0.045290 0.002051141         250 |000000000000000000000000000000000000000000000020000000000000000000000000000000000000>
+
+  Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
+  Cycle 13 took: 0.936920 s
+
+  ==> Cycle 14 <==
+
+  Initial P space dimension: 260
+  Spin-complete dimension of the P space: 261 determinants
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000600 s
+        β          0.000612 s
+        αα         0.000336 s
+        ββ         0.000336 s
+        αβ         0.000630 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261668820130  -2.385e-03
+      3      -17.261803383007  -1.346e-04
+      4      -17.261815738024  -1.236e-05
+      5      -17.261818414130  -2.676e-06
+      6      -17.261818637577  -2.234e-07
+      7      -17.261818665385  -2.781e-08
+      8      -17.261818670222  -4.837e-09
+      9      -17.261818671539  -1.317e-09
+     10      -17.261818671735  -1.961e-10
+     11      -17.261818671769  -3.380e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.298756 s
+  Time spent diagonalizing H:   0.300149 s
+
+    P-space  CI Energy Root   0        = -14.880521233114 Eh =   0.0000 eV
+
+  Time spent forming F space:             0.332436
+  Time spent merging thread F spaces:             0.000599
+  Time spent preparing PQ_space: 0.000177
+  Dimension of the SD space: 819 determinants
+  Time spent building the external space (default): 0.333415 s
+
+  Time spent building sorting list: 0.003810
+  Time spent sorting: 0.000166
+  Time spent selecting: 0.000006
+  Dimension of the P + Q space: 261 determinants
+  Time spent screening the model space: 0.004046 s
+  Time spent building the model space: 0.337586
+  Spin-complete dimension of the PQ space: 261
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000598 s
+        β          0.000617 s
+        αα         0.000337 s
+        ββ         0.000336 s
+        αβ         0.000629 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm
+  Using SPARSE sigma builder
+  Initial guess space is incomplete!
+  Trying to add 1 determinant(s).  1 determinant(s) added.
+  Initial guess found 61 solutions with 2S+1 = 1 *
+  Initial guess found 40 solutions with 2S+1 = 3  
+  Adding guess 0 (multiplicity = 1.000000)
+  Adding guess 1 (multiplicity = 1.000000)
+
+  ==> Diagonalizing Hamiltonian <==
+
+  ----------------------------------------
+    Iter.      Avg. Energy       Delta_E
+  ----------------------------------------
+      1      -17.259283753123  -1.726e+01
+      2      -17.261668820130  -2.385e-03
+      3      -17.261803383007  -1.346e-04
+      4      -17.261815738024  -1.236e-05
+      5      -17.261818414130  -2.676e-06
+      6      -17.261818637577  -2.234e-07
+      7      -17.261818665385  -2.781e-08
+      8      -17.261818670222  -4.837e-09
+      9      -17.261818671539  -1.317e-09
+     10      -17.261818671735  -1.961e-10
+     11      -17.261818671769  -3.380e-11
+  ----------------------------------------
+  The Davidson-Liu algorithm converged in 12 iterations.
+  Davidson-Liu procedure took  0.264521 s
+  Total time spent diagonalizing H:   0.265911 s
+
+    PQ-space CI Energy Root   0        = -14.880521233114 Eh =   0.0000 eV
+    PQ-space CI Energy + EPT2 Root   0 = -14.880583937553 Eh =   0.0000 eV
+
+  ***** Calculation Converged *****
+  Saving root 0, ref_root is 0
+  Number of old roots: 1
+
+  ==> ACI Summary <==
+
+  Iterations required:                         14
+  Dimension of optimized determinant space:    261
+
+  * Adaptive-CI Energy Root   0        = -14.880521233114 Eh =   0.0000 eV
+  * Adaptive-CI Energy Root   0 + EPT2 = -14.880583937553 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0   0.937674 0.879232327         257 |200000000000000000000000000000000000000000000000000000000000000000000000000000000000>
+    1  -0.123247 0.015189861         256 |000000000000000000000000000000000000000000000000000000000000000000000000002000000000>
+    2  -0.123247 0.015189861         255 |000000000000000000000000000000000000000000000000000000000000000020000000000000000000>
+    3  -0.101534 0.010309181         254 |00000000000000000000000000000000000000000000000000000000000000000000000000-+00000000>
+    4  -0.101534 0.010309181         253 |00000000000000000000000000000000000000000000000000000000000000000000000000+-00000000>
+    5  -0.101534 0.010309181         252 |0000000000000000000000000000000000000000000000000000000000000000+-000000000000000000>
+    6  -0.101534 0.010309181         251 |0000000000000000000000000000000000000000000000000000000000000000-+000000000000000000>
+    7  -0.084388 0.007121366         250 |000000000000000000000000000000000000000000000000000000000000000002000000000000000000>
+    8  -0.084388 0.007121366         249 |000000000000000000000000000000000000000000000000000000000000000000000000000200000000>
+    9  -0.045290 0.002051141         248 |000000000000000000000000000000000000000000000020000000000000000000000000000000000000>
+
+  Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000618 s
+        β          0.000622 s
+        αα         0.000339 s
+        ββ         0.000336 s
+        αβ         0.000631 s
+  --------------------------------
+  1-RDM  took 0.003634 s (determinant)
+
+  ==> NATURAL ORBITALS <==
+
+        1Ag     1.764044      1B3u    0.097455      1B2u    0.097455  
+        2Ag     0.022469      1B1u    0.017976      3Ag     0.000126  
+        2B1u    0.000084      4Ag     0.000074      1B1g    0.000074  
+        2B2u    0.000043      2B3u    0.000043      1B2g    0.000032  
+        1B3g    0.000032      5Ag     0.000016      3B3u    0.000008  
+        3B2u    0.000008      3B1u    0.000008      4B2u    0.000005  
+        4B3u    0.000005      2B3g    0.000004      2B2g    0.000004  
+        6Ag     0.000003      2B1g    0.000003      4B1u    0.000003  
+        1Au     0.000003      7Ag     0.000002      5B1u    0.000002  
+        2Au     0.000002      8Ag     0.000002      5B3u    0.000002  
+        5B2u    0.000002      6B1u    0.000002      9Ag     0.000001  
+        3B2g    0.000001      3B3g    0.000001      7B1u    0.000001  
+       10Ag     0.000001     11Ag     0.000001      3B1g    0.000001  
+       12Ag     0.000001      4B2g    0.000001      4B3g    0.000001  
+        5B3g    0.000000      5B2g    0.000000      6B2u    0.000000  
+        6B3u    0.000000      8B1u    0.000000      7B3u    0.000000  
+        7B2u    0.000000      9B1u    0.000000      8B2u    0.000000  
+        8B3u    0.000000     13Ag     0.000000     10B1u    0.000000  
+       11B1u    0.000000     12B1u    0.000000      6B2g    0.000000  
+       10B3u    0.000000      9B3u    0.000000     10B2u    0.000000  
+        9B2u    0.000000     16B1u    0.000000     15B1u    0.000000  
+       14B1u    0.000000     13B1u    0.000000      4Au     0.000000  
+        3Au     0.000000      9B3g    0.000000      8B3g    0.000000  
+        7B3g    0.000000      6B3g    0.000000      9B2g    0.000000  
+        8B2g    0.000000      7B2g    0.000000      4B1g    0.000000  
+       18Ag     0.000000     17Ag     0.000000     16Ag     0.000000  
+       15Ag     0.000000     14Ag     0.000000     10B2g   -0.000000  
+       17B1u   -0.000000     10B3g   -0.000000     18B1u   -0.000000  
+
+
+  RDMS took 0.007985
+
+  Adaptive-CI ran in : 17.800071 s
+
+  Saving information for root: 0	ACI energy........................................................PASSED
+	ACI+PT2 energy....................................................PASSED
+
+    Psi4 stopped on: Monday, 10 September 2018 04:53PM
+    Psi4 wall time for execution: 0:01:16.30
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/large_det/run_forte_tests.py
+++ b/tests/large_det/run_forte_tests.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import subprocess
+import re
+import datetime
+
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+
+timing_re = re.compile(r"Your calculation took (\d+.\d+) seconds")
+timing_re = re.compile(r"Psi4 exiting successfully. Buy a developer a beer!")
+
+psi4command = ""
+
+
+print("Running forte tests using the psi4 executable found in:\n  %s\n" % psi4command)
+
+adaptive_ci_tests = ["aci-1"]
+tests = adaptive_ci_tests
+
+maindir = os.getcwd()
+if len(sys.argv) == 1:
+    cmd = ["which","psi4"]
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    res = p.stdout.readlines()
+    if len(res) == 0:
+        print("Could not detect your PSI4 executable.  Please specify its location.")
+        exit(1)
+    psi4command = res[0][:-1]
+elif len(sys.argv) == 2:
+    psi4command = sys.argv[1]
+#elif len(sys.argv) == 3:
+#    tests = sys.argv[2]
+
+print("Running forte tests using the psi4 executable found in:\n  %s\n" % psi4command)
+
+
+test_results = {}
+for d in tests:
+    print("Running test %s" % d.upper())
+
+    os.chdir(d)
+    successful = True
+    # Run psi
+    try:
+        out = subprocess.check_output([psi4command])
+    except:
+        # something went wrong
+        successful = False
+        test_results[d] = "DOES NOT MATCH"
+
+    if successful:
+        # Check if FORTE ended successfully
+        timing = open("output.dat").read()
+        m = timing_re.search(timing)
+        if m:
+            test_results[d] = "PASSED"
+        else:
+            test_results[d] = "FAILED"
+        print(out)
+    os.chdir(maindir)
+
+
+summary = []
+failed = []
+nomatch = []
+for d in tests:
+    if test_results[d] == "PASSED":
+        msg = bcolors.OKGREEN + "PASSED" + bcolors.ENDC
+    elif test_results[d] == "FAILED":
+        msg = bcolors.FAIL + "FAILED" + bcolors.ENDC
+        failed.append(d)
+    elif test_results[d] == "DOES NOT MATCH":
+        msg = bcolors.FAIL + "DOES NOT MATCH" + bcolors.ENDC
+        nomatch.append(d)
+
+    filler = "." * (81 - len(d + msg))
+    summary.append("        %s%s%s" % (d.upper(),filler,msg))
+
+print("Summary:")
+print(" " * 8 + "-" * 72)
+print("\n".join(summary))
+print(" " * 8 + "-" * 72)
+
+test_result_log = open("test_results","w+")
+test_result_log.write("\n".join(summary))
+
+nfailed = len(failed)
+nnomatch = len(nomatch)
+if nnomatch + nfailed == 0:
+    print("Tests: All passed\n")
+else:
+    print("Tests: %d passed, %d failed, %d did not match\n" % (len(tests) -  nnomatch - nfailed,nfailed,nnomatch))
+    # Get the current date and time
+    dt = datetime.datetime.now()
+    now = dt.strftime("%Y-%m-%d-%H:%M")
+    if nfailed > 0:
+        failed_log = open("failed_tests","w+")
+        failed_log.write("# %s\n" % now)
+        failed_log.write("\n".join(failed))
+    if nnomatch > 0:
+        nomatch_log = open("nomatch_tests","w+")
+        nomatch_log.write("# %s\n" % now)
+        nomatch_log.write("\n".join(nomatch))

--- a/tests/large_det/run_forte_tests_travis.py
+++ b/tests/large_det/run_forte_tests_travis.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import subprocess
+import re
+import datetime
+import time
+
+
+class bcolors:
+    HEADER = ''
+    OKBLUE = ''
+    OKGREEN = ''
+    WARNING = ''
+    FAIL = ''
+    ENDC = ''
+
+timing_re = re.compile(r"Your calculation took (\d+.\d+) seconds")
+timing_re = re.compile(r"Psi4 exiting successfully. Buy a developer a beer!")
+
+psi4command = ""
+
+
+adaptive_ci_tests = ["aci-1"]
+tests = adaptive_ci_tests
+
+maindir = os.getcwd()
+if len(sys.argv) == 1:
+    cmd = ["which","psi4"]
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    res = p.stdout.readlines()
+    if len(res) == 0:
+        print("Could not detect your PSI4 executable.  Please specify its location.")
+        exit(1)
+    psi4command = res[0][:-1]
+elif len(sys.argv) == 2:
+    psi4command = sys.argv[1]
+#elif len(sys.argv) == 3:
+#    tests = sys.argv[2]
+
+print("Running forte tests using the psi4 executable found in:\n  %s\n" % psi4command)
+
+test_results = {}
+test_time = {}
+for d in tests:
+    print("Running test %s" % d.upper())
+
+    start = time.time()
+    os.chdir(d)
+    successful = True
+    # Run psi
+    try:
+        out = subprocess.check_output([psi4command])
+    except:
+        # something went wrong
+        successful = False
+        test_results[d] = "FAILED"
+
+    if successful:
+        # Check if FORTE ended successfully
+        timing = open("output.dat").read()
+        m = timing_re.search(timing)
+        if m:
+            test_results[d] = "PASSED"
+        else:
+            test_results[d] = "FAILED"
+        print(out.decode("utf-8"))
+    os.chdir(maindir)
+    end = time.time()
+    test_time[d] = end - start
+
+total_time = 0.0
+summary = []
+failed = []
+for d in tests:
+    if test_results[d] == "PASSED":
+        msg = bcolors.OKGREEN + "PASSED" + bcolors.ENDC
+    elif test_results[d] == "FAILED":
+        msg = bcolors.FAIL + "FAILED" + bcolors.ENDC
+        failed.append(d)
+    duration = test_time[d]
+    total_time += duration
+    filler = "." * max(0,67 - len(d + msg))
+    summary.append("    %s%s%s  %5.1f" % (d.upper(),filler,msg,duration))
+
+print("Summary:")
+print(" " * 4 + "=" * 76)
+print("    TEST" + ' ' * 57 + 'RESULT TIME (s)')
+print(" " * 4 + "-" * 76)
+print("\n".join(summary))
+print(" " * 4 + "=" * 76)
+
+test_result_log = open("test_results","w+")
+test_result_log.write("\n".join(summary))
+
+nfailed = len(failed)
+if nfailed == 0:
+    print("Tests: All passed\n")
+else:
+    print("Tests: %d passed and %d failed\n" % (len(tests) -  nfailed,nfailed))
+    # Get the current date and time
+    dt = datetime.datetime.now()
+    now = dt.strftime("%Y-%m-%d-%H:%M")
+   
+    print("The following tests failed:")
+    for failed_test in failed:
+        print("  %s" % failed_test)
+    
+print("\nTotal time: %6.1f s\n" % total_time)
+if nfailed > 0:
+    failed_log = open("failed_tests","w")
+    failed_log.write("# %s\n" % now)
+    failed_log.write("\n".join(failed))
+    failed_log.close()
+    exit(1)

--- a/tests/methods/aci-1/input.dat
+++ b/tests/methods/aci-1/input.dat
@@ -31,13 +31,10 @@ set forte {
   job_type = aci
   multiplicity 1
   ms 0.0
-  ACI_SELECT_TYPE energy
-  sigma 0.00001000
-  gamma 100.0
+  aci_screen_alg sr
+  sigma 0.001
   aci_nroot 1
-  root_sym 0
   charge 0
-  aci_perturb_select true
   aci_enforce_spin_complete false
   active_ref_type hf 
 }

--- a/tests/methods/aci-10/input.dat
+++ b/tests/methods/aci-10/input.dat
@@ -44,7 +44,6 @@ set forte {
   aci_nroot                  1
   job_type               aci
   sigma	                  0.001
-  aci_select_type            aimed_energy	 
   aci_enforce_spin_complete  true
   aci_add_aimed_degenerate false
   aci_project_out_spin_contaminants false

--- a/tests/methods/aci-11/input.dat
+++ b/tests/methods/aci-11/input.dat
@@ -32,7 +32,7 @@ set {
 set forte {
   job_type = aci
   multiplicity 1
-  aci_select_type amp
+#  aci_select_type amp
   aci_perturb_select false
   frozen_docc [1,0,0,0,0,1,0,0]
   root_sym 0

--- a/tests/methods/aci-12/input.dat
+++ b/tests/methods/aci-12/input.dat
@@ -31,7 +31,6 @@ set {
 set forte {
   job_type = aci
   multiplicity 1
-  aci_SELECT_TYPE aimed_energy
   frozen_docc [1,0,0,0,0,1,0,0]
   aci_excited_algorithm average
   sigma 0.05
@@ -49,4 +48,4 @@ compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
 compare_values(refaci, get_variable("ACI ENERGY"),9, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
+#compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST

--- a/tests/methods/aci-13/input.dat
+++ b/tests/methods/aci-13/input.dat
@@ -32,7 +32,7 @@ set {
 set forte {
   job_type = aci
   multiplicity 1
-  aci_select_type amp
+#  aci_select_type amp
   frozen_docc [1,0,0,0,0,1,0,0]
   root_sym 0
   sigma 0.01

--- a/tests/methods/aci-14/input.dat
+++ b/tests/methods/aci-14/input.dat
@@ -25,7 +25,6 @@ set forte {
   frozen_docc [0,0,0,0,0,0,0,0]
   restricted_docc [0,0,0,0,0,0,0,0]
   active [3,0,1,1,0,3,2,2]
-  aci_SELECT_TYPE aimed_energy
   aci_excited_algorithm root_orthogonalize
   sigma 0.001
   nroot 2

--- a/tests/methods/aci-15/input.dat
+++ b/tests/methods/aci-15/input.dat
@@ -32,7 +32,7 @@ set {
 set forte {
   job_type = aci
   multiplicity 1
-  aci_select_type amp
+#  aci_select_type amp
   frozen_docc [1,0,0,0,0,0,0,0]
   restricted_docc [0,0,0,0,0,1,0,0]
   root_sym 0

--- a/tests/methods/aci-17/input.dat
+++ b/tests/methods/aci-17/input.dat
@@ -33,7 +33,7 @@ set forte {
   ms 0.5
   job_type = aci
   frozen_docc = [0,0,0,0,0,0,0,0]
-  aci_SELECT_TYPE amp
+#  aci_SELECT_TYPE amp
   gamma 10.00
   sigma 0.001000
   aci_enforce_spin_complete false

--- a/tests/methods/aci-3/input.dat
+++ b/tests/methods/aci-3/input.dat
@@ -29,7 +29,6 @@ set forte {
   multiplicity 1
   ms 0.0
   job_type aci
-  aci_SELECT_TYPE aimed_energy
   sigma 0.001000
   aci_nroot 1
   charge 0

--- a/tests/methods/aci-3/output.ref
+++ b/tests/methods/aci-3/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.2a1.dev704 
+                               Psi4 1.2rc2.dev6 
 
-                         Git: Rev {master} a7fc050 
+                         Git: Rev {master} ce9c78d dirty
 
 
     R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
@@ -18,10 +18,11 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Monday, 04 December 2017 12:08PM
+    Psi4 started on: Monday, 10 September 2018 11:10AM
 
-    Process ID:  32904
-    PSIDATADIR: /Users/york/src/psi4new/psi4/share/psi4
+    Process ID: 47566
+    Host:       jeffs-mbp-2.wireless.emory.edu
+    PSIDATADIR: /Users/jeffschriber/src/psi4-debug-install/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -59,12 +60,12 @@ set forte {
   multiplicity 1
   ms 0.0
   job_type aci
-  aci_SELECT_TYPE aimed_energy
   sigma 0.001000
   aci_nroot 1
   charge 0
   diag_algorithm sparse
   active_guess_size 300
+#  aci_screen_alg average
 }
 
 energy('scf')
@@ -76,15 +77,15 @@ compare_values(refaci, get_variable("ACI ENERGY"),9, "ACI energy") #TEST
 compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
 --------------------------------------------------------------------------
 
-*** tstart() called on yorks-mac.wireless.emory.edu
-*** at Mon Dec  4 12:08:40 2017
+*** tstart() called on jeffs-mbp-2.wireless.emory.edu
+*** at Mon Sep 10 11:10:59 2018
 
    => Loading Basis Set <=
 
     Name: CC-PVDZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-4 entry H          line    22 file /Users/york/src/psi4new/psi4/share/psi4/basis/cc-pvdz.gbs 
+    atoms 1-4 entry H          line    22 file /Users/jeffschriber/src/psi4-debug-install/share/psi4/basis/cc-pvdz.gbs 
 
 
          ---------------------------------------------------------
@@ -169,6 +170,7 @@ compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #T
   Using 44310 doubles for integral storage.
   We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
+
   ==> DiskJK: Disk-Based J/K Matrices <==
 
     J tasked:                  Yes
@@ -178,6 +180,7 @@ compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #T
     Schwarz Cutoff:          1E-12
 
     OpenMP threads:              1
+
   Minimum eigenvalue in the overlap matrix is 5.7536001511E-02.
   Using Symmetric Orthogonalization.
 
@@ -188,22 +191,211 @@ compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #T
                         Total Energy        Delta E     RMS |[F,P]|
 
    @RHF iter   1:    -1.84014935812622   -1.84015e+00   2.47849e-02 
+   @RHF iter   2:    -2.01742297769517   -1.77274e-01   5.46427e-03 DIIS
+   @RHF iter   3:    -2.03075676867326   -1.33338e-02   8.10172e-04 DIIS
+   @RHF iter   4:    -2.03108069576760   -3.23927e-04   4.83230e-05 DIIS
+   @RHF iter   5:    -2.03108137217734   -6.76410e-07   3.21514e-06 DIIS
+   @RHF iter   6:    -2.03108138109902   -8.92168e-09   1.12166e-06 DIIS
+   @RHF iter   7:    -2.03108138276120   -1.66218e-09   3.00676e-07 DIIS
+   @RHF iter   8:    -2.03108138290438   -1.43177e-10   7.08609e-08 DIIS
+   @RHF iter   9:    -2.03108138291130   -6.92602e-12   6.48722e-09 DIIS
+   @RHF iter  10:    -2.03108138291133   -2.35367e-14   1.18712e-09 DIIS
+   @RHF iter  11:    -2.03108138291133   -2.66454e-15   3.01061e-10 DIIS
+   @RHF iter  12:    -2.03108138291133    8.88178e-16   5.60273e-11 DIIS
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A     -0.831246     2A     -0.342592  
+
+    Virtual:                                                              
+
+       3A      0.129478     4A      0.165148     5A      0.393168  
+       6A      0.538096     7A      0.774720     8A      0.856941  
+       9A      1.266282    10A      1.334161    11A      1.395911  
+      12A      1.711764    13A      1.730215    14A      1.976391  
+      15A      2.251536    16A      2.286274    17A      2.404790  
+      18A      2.533391    19A      3.214030    20A      3.326443  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     2 ]
+
+  Energy converged.
+
+  @RHF Final Energy:    -2.03108138291133
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              3.1366905881325060
+    One-Electron Energy =                  -7.9878690268690553
+    Two-Electron Energy =                   2.8200970558252223
+    Total Energy =                         -2.0310813829113270
+
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0029      Y:    -0.0417      Z:    -0.0248
+
+  Dipole Moment: [e a0]
+     X:     0.0029      Y:    -0.0417      Z:    -0.0248     Total:     0.0486
+
+  Dipole Moment: [D]
+     X:     0.0074      Y:    -0.1060      Z:    -0.0631     Total:     0.1235
+
+
+*** tstop() called on jeffs-mbp-2.wireless.emory.edu at Mon Sep 10 11:10:59 2018
+Module time:
+	user time   =       0.17 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.17 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+	SCF energy........................................................PASSED
+
+*** tstart() called on jeffs-mbp-2.wireless.emory.edu
+*** at Mon Sep 10 11:10:59 2018
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-4 entry H          line    22 file /Users/jeffschriber/src/psi4-debug-install/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+            by Justin Turney, Rob Parrish, Andy Simmonett
+                             and Daniel Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C1
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+           H         -0.400000000000    -0.050000000000    -0.500000000000     1.007825032070
+           H          0.400000000000    -0.050000000000    -0.500000000000     1.007825032070
+           H          0.100000000000    -0.350000000000     0.500000000000     1.007825032070
+           H         -0.100000000000     0.450000000000     0.500000000000     1.007825032070
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     25.52952  B =     13.25079  C =     11.75880 [cm^-1]
+  Rotational constants: A = 765355.63070  B = 397248.78268  C = 352519.82412 [MHz]
+  Nuclear repulsion =    3.136690588132506
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 4
+  Nalpha       = 2
+  Nbeta        = 2
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is GWH.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis function: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: true
+    Max angular momentum: 1
+
+  ==> Pre-Iterations <==
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A         20      20       0       0       0       0
+   -------------------------------------------------------
+    Total      20      20       2       2       2       0
+   -------------------------------------------------------
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   4
+      Number of AO shells:              12
+      Number of primitives:             20
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory (MB):               375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 5.7536001511E-02.
+  Using Symmetric Orthogonalization.
+
+  SCF Guess: Generalized Wolfsberg-Helmholtz.
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter   1:    -1.84014935812621   -1.84015e+00   2.47849e-02 
    @RHF iter   2:    -2.01742297769517   -1.77274e-01   5.46427e-03 DIIS
    @RHF iter   3:    -2.03075676867327   -1.33338e-02   8.10172e-04 DIIS
    @RHF iter   4:    -2.03108069576760   -3.23927e-04   4.83230e-05 DIIS
    @RHF iter   5:    -2.03108137217734   -6.76410e-07   3.21514e-06 DIIS
    @RHF iter   6:    -2.03108138109902   -8.92168e-09   1.12166e-06 DIIS
-   @RHF iter   7:    -2.03108138276119   -1.66217e-09   3.00676e-07 DIIS
-   @RHF iter   8:    -2.03108138290438   -1.43185e-10   7.08609e-08 DIIS
-   @RHF iter   9:    -2.03108138291130   -6.92690e-12   6.48722e-09 DIIS
-   @RHF iter  10:    -2.03108138291133   -2.44249e-14   1.18712e-09 DIIS
-   @RHF iter  11:    -2.03108138291132    3.55271e-15   3.01061e-10 DIIS
-   @RHF iter  12:    -2.03108138291133   -5.77316e-15   5.60274e-11 DIIS
+   @RHF iter   7:    -2.03108138276120   -1.66217e-09   3.00676e-07 DIIS
+   @RHF iter   8:    -2.03108138290438   -1.43184e-10   7.08609e-08 DIIS
+   @RHF iter   9:    -2.03108138291130   -6.92246e-12   6.48722e-09 DIIS
+   @RHF iter  10:    -2.03108138291133   -2.22045e-14   1.18712e-09 DIIS
+   @RHF iter  11:    -2.03108138291132    8.88178e-16   3.01060e-10 DIIS
+   @RHF iter  12:    -2.03108138291133   -3.99680e-15   5.60274e-11 DIIS
 
   ==> Post-Iterations <==
 
-    Orbital Energies (a.u.)
-    -----------------------
+    Orbital Energies [Eh]
+    ---------------------
 
     Doubly Occupied:                                                      
 
@@ -229,231 +421,44 @@ compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #T
    => Energetics <=
 
     Nuclear Repulsion Energy =              3.1366905881325060
-    One-Electron Energy =                  -7.9878690268690651
-    Two-Electron Energy =                   2.8200970558252285
-    Total Energy =                         -2.0310813829113306
+    One-Electron Energy =                  -7.9878690268690518
+    Two-Electron Energy =                   2.8200970558252170
+    Total Energy =                         -2.0310813829113288
 
 
 
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
-
-Properties computed using the SCF density matrix
-
-  Nuclear Dipole Moment: (a.u.)
-     X:     0.0000      Y:     0.0000      Z:     0.0000
-
-  Electronic Dipole Moment: (a.u.)
-     X:     0.0029      Y:    -0.0417      Z:    -0.0248
-
-  Dipole Moment: (a.u.)
-     X:     0.0029      Y:    -0.0417      Z:    -0.0248     Total:     0.0486
-
-  Dipole Moment: (Debye)
-     X:     0.0074      Y:    -0.1060      Z:    -0.0631     Total:     0.1235
-
-
-*** tstop() called on yorks-mac.wireless.emory.edu at Mon Dec  4 12:08:40 2017
-Module time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.18 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-	SCF energy........................................................PASSED
-
-*** tstart() called on yorks-mac.wireless.emory.edu
-*** at Mon Dec  4 12:08:40 2017
-
-   => Loading Basis Set <=
-
-    Name: CC-PVDZ
-    Role: ORBITAL
-    Keyword: BASIS
-    atoms 1-4 entry H          line    22 file /Users/york/src/psi4new/psi4/share/psi4/basis/cc-pvdz.gbs 
-
-
-         ---------------------------------------------------------
-                                   SCF
-            by Justin Turney, Rob Parrish, Andy Simmonett
-                             and Daniel Smith
-                              RHF Reference
-                        1 Threads,    500 MiB Core
-         ---------------------------------------------------------
-
-  ==> Geometry <==
-
-    Molecular point group: c1
-    Full point group: C1
-
-    Geometry (in Angstrom), charge = 0, multiplicity = 1:
-
-       Center              X                  Y                   Z               Mass       
-    ------------   -----------------  -----------------  -----------------  -----------------
-           H         -0.400000000000    -0.050000000000    -0.500000000000     1.007825032070
-           H          0.400000000000    -0.050000000000    -0.500000000000     1.007825032070
-           H          0.100000000000    -0.350000000000     0.500000000000     1.007825032070
-           H         -0.100000000000     0.450000000000     0.500000000000     1.007825032070
-
-  Running in c1 symmetry.
-
-  Rotational constants: A =     25.52952  B =     13.25079  C =     11.75880 [cm^-1]
-  Rotational constants: A = 765355.63070  B = 397248.78268  C = 352519.82412 [MHz]
-  Nuclear repulsion =    3.136690588132506
-
-  Charge       = 0
-  Multiplicity = 1
-  Electrons    = 4
-  Nalpha       = 2
-  Nbeta        = 2
-
-  ==> Algorithm <==
-
-  SCF Algorithm Type is PK.
-  DIIS enabled.
-  MOM disabled.
-  Fractional occupation disabled.
-  Guess Type is GWH.
-  Energy threshold   = 1.00e-10
-  Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
-
-  ==> Primary Basis <==
-
-  Basis Set: CC-PVDZ
-    Blend: CC-PVDZ
-    Number of shells: 12
-    Number of basis function: 20
-    Number of Cartesian functions: 20
-    Spherical Harmonics?: true
-    Max angular momentum: 1
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A         20      20       0       0       0       0
-   -------------------------------------------------------
-    Total      20      20       2       2       2       0
-   -------------------------------------------------------
-
-  ==> Integral Setup <==
-
-  Using in-core PK algorithm.
-   Calculation information:
-      Number of atoms:                   4
-      Number of AO shells:              12
-      Number of primitives:             20
-      Number of atomic orbitals:        20
-      Number of basis functions:        20
-
-      Integral cutoff                 1.00e-12
-      Number of threads:                 1
-
-  Performing in-core PK
-  Using 44310 doubles for integral storage.
-  We computed 3081 shell quartets total.
-  Whereas there are 3081 unique shell quartets.
-  ==> DiskJK: Disk-Based J/K Matrices <==
-
-    J tasked:                  Yes
-    K tasked:                  Yes
-    wK tasked:                  No
-    Memory (MB):               375
-    Schwarz Cutoff:          1E-12
-
-    OpenMP threads:              1
-  Minimum eigenvalue in the overlap matrix is 5.7536001511E-02.
-  Using Symmetric Orthogonalization.
-
-  SCF Guess: Generalized Wolfsberg-Helmholtz.
-
-  ==> Iterations <==
-
-                        Total Energy        Delta E     RMS |[F,P]|
-
-   @RHF iter   1:    -1.84014935812622   -1.84015e+00   2.47849e-02 
-   @RHF iter   2:    -2.01742297769517   -1.77274e-01   5.46427e-03 DIIS
-   @RHF iter   3:    -2.03075676867327   -1.33338e-02   8.10172e-04 DIIS
-   @RHF iter   4:    -2.03108069576761   -3.23927e-04   4.83230e-05 DIIS
-   @RHF iter   5:    -2.03108137217735   -6.76410e-07   3.21514e-06 DIIS
-   @RHF iter   6:    -2.03108138109902   -8.92167e-09   1.12166e-06 DIIS
-   @RHF iter   7:    -2.03108138276120   -1.66218e-09   3.00676e-07 DIIS
-   @RHF iter   8:    -2.03108138290438   -1.43176e-10   7.08609e-08 DIIS
-   @RHF iter   9:    -2.03108138291130   -6.92779e-12   6.48722e-09 DIIS
-   @RHF iter  10:    -2.03108138291133   -2.44249e-14   1.18712e-09 DIIS
-   @RHF iter  11:    -2.03108138291133   -4.88498e-15   3.01061e-10 DIIS
-   @RHF iter  12:    -2.03108138291133    0.00000e+00   5.60274e-11 DIIS
-
-  ==> Post-Iterations <==
-
-    Orbital Energies (a.u.)
-    -----------------------
-
-    Doubly Occupied:                                                      
-
-       1A     -0.831246     2A     -0.342592  
-
-    Virtual:                                                              
-
-       3A      0.129478     4A      0.165148     5A      0.393168  
-       6A      0.538096     7A      0.774720     8A      0.856941  
-       9A      1.266282    10A      1.334161    11A      1.395911  
-      12A      1.711764    13A      1.730215    14A      1.976391  
-      15A      2.251536    16A      2.286274    17A      2.404790  
-      18A      2.533391    19A      3.214030    20A      3.326443  
-
-    Final Occupation by Irrep:
-              A 
-    DOCC [     2 ]
-
-  Energy converged.
-
-  @RHF Final Energy:    -2.03108138291133
-
-   => Energetics <=
-
-    Nuclear Repulsion Energy =              3.1366905881325060
-    One-Electron Energy =                  -7.9878690268690704
-    Two-Electron Energy =                   2.8200970558252303
-    Total Energy =                         -2.0310813829113341
-
-
-
-Properties will be evaluated at   0.000000,   0.000000,   0.000000 Bohr
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
 
 Properties computed using the SCF density matrix
 
-  Nuclear Dipole Moment: (a.u.)
+  Nuclear Dipole Moment: [e a0]
      X:     0.0000      Y:     0.0000      Z:     0.0000
 
-  Electronic Dipole Moment: (a.u.)
+  Electronic Dipole Moment: [e a0]
      X:     0.0029      Y:    -0.0417      Z:    -0.0248
 
-  Dipole Moment: (a.u.)
+  Dipole Moment: [e a0]
      X:     0.0029      Y:    -0.0417      Z:    -0.0248     Total:     0.0486
 
-  Dipole Moment: (Debye)
+  Dipole Moment: [D]
      X:     0.0074      Y:    -0.1060      Z:    -0.0631     Total:     0.1235
 
 
-*** tstop() called on yorks-mac.wireless.emory.edu at Mon Dec  4 12:08:41 2017
+*** tstop() called on jeffs-mbp-2.wireless.emory.edu at Mon Sep 10 11:10:59 2018
 Module time:
-	user time   =       0.17 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.16 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.38 seconds =       0.01 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.36 seconds =       0.01 minutes
+	system time =       0.04 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
    => Loading Basis Set <=
 
     Name: STO-3G
     Role: ORBITAL
     Keyword: MINAO_BASIS
-    atoms 1-4 entry H          line    19 file /Users/york/src/psi4new/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 1-4 entry H          line    19 file /Users/jeffschriber/src/psi4-debug-install/share/psi4/basis/sto-3g.gbs 
 
 
 Reading options from the FORTE block
@@ -465,14 +470,14 @@ Calling plugin forte.so.
   ----------------------------------------------------------------------------
   A suite of quantum chemistry methods for strongly correlated electrons
 
-    git branch: master - git commit: 1c92254a
+    git branch: aci_ex_refs - git commit: d048c1c6
 
   Developed by:
     Francesco A. Evangelista, Chenyang Li, Kevin P. Hannon,
     Jeffrey B. Schriber, Tianyuan Zhang, Chenxi Cai
   ----------------------------------------------------------------------------
 
-  Size of Determinant class: 32
+  Size of Determinant class: 16
 
   ==> MO Space Information <==
 
@@ -489,86 +494,11 @@ Calling plugin forte.so.
 
   ==> Integral Transformation <==
 
-  Number of molecular orbitals:               20
-  Number of correlated molecular orbitals:    20
-  Number of frozen occupied orbitals:          0
-  Number of frozen unoccupied orbitals:        0
-
-    Molecular point group: c1
-    Full point group: C1
-
-    Geometry (in Angstrom), charge = 0, multiplicity = 1:
-
-       Center              X                  Y                   Z               Mass       
-    ------------   -----------------  -----------------  -----------------  -----------------
-           H         -0.400000000000    -0.050000000000    -0.500000000000     1.007825032070
-           H          0.400000000000    -0.050000000000    -0.500000000000     1.007825032070
-           H          0.100000000000    -0.350000000000     0.500000000000     1.007825032070
-           H         -0.100000000000     0.450000000000     0.500000000000     1.007825032070
-
-  -AO BASIS SET INFORMATION:
-    Name                   = CC-PVDZ
-    Blend                  = CC-PVDZ
-    Total number of shells = 12
-    Number of primitives   = 20
-    Number of AO           = 20
-    Number of SO           = 20
-    Maximum AM             = 1
-    Spherical Harmonics    = TRUE
-
-  -Contraction Scheme:
-    Atom   Type   All Primitives // Shells:
-   ------ ------ --------------------------
-       1     H     4s 1p // 2s 1p 
-       2     H     4s 1p // 2s 1p 
-       3     H     4s 1p // 2s 1p 
-       4     H     4s 1p // 2s 1p 
-
-  ==> AO Basis Functions <==
-
-    [ CC-PVDZ ]
-    spherical
-    ****
-    H   1
-    S   3 1.00
-                        13.01000000           0.01968500
-                         1.96200000           0.13797700
-                         0.44460000           0.47814800
-    S   1 1.00
-                         0.12200000           1.00000000
-    P   1 1.00
-                         0.72700000           1.00000000
-    ****
-    H   2
-    S   3 1.00
-                        13.01000000           0.01968500
-                         1.96200000           0.13797700
-                         0.44460000           0.47814800
-    S   1 1.00
-                         0.12200000           1.00000000
-    P   1 1.00
-                         0.72700000           1.00000000
-    ****
-    H   3
-    S   3 1.00
-                        13.01000000           0.01968500
-                         1.96200000           0.13797700
-                         0.44460000           0.47814800
-    S   1 1.00
-                         0.12200000           1.00000000
-    P   1 1.00
-                         0.72700000           1.00000000
-    ****
-    H   4
-    S   3 1.00
-                        13.01000000           0.01968500
-                         1.96200000           0.13797700
-                         0.44460000           0.47814800
-    S   1 1.00
-                         0.12200000           1.00000000
-    P   1 1.00
-                         0.72700000           1.00000000
-    ****
+  Number of molecular orbitals:                    20
+  Number of correlated molecular orbitals:         20
+  Number of frozen occupied orbitals:               0
+  Number of frozen unoccupied orbitals:             0
+  Two-electron integral type:              Conventional
 
 
   Overall Conventional Integrals timings
@@ -582,10 +512,11 @@ Calling plugin forte.so.
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
 
-  Integral transformation done. 0.03305500 s
+  Integral transformation done. 0.02996400 s
   Reading the two-electron integrals from disk
   Size of two-electron integrals:   0.003576 GB
-  Conventional integrals take 0.09826900 s
+  Timing for freezing core and virtual orbitals:              0.000 s.
+  Conventional integrals take 0.08974600 s
   Number of active alpha electrons: 2
   Number of active beta electrons: 2
   Maximum reference space size: 300
@@ -629,14 +560,18 @@ Calling plugin forte.so.
 
   Initial P space dimension: 225
   Spin-complete dimension of the P space: 225 determinants
-  Time spent building a_list   0.000788 s
-  Time spent building b_list   0.000756 s
-  Time spent building aa_list  0.000451 s
-  Time spent building bb_list  0.000444 s
-  Time spent building ab_list  0.000720 s
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000418 s
+        β          0.000483 s
+        αα         0.000341 s
+        ββ         0.000238 s
+        αβ         0.000579 s
+  --------------------------------
 
   Davidson-liu sparse algorithm
-  Time spent building H:   0.005482 s
+  Time spent building H:   0.004053 s
   H contains 20925 nonzero elements (0.319 MB)
   Initial guess space is incomplete!
   Trying to add 1 determinant(s).  1 determinant(s) added.
@@ -661,34 +596,37 @@ Calling plugin forte.so.
       8       -5.186495900664  -1.571e-11
   ----------------------------------------
   The Davidson-Liu algorithm converged in 9 iterations.
-  Davidson-Liu procedure took  0.075911 s
-  Time spent diagonalizing H:   0.081821 s
+  Davidson-Liu procedure took  0.014458 s
+  Time spent diagonalizing H:   0.018960 s
 
     P-space  CI Energy Root   0        = -2.049805312532 Eh =   0.0000 eV
 
-  Time spent forming F space:             0.353747
- td[0] = 12531 new entries
- td[0] = 0 repeat entries
-  Time spent merging thread F spaces:             0.009746
-  Time spent preparing PQ_space: 0.000114
-  Dimension of the SD space: 12306 determinants
-  Time spent building the model space (default): 0.364852 s
-
-  Time spent building sorting list: 0.024139
-  Time spent sorting: 0.006001
+  Time spent forming F space:             0.076648
+  Time spent merging thread F spaces:             0.004025
+  size of hash: 12306
+  Time spent building sorting list: 0.008601
+  Size of F space: 12306
+  Time spent sorting: 0.002571
+  total f space: 0.06799345
+  PQ space: 225
   Added 1 missing determinants in aimed selection.
- Time spent selecting: 0.000596
+  PQ space: 727
   Dimension of the P + Q space: 727 determinants
-  Time spent screening the model space: 0.031018 s
+  Time spent screening the model space: 0.000212 s
+  Time spent building the model space: 0.094393
   Spin-complete dimension of the PQ space: 841
-  Time spent building a_list   0.002024 s
-  Time spent building b_list   0.002048 s
-  Time spent building aa_list  0.001216 s
-  Time spent building bb_list  0.001107 s
-  Time spent building ab_list  0.003092 s
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.001586 s
+        β          0.001982 s
+        αα         0.001031 s
+        ββ         0.000907 s
+        αβ         0.002193 s
+  --------------------------------
 
   Davidson-liu sparse algorithm
-  Time spent building H:   0.032230 s
+  Time spent building H:   0.021126 s
   H contains 157569 nonzero elements (2.404 MB)
   Initial guess space is incomplete!
   Trying to add 9 determinant(s).  9 determinant(s) added.
@@ -717,8 +655,8 @@ Calling plugin forte.so.
      12       -5.250720778283  -2.479e-11
   ----------------------------------------
   The Davidson-Liu algorithm converged in 13 iterations.
-  Davidson-Liu procedure took  0.109041 s
-  Total time spent diagonalizing H:   0.143153 s
+  Davidson-Liu procedure took  0.041394 s
+  Total time spent diagonalizing H:   0.064468 s
 
     PQ-space CI Energy Root   0        = -2.114030190151 Eh =   0.0000 eV
     PQ-space CI Energy + EPT2 Root   0 = -2.115027122435 Eh =   0.0000 eV
@@ -735,23 +673,27 @@ Calling plugin forte.so.
     6  -0.031878 0.001016203         144 |02200000000000000000>
     7   0.028980 0.000839828         147 |-++-0000000000000000>
     8   0.028980 0.000839828         189 |+--+0000000000000000>
-    9  -0.028831 0.000831215         708 |200+000-000000000000>
+    9  -0.028831 0.000831215         707 |200+000-000000000000>
 
   Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
-  Cycle 0 took: 0.652139 s
+  Cycle 0 took: 0.194190 s
 
   ==> Cycle 1 <==
 
   Initial P space dimension: 281
   Spin-complete dimension of the P space: 367 determinants
-  Time spent building a_list   0.001000 s
-  Time spent building b_list   0.001005 s
-  Time spent building aa_list  0.000610 s
-  Time spent building bb_list  0.000659 s
-  Time spent building ab_list  0.001480 s
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000810 s
+        β          0.000804 s
+        αα         0.000439 s
+        ββ         0.000412 s
+        αβ         0.001099 s
+  --------------------------------
 
   Davidson-liu sparse algorithm
-  Time spent building H:   0.007580 s
+  Time spent building H:   0.005310 s
   H contains 36233 nonzero elements (0.553 MB)
   Initial guess space is incomplete!
   Trying to add 5 determinant(s).  5 determinant(s) added.
@@ -778,34 +720,37 @@ Calling plugin forte.so.
      10       -5.248420408014  -4.274e-11
   ----------------------------------------
   The Davidson-Liu algorithm converged in 11 iterations.
-  Davidson-Liu procedure took  0.075723 s
-  Time spent diagonalizing H:   0.083943 s
+  Davidson-Liu procedure took  0.018301 s
+  Time spent diagonalizing H:   0.024330 s
 
     P-space  CI Energy Root   0        = -2.111729819882 Eh =   0.0000 eV
 
-  Time spent forming F space:             0.833286
- td[0] = 34458 new entries
- td[0] = 0 repeat entries
-  Time spent merging thread F spaces:             0.037698
-  Time spent preparing PQ_space: 0.000227
-  Dimension of the SD space: 34091 determinants
-  Time spent building the model space (default): 0.875070 s
-
-  Time spent building sorting list: 0.064285
-  Time spent sorting: 0.014414
+  Time spent forming F space:             0.149296
+  Time spent merging thread F spaces:             0.012800
+  size of hash: 34091
+  Time spent building sorting list: 0.022931
+  Size of F space: 34091
+  Time spent sorting: 0.008018
+  total f space: 0.00462961
+  PQ space: 367
   Added 2 missing determinants in aimed selection.
- Time spent selecting: 0.001220
+  PQ space: 1043
   Dimension of the P + Q space: 1043 determinants
-  Time spent screening the model space: 0.081066 s
+  Time spent screening the model space: 0.000571 s
+  Time spent building the model space: 0.201849
   Spin-complete dimension of the PQ space: 1271
-  Time spent building a_list   0.003368 s
-  Time spent building b_list   0.003302 s
-  Time spent building aa_list  0.001734 s
-  Time spent building bb_list  0.001758 s
-  Time spent building ab_list  0.004772 s
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.002587 s
+        β          0.002583 s
+        αα         0.001310 s
+        ββ         0.001296 s
+        αβ         0.003343 s
+  --------------------------------
 
   Davidson-liu sparse algorithm
-  Time spent building H:   0.041833 s
+  Time spent building H:   0.033434 s
   H contains 245481 nonzero elements (3.746 MB)
   Initial guess found 46 solutions with 2S+1 = 1 *
   Initial guess found 46 solutions with 2S+1 = 3  
@@ -832,8 +777,8 @@ Calling plugin forte.so.
      12       -5.252105750433  -2.083e-11
   ----------------------------------------
   The Davidson-Liu algorithm converged in 13 iterations.
-  Davidson-Liu procedure took  0.134937 s
-  Total time spent diagonalizing H:   0.181533 s
+  Davidson-Liu procedure took  0.055597 s
+  Total time spent diagonalizing H:   0.091639 s
 
     PQ-space CI Energy Root   0        = -2.115415162300 Eh =   0.0000 eV
     PQ-space CI Energy + EPT2 Root   0 = -2.116414953473 Eh =   0.0000 eV
@@ -852,20 +797,24 @@ Calling plugin forte.so.
     9   0.029799 0.000887978         272 |-++-0000000000000000>
 
   Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
-  Cycle 1 took: 1.268021 s
+  Cycle 1 took: 0.341376 s
 
   ==> Cycle 2 <==
 
   Initial P space dimension: 332
   Spin-complete dimension of the P space: 412 determinants
-  Time spent building a_list   0.001213 s
-  Time spent building b_list   0.001281 s
-  Time spent building aa_list  0.001473 s
-  Time spent building bb_list  0.001564 s
-  Time spent building ab_list  0.002457 s
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000964 s
+        β          0.000889 s
+        αα         0.000484 s
+        ββ         0.000456 s
+        αβ         0.001518 s
+  --------------------------------
 
   Davidson-liu sparse algorithm
-  Time spent building H:   0.009480 s
+  Time spent building H:   0.006255 s
   H contains 43826 nonzero elements (0.669 MB)
   Initial guess found 45 solutions with 2S+1 = 1 *
   Initial guess found 45 solutions with 2S+1 = 3  
@@ -890,34 +839,37 @@ Calling plugin forte.so.
      10       -5.249323883396  -2.498e-11
   ----------------------------------------
   The Davidson-Liu algorithm converged in 11 iterations.
-  Davidson-Liu procedure took  0.077187 s
-  Time spent diagonalizing H:   0.094880 s
+  Davidson-Liu procedure took  0.017863 s
+  Time spent diagonalizing H:   0.024816 s
 
     P-space  CI Energy Root   0        = -2.112633295263 Eh =   0.0000 eV
 
-  Time spent forming F space:             0.910262
- td[0] = 34854 new entries
- td[0] = 0 repeat entries
-  Time spent merging thread F spaces:             0.036075
-  Time spent preparing PQ_space: 0.000279
-  Dimension of the SD space: 34442 determinants
-  Time spent building the model space (default): 0.950370 s
-
-  Time spent building sorting list: 0.067732
-  Time spent sorting: 0.014038
+  Time spent forming F space:             0.159192
+  Time spent merging thread F spaces:             0.013904
+  size of hash: 34442
+  Time spent building sorting list: 0.023376
+  Size of F space: 34442
+  Time spent sorting: 0.009089
+  total f space: 0.00376202
+  PQ space: 412
   Added 1 missing determinants in aimed selection.
- Time spent selecting: 0.001121
+  PQ space: 1065
   Dimension of the P + Q space: 1065 determinants
-  Time spent screening the model space: 0.084055 s
+  Time spent screening the model space: 0.000414 s
+  Time spent building the model space: 0.213581
   Spin-complete dimension of the PQ space: 1305
-  Time spent building a_list   0.003401 s
-  Time spent building b_list   0.003392 s
-  Time spent building aa_list  0.001795 s
-  Time spent building bb_list  0.001763 s
-  Time spent building ab_list  0.004764 s
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.002908 s
+        β          0.002691 s
+        αα         0.001616 s
+        ββ         0.001287 s
+        αβ         0.003296 s
+  --------------------------------
 
   Davidson-liu sparse algorithm
-  Time spent building H:   0.041740 s
+  Time spent building H:   0.032896 s
   H contains 253149 nonzero elements (3.863 MB)
   Initial guess found 46 solutions with 2S+1 = 1 *
   Initial guess found 46 solutions with 2S+1 = 3  
@@ -944,8 +896,8 @@ Calling plugin forte.so.
      12       -5.252138308776  -1.839e-11
   ----------------------------------------
   The Davidson-Liu algorithm converged in 13 iterations.
-  Davidson-Liu procedure took  0.127654 s
-  Total time spent diagonalizing H:   0.172179 s
+  Davidson-Liu procedure took  0.055587 s
+  Total time spent diagonalizing H:   0.091057 s
 
     PQ-space CI Energy Root   0        = -2.115447720644 Eh =   0.0000 eV
     PQ-space CI Energy + EPT2 Root   0 = -2.116446799678 Eh =   0.0000 eV
@@ -964,20 +916,24 @@ Calling plugin forte.so.
     9   0.029801 0.000888110         322 |-++-0000000000000000>
 
   Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
-  Cycle 2 took: 1.347990 s
+  Cycle 2 took: 0.355426 s
 
   ==> Cycle 3 <==
 
   Initial P space dimension: 334
   Spin-complete dimension of the P space: 414 determinants
-  Time spent building a_list   0.001506 s
-  Time spent building b_list   0.001811 s
-  Time spent building aa_list  0.000616 s
-  Time spent building bb_list  0.000769 s
-  Time spent building ab_list  0.004076 s
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000899 s
+        β          0.000890 s
+        αα         0.000485 s
+        ββ         0.000458 s
+        αβ         0.001218 s
+  --------------------------------
 
   Davidson-liu sparse algorithm
-  Time spent building H:   0.012441 s
+  Time spent building H:   0.006433 s
   H contains 43918 nonzero elements (0.670 MB)
   Initial guess found 45 solutions with 2S+1 = 1 *
   Initial guess found 45 solutions with 2S+1 = 3  
@@ -1002,34 +958,37 @@ Calling plugin forte.so.
      10       -5.249366104592  -2.048e-11
   ----------------------------------------
   The Davidson-Liu algorithm converged in 11 iterations.
-  Davidson-Liu procedure took  0.074283 s
-  Time spent diagonalizing H:   0.087411 s
+  Davidson-Liu procedure took  0.017696 s
+  Time spent diagonalizing H:   0.024793 s
 
     P-space  CI Energy Root   0        = -2.112675516460 Eh =   0.0000 eV
 
-  Time spent forming F space:             0.915316
- td[0] = 34854 new entries
- td[0] = 0 repeat entries
-  Time spent merging thread F spaces:             0.033843
-  Time spent preparing PQ_space: 0.000431
-  Dimension of the SD space: 34440 determinants
-  Time spent building the model space (default): 0.953346 s
-
-  Time spent building sorting list: 0.060731
-  Time spent sorting: 0.016243
+  Time spent forming F space:             0.164864
+  Time spent merging thread F spaces:             0.013777
+  size of hash: 34440
+  Time spent building sorting list: 0.022675
+  Size of F space: 34440
+  Time spent sorting: 0.010221
+  total f space: 0.00372146
+  PQ space: 414
   Added 3 missing determinants in aimed selection.
- Time spent selecting: 0.001438
+  PQ space: 1067
   Dimension of the P + Q space: 1067 determinants
-  Time spent screening the model space: 0.080203 s
+  Time spent screening the model space: 0.000547 s
+  Time spent building the model space: 0.220428
   Spin-complete dimension of the PQ space: 1317
-  Time spent building a_list   0.003899 s
-  Time spent building b_list   0.004755 s
-  Time spent building aa_list  0.001781 s
-  Time spent building bb_list  0.001814 s
-  Time spent building ab_list  0.005349 s
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.002810 s
+        β          0.002635 s
+        αα         0.001340 s
+        ββ         0.001295 s
+        αβ         0.004130 s
+  --------------------------------
 
   Davidson-liu sparse algorithm
-  Time spent building H:   0.046715 s
+  Time spent building H:   0.037547 s
   H contains 255637 nonzero elements (3.901 MB)
   Initial guess found 46 solutions with 2S+1 = 1 *
   Initial guess found 46 solutions with 2S+1 = 3  
@@ -1055,8 +1014,8 @@ Calling plugin forte.so.
      11       -5.252146138643  -9.825e-11
   ----------------------------------------
   The Davidson-Liu algorithm converged in 12 iterations.
-  Davidson-Liu procedure took  0.115985 s
-  Total time spent diagonalizing H:   0.165464 s
+  Davidson-Liu procedure took  0.051293 s
+  Total time spent diagonalizing H:   0.091564 s
 
     PQ-space CI Energy Root   0        = -2.115455550510 Eh =   0.0000 eV
     PQ-space CI Energy + EPT2 Root   0 = -2.116454736581 Eh =   0.0000 eV
@@ -1075,20 +1034,24 @@ Calling plugin forte.so.
     9  -0.029791 0.000887492         324 |-++-0000000000000000>
 
   Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
-  Cycle 3 took: 1.343783 s
+  Cycle 3 took: 0.362801 s
 
   ==> Cycle 4 <==
 
   Initial P space dimension: 334
   Spin-complete dimension of the P space: 414 determinants
-  Time spent building a_list   0.001115 s
-  Time spent building b_list   0.001187 s
-  Time spent building aa_list  0.000648 s
-  Time spent building bb_list  0.000614 s
-  Time spent building ab_list  0.001627 s
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000903 s
+        β          0.000893 s
+        αα         0.000482 s
+        ββ         0.000457 s
+        αβ         0.001221 s
+  --------------------------------
 
   Davidson-liu sparse algorithm
-  Time spent building H:   0.008549 s
+  Time spent building H:   0.006489 s
   H contains 43918 nonzero elements (0.670 MB)
   Initial guess found 45 solutions with 2S+1 = 1 *
   Initial guess found 45 solutions with 2S+1 = 3  
@@ -1113,34 +1076,37 @@ Calling plugin forte.so.
      10       -5.249366104592  -2.048e-11
   ----------------------------------------
   The Davidson-Liu algorithm converged in 11 iterations.
-  Davidson-Liu procedure took  0.077641 s
-  Time spent diagonalizing H:   0.086873 s
+  Davidson-Liu procedure took  0.017944 s
+  Time spent diagonalizing H:   0.025121 s
 
     P-space  CI Energy Root   0        = -2.112675516460 Eh =   0.0000 eV
 
-  Time spent forming F space:             0.890813
- td[0] = 34854 new entries
- td[0] = 0 repeat entries
-  Time spent merging thread F spaces:             0.033742
-  Time spent preparing PQ_space: 0.000499
-  Dimension of the SD space: 34440 determinants
-  Time spent building the model space (default): 0.932090 s
-
-  Time spent building sorting list: 0.067353
-  Time spent sorting: 0.014440
+  Time spent forming F space:             0.173039
+  Time spent merging thread F spaces:             0.011983
+  size of hash: 34440
+  Time spent building sorting list: 0.022953
+  Size of F space: 34440
+  Time spent sorting: 0.008430
+  total f space: 0.00372146
+  PQ space: 414
   Added 3 missing determinants in aimed selection.
- Time spent selecting: 0.001100
+  PQ space: 1067
   Dimension of the P + Q space: 1067 determinants
-  Time spent screening the model space: 0.084096 s
+  Time spent screening the model space: 0.000403 s
+  Time spent building the model space: 0.224920
   Spin-complete dimension of the PQ space: 1317
-  Time spent building a_list   0.003395 s
-  Time spent building b_list   0.003446 s
-  Time spent building aa_list  0.001889 s
-  Time spent building bb_list  0.002917 s
-  Time spent building ab_list  0.006330 s
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.002650 s
+        β          0.002759 s
+        αα         0.001340 s
+        ββ         0.001295 s
+        αβ         0.003393 s
+  --------------------------------
 
   Davidson-liu sparse algorithm
-  Time spent building H:   0.040910 s
+  Time spent building H:   0.033820 s
   H contains 255637 nonzero elements (3.901 MB)
   Initial guess found 46 solutions with 2S+1 = 1 *
   Initial guess found 46 solutions with 2S+1 = 3  
@@ -1166,14 +1132,13 @@ Calling plugin forte.so.
      11       -5.252146138643  -9.825e-11
   ----------------------------------------
   The Davidson-Liu algorithm converged in 12 iterations.
-  Davidson-Liu procedure took  0.126608 s
-  Total time spent diagonalizing H:   0.170939 s
+  Davidson-Liu procedure took  0.053901 s
+  Total time spent diagonalizing H:   0.090409 s
 
     PQ-space CI Energy Root   0        = -2.115455550510 Eh =   0.0000 eV
     PQ-space CI Energy + EPT2 Root   0 = -2.116454736581 Eh =   0.0000 eV
 
   ***** Calculation Converged *****
-  Not performing spin projection.
   Saving root 0, ref_root is 0
   Number of old roots: 1
 
@@ -1200,12 +1165,16 @@ Calling plugin forte.so.
     9  -0.029791 0.000887492         324 |-++-0000000000000000>
 
   Spin state for root 0: S^2 = 0.000000, S = 0.000, singlet
-  Time spent building a_list   0.003450 s
-  Time spent building b_list   0.003794 s
-  Time spent building aa_list  0.001842 s
-  Time spent building bb_list  0.001819 s
-  Time spent building ab_list  0.004793 s
-  1-RDM  took 0.008124 s (determinant)
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.003223 s
+        β          0.003068 s
+        αα         0.001343 s
+        ββ         0.001297 s
+        αβ         0.003318 s
+  --------------------------------
+  1-RDM  took 0.006891 s (determinant)
 
   ==> NATURAL ORBITALS <==
 
@@ -1218,10 +1187,14 @@ Calling plugin forte.so.
        19A      0.000049     20A      0.000044  
 
 
+  RDMS took 0.020028
 
-  Adaptive-CI ran in : 5.960751 s
+  Adaptive-CI ran in : 1.639234 s
 
   Saving information for root: 0	ACI energy........................................................PASSED
 	ACI+PT2 energy....................................................PASSED
+
+    Psi4 stopped on: Monday, 10 September 2018 11:11AM
+    Psi4 wall time for execution: 0:00:02.26
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/methods/aci-4/input.dat
+++ b/tests/methods/aci-4/input.dat
@@ -30,8 +30,6 @@ set scf {
 set forte {
   job_type = aci
   multiplicity 1
-  aci_SELECT_TYPE aimed_energy
-  aci_perturb_select false
   aci_excited_algorithm average
   aci_n_average 2
   aci_average_offset 1
@@ -39,7 +37,7 @@ set forte {
   aci_nroot 3
   aci_root 1 
   charge 0
- # aci_initial_space cis
+#  active_ref_type cis
   aci_enforce_spin_complete true
 }
 
@@ -49,4 +47,4 @@ compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
 compare_values(refaci, get_variable("ACI ENERGY"),9, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
+#compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST

--- a/tests/methods/aci-5/input.dat
+++ b/tests/methods/aci-5/input.dat
@@ -27,8 +27,6 @@ set {
 
 set forte {
   job_type aci
-  aci_SELECT_TYPE aimed_energy
-  aci_perturb_select false
   aci_excited_algorithm state_average
   aci_pq_function average
   aci_root 0

--- a/tests/methods/aci-6/input.dat
+++ b/tests/methods/aci-6/input.dat
@@ -32,7 +32,6 @@ set {
 set forte {
   JOB_TYPE aci
   multiplicity 1
-  aci_SELECT_TYPE aimed_energy
   sigma 0.07
   aci_nroot 1
   charge 0

--- a/tests/methods/aci-7/input.dat
+++ b/tests/methods/aci-7/input.dat
@@ -31,7 +31,6 @@ set {
 set forte {
   job_type = aci
   multiplicity 1
-  aci_select_type aimed_energy
   frozen_docc [1,0,0,0,0,1,0,0]
   sigma 0.08
   aci_excited_algorithm average

--- a/tests/methods/aci-8/input.dat
+++ b/tests/methods/aci-8/input.dat
@@ -28,7 +28,7 @@ set {
 
 set forte {
   job_type aci
-  aci_SELECT_TYPE amp
+#  aci_SELECT_TYPE amp
   aci_add_aimed_degenerate false
   aci_project_out_spin_contaminants false
   aci_enforce_spin_complete false

--- a/tests/methods/aci-9/input.dat
+++ b/tests/methods/aci-9/input.dat
@@ -25,7 +25,6 @@ set {
 
 set forte {
   job_type aci
-  aci_select_type aimed_energy
   aci_add_aimed_degenerate false
   aci_enforce_spin_complete false
   frozen_docc [1,0,0,0,0,1,0,0]

--- a/tests/methods/aci-mrcisd-1/input.dat
+++ b/tests/methods/aci-mrcisd-1/input.dat
@@ -35,7 +35,6 @@ set forte {
   active [1,0,1,0]
   root_sym 0
   multiplicity 1
-  aci_SELECT_TYPE aimed_energy
   sigma 0.8
   aci_prescreen_threshold 0.0
   aci_max_cycle 1

--- a/tests/methods/aci_scf-1/input.dat
+++ b/tests/methods/aci_scf-1/input.dat
@@ -51,7 +51,7 @@ set forte{
    sigma                    0.0
    gamma                    0.0
    job_type                 CASSCF
-   aci_select_type              amp
+#   aci_select_type              amp
 }
 
 

--- a/tests/methods/cis-aci-1/input.dat
+++ b/tests/methods/cis-aci-1/input.dat
@@ -28,15 +28,16 @@ set forte {
   frozen_docc [1,0,0,0,0,1,0,0]
   sigma 0.05
   charge 0
+  nroot 2
   aci_nroot 2
   aci_n_average 2
-  ACI_INITIAL_SPACE CIS
+  active_ref_type CIS
   aci_excited_algorithm average
   aci_pq_function average
+  aci_screen_alg average
 }
 
 energy('scf')
 compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
 energy('forte')
 compare_values(refaci, get_variable("ACI ENERGY"),10, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),10, "ACI+PT2 energy") #TEST


### PR DESCRIPTION
Options and user interface need to be cleaned up for selecting a reference root in ACI for subsequent use in a DSRG computation. Accomplishing this is simple, but it could be complicated by the various excited state algorithms of ACI.

Added goal: Use bit masks to generalize any restrictions on the screening of determinants.

- [ ] Ready to go