### PR TITLE
Run Forte via Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ src/mrpt2.cc
 src/operator.cc
 src/options.cc
 src/orbitaloptimizer.cc
+src/python_api.cc
 src/reference.cc
 src/sa_fcisolver.cc
 src/semi_canonicalize.cc

--- a/__init__.py
+++ b/__init__.py
@@ -44,4 +44,4 @@ from .forte import *
 # Register options with psi
 options = psi4.core.get_options()
 options.set_current_module('FORTE')
-forte.read_forte_options(psi4.core.get_options())
+forte.read_options(psi4.core.get_options())

--- a/__init__.py
+++ b/__init__.py
@@ -30,15 +30,18 @@
 """Plugin docstring.
 
 """
-__version__ = '0.1'
-__author__  = 'Psi4 Developer'
+__version__ = '1.0'
+__author__  = 'Forte Developers'
 
 # Load Python modules
 from .pymodule import *
 
 # Load C++ plugin
-import os
+#import os
 import psi4
-plugdir = os.path.split(os.path.abspath(__file__))[0]
-sofile = plugdir + '/' + os.path.split(plugdir)[1] + '.so'
-psi4.core.plugin_load(sofile)
+from .forte import *
+
+# Register options with psi
+options = psi4.core.get_options()
+options.set_current_module('FORTE')
+forte.read_forte_options(psi4.core.get_options())

--- a/pymodule.py
+++ b/pymodule.py
@@ -66,11 +66,11 @@ def run_forte(name, **kwargs):
         ref_wfn.set_basisset('MINAO_BASIS', minao_basis)
 
     # Start Forte, initialize ambit
-    my_proc_n_nodes = forte.forte_startup()
+    my_proc_n_nodes = forte.startup()
     my_proc, n_nodes = my_proc_n_nodes
 
     # Print the banner
-    forte.forte_banner()
+    forte.banner()
 
     # Create the MOSpaceInfo object
     mo_space_info = forte.make_mo_space_info(ref_wfn, options)
@@ -97,7 +97,7 @@ def run_forte(name, **kwargs):
         #print('\n\n  Your calculation took ', (end - start), ' seconds');
 
     # Close ambit, etc.
-    forte.forte_cleanup()
+    forte.cleanup()
     return ref_wfn
 
 # Integration with driver routines

--- a/pymodule.py
+++ b/pymodule.py
@@ -50,10 +50,9 @@ def run_forte(name, **kwargs):
     if ref_wfn is None:
         ref_wfn = psi4.driver.scf_helper(name, **kwargs)
 
+    # Get the option object
     options = psi4.core.get_options()
     options.set_current_module('FORTE')
-    options.print()
-    options.print_globals()
 
     if ('DF' in options.get_str('INT_TYPE')):
         aux_basis = psi4.core.BasisSet.build(ref_wfn.molecule(), 'DF_BASIS_MP2',

--- a/src/aci/aci.cc
+++ b/src/aci/aci.cc
@@ -27,6 +27,7 @@
  * @END LICENSE
  */
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/pointgrp.h"

--- a/src/aci/aci_build_F.cc
+++ b/src/aci/aci_build_F.cc
@@ -1,3 +1,5 @@
+#include "psi4/libpsi4util/libpsi4util.h"
+
 #include "aci.h"
 
 namespace psi {

--- a/src/asci.cc
+++ b/src/asci.cc
@@ -27,6 +27,7 @@
  * @END LICENSE
  */
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/pointgrp.h"

--- a/src/avas.cc
+++ b/src/avas.cc
@@ -1,10 +1,39 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Forte: an open-source plugin to Psi4 (https://github.com/psi4/psi4)
+ * that implements a variety of quantum chemistry methods for strongly
+ * correlated electrons.
+ *
+ * Copyright (c) 2012-2017 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ * @END LICENSE
+ */
+
+#include <algorithm>
+#include <cmath>
+
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libmints/vector.h"
 
 #include "avas.h"
-
-#include <cmath>
 
 namespace psi {
 namespace forte {

--- a/src/blockedtensorfactory.cc
+++ b/src/blockedtensorfactory.cc
@@ -35,6 +35,7 @@
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libpsi4util/process.h"
 
+#include <algorithm>
 #include <string>
 #include <tuple>
 #include <vector>

--- a/src/casscf.cc
+++ b/src/casscf.cc
@@ -30,6 +30,7 @@
 #include "integrals/integrals.h"
 #include "reference.h"
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libfock/jk.h"
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/wavefunction.h"

--- a/src/ci-no/ci-no.cc
+++ b/src/ci-no/ci-no.cc
@@ -27,9 +27,10 @@
  * @END LICENSE
  */
 
+#include "psi4/psi4-dec.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/pointgrp.h"
-#include "psi4/psi4-dec.h"
 
 #include "../ci_rdm/ci_rdms.h"
 #include "../fci/fci_integrals.h"
@@ -37,7 +38,6 @@
 #include "../sparse_ci/sparse_ci_solver.h"
 #include "../sparse_ci/determinant.h"
 #include "ci-no.h"
-//#include "../hash_vector.h"
 
 namespace psi {
 namespace forte {

--- a/src/ci-no/mrci-no.cc
+++ b/src/ci-no/mrci-no.cc
@@ -27,9 +27,10 @@
  * @END LICENSE
  */
 
+#include "psi4/libpsi4util/libpsi4util.h"
+#include "psi4/psi4-dec.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/pointgrp.h"
-#include "psi4/psi4-dec.h"
 
 #include "../ci_rdm/ci_rdms.h"
 #include "../fci/fci_integrals.h"

--- a/src/ci_rdm/ci_rdms.cc
+++ b/src/ci_rdm/ci_rdms.cc
@@ -29,6 +29,7 @@
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/liboptions/liboptions.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
 
 #include "ci_rdms.h"

--- a/src/ci_rdm/ci_rdms_dynamic.cc
+++ b/src/ci_rdm/ci_rdms_dynamic.cc
@@ -29,6 +29,7 @@
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/liboptions/liboptions.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
 
 #include "ci_rdms.h"

--- a/src/fci/fci_solver.cc
+++ b/src/fci/fci_solver.cc
@@ -26,6 +26,7 @@
  * @END LICENSE
  */
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libmints/molecule.h"
 
@@ -44,16 +45,6 @@
 #include "psi4/psi4-dec.h"
 
 using namespace psi;
-
-// extern double h1_aa_timer;
-// extern double h1_bb_timer;
-// extern double h2_aaaa_timer;
-// extern double h2_aabb_timer;
-// extern double h2_bbbb_timer;
-// extern double oo_list_timer;
-// extern double vo_list_timer;
-// extern double vovo_list_timer;
-// extern double vvoo_list_timer;
 
 int fci_debug_level = 4;
 

--- a/src/fci/fci_vector_rdm.cc
+++ b/src/fci/fci_vector_rdm.cc
@@ -28,10 +28,11 @@
 
 #include <cmath>
 
+#include "psi4/psi4-dec.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libqt/qt.h"
-#include "psi4/psi4-dec.h"
 
 #include "../helpers.h"
 #include "../sparse_ci/determinant.h"

--- a/src/fci_mo.cc
+++ b/src/fci_mo.cc
@@ -33,6 +33,7 @@
 #include <numeric>
 #include <sstream>
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libmints/dipole.h"
 #include "psi4/libmints/oeprop.h"
 #include "psi4/libmints/petitelist.h"
@@ -1451,8 +1452,9 @@ void FCI_MO::compute_permanent_dipole() {
     std::vector<SharedMatrix> aodipole_ints = integral_->AOdipole_ints();
 
     // Nuclear dipole contribution
-    SharedVector ndip =
-        DipoleInt::nuclear_contribution(Process::environment.molecule(), Vector3(0.0, 0.0, 0.0));
+    Vector3 ndip =
+            Process::environment.molecule()->nuclear_dipole(Vector3(0.0, 0.0, 0.0));
+//        DipoleInt::nuclear_contribution(Process::environment.molecule(), );
 
     // SO to AO transformer
     SharedMatrix sotoao(this->aotoso()->transpose());
@@ -1483,8 +1485,8 @@ void FCI_MO::compute_permanent_dipole() {
         std::vector<double> de(4, 0.0);
         for (int i = 0; i < 3; ++i) {
             de[i] = 2.0 * AOdens->vector_dot(aodipole_ints[i]); // 2.0 for beta spin
-            de[i] += ndip->get(i);                              // add nuclear contributions
-            de[3] += de[i] * de[i];
+            de[i] += ndip[i];                                   // add nuclear contributions
+            de[3] += de[i] * de[i];                             // store de * de in the fourth dim
         }
         de[3] = sqrt(de[3]);
 

--- a/src/forte.h
+++ b/src/forte.h
@@ -33,14 +33,14 @@ namespace forte {
 
 void forte_options(ForteOptions& options);
 
-void forte_banner();
+std::pair<int, int> startup();
+void banner();
+void cleanup();
 
 int read_options(Options& options);
 SharedWavefunction run_forte(SharedWavefunction ref_wfn, Options& options);
 
-std::pair<int, int> forte_startup();
 
-void forte_cleanup();
 
 std::shared_ptr<MOSpaceInfo> make_mo_space_info(SharedWavefunction ref_wfn, Options& options);
 

--- a/src/forte.h
+++ b/src/forte.h
@@ -31,20 +31,12 @@
 namespace psi {
 namespace forte {
 
-void forte_options(std::string name, ForteOptions& options);
+void forte_options(ForteOptions& options);
 
 void forte_banner();
 
-int read_forte_options(std::string name, Options& options);
+int read_options(Options& options);
 SharedWavefunction run_forte(SharedWavefunction ref_wfn, Options& options);
-
-int api_forte_read_options(Options& options);
-SharedWavefunction api_run_forte(SharedWavefunction ref_wfn, Options& options);
-}
-}
-
-namespace psi {
-namespace forte {
 
 std::pair<int, int> forte_startup();
 

--- a/src/forte.h
+++ b/src/forte.h
@@ -34,12 +34,14 @@ namespace forte {
 void forte_options(std::string name, ForteOptions& options);
 
 void forte_banner();
-}
-}
 
-/// These functions replace the Memory Allocator in GA with C/C++ allocator.
-void* replace_malloc(size_t bytes, int align, char* name) { return malloc(bytes); }
-void replace_free(void* ptr) { free(ptr); }
+int read_forte_options(std::string name, Options& options);
+SharedWavefunction run_forte(SharedWavefunction ref_wfn, Options& options);
+
+int api_forte_read_options(Options& options);
+SharedWavefunction api_run_forte(SharedWavefunction ref_wfn, Options& options);
+}
+}
 
 namespace psi {
 namespace forte {

--- a/src/forte_old_methods.cc
+++ b/src/forte_old_methods.cc
@@ -33,6 +33,7 @@
 #include "boost/format.hpp"
 #include <ambit/tensor.h>
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/wavefunction.h"

--- a/src/integrals/cholesky_integrals.cc
+++ b/src/integrals/cholesky_integrals.cc
@@ -29,6 +29,7 @@
 #include <cmath>
 #include <cstring>
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libmints/basisset.h"
 #include "psi4/libmints/wavefunction.h"

--- a/src/integrals/conventional_integrals.cc
+++ b/src/integrals/conventional_integrals.cc
@@ -28,12 +28,13 @@
 
 #include <cmath>
 
+#include "psi4/psi4-dec.h"
+#include "psi4/psifiles.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libdpd/dpd.h"
 #include "psi4/libmints/mintshelper.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libtrans/integraltransform.h"
-#include "psi4/psi4-dec.h"
-#include "psi4/psifiles.h"
 
 #include "../blockedtensorfactory.h"
 #include "../helpers.h"

--- a/src/integrals/df_integrals.cc
+++ b/src/integrals/df_integrals.cc
@@ -29,6 +29,7 @@
 #include <cmath>
 #include <numeric>
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libmints/basisset.h"
 #include "psi4/libmints/matrix.h"

--- a/src/integrals/diskdf_integrals.cc
+++ b/src/integrals/diskdf_integrals.cc
@@ -29,6 +29,7 @@
 #include <cmath>
 #include <numeric>
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libmints/basisset.h"
 #include "psi4/libmints/matrix.h"

--- a/src/integrals/integrals.cc
+++ b/src/integrals/integrals.cc
@@ -41,6 +41,7 @@
 #include "psi4/libtrans/integraltransform.h"
 #include "psi4/psi4-dec.h"
 #include "psi4/psifiles.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 
 #include "../blockedtensorfactory.h"
 #include "../forte_options.h"

--- a/src/main.cc
+++ b/src/main.cc
@@ -110,7 +110,7 @@ int read_options(Options& options) {
  * once before running forte should go here.
  * @return The pair (my_proc,n_nodes)
  */
-std::pair<int, int> forte_startup() {
+std::pair<int, int> startup() {
     ambit::initialize();
 
 #ifdef HAVE_MPI
@@ -139,7 +139,7 @@ std::pair<int, int> forte_startup() {
  * @brief Finalize ambit, MPI, and GA. All functions that need to be called
  * once after running forte should go here.
  */
-void forte_cleanup() {
+void cleanup() {
 
 #ifdef HAVE_GA
     GA_Terminate();
@@ -215,7 +215,7 @@ std::shared_ptr<ForteIntegrals> make_forte_integrals(SharedWavefunction ref_wfn,
     return ints;
 }
 
-void forte_banner() {
+void banner() {
     outfile->Printf(
         "\n"
         "  Forte\n"
@@ -228,8 +228,6 @@ void forte_banner() {
         "  ----------------------------------------------------------------------------\n",
         GIT_BRANCH, GIT_COMMIT_HASH);
     outfile->Printf("\n  Size of Determinant class: %d", sizeof(Determinant));
-    //    std::cout << "\n " << Determinant::alfa_mask << std::endl;
-    //    std::cout << "\n " << Determinant::beta_mask << std::endl;
 }
 
 } // namespace forte

--- a/src/mcsrgpt2_mo.h
+++ b/src/mcsrgpt2_mo.h
@@ -30,6 +30,7 @@
 #define _mcsrgpt2_mo_h_
 
 #include "boost/assign.hpp"
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/liboptions/liboptions.h"
 #include "psi4/libmints/vector.h"
 #include "psi4/libmints/matrix.h"

--- a/src/mrci.cc
+++ b/src/mrci.cc
@@ -27,6 +27,7 @@
  * @END LICENSE
  */
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/wavefunction.h"

--- a/src/mrdsrg-so/mrdsrg_so.cc
+++ b/src/mrdsrg-so/mrdsrg_so.cc
@@ -30,6 +30,7 @@
 #include <map>
 #include <vector>
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libmints/molecule.h"
 

--- a/src/mrdsrg-spin-adapted/dsrg_mrpt_2nd.cc
+++ b/src/mrdsrg-spin-adapted/dsrg_mrpt_2nd.cc
@@ -28,9 +28,10 @@
 
 #include <utility>
 
-#include "dsrg_mrpt.h"
-
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+
+#include "dsrg_mrpt.h"
 
 namespace psi {
 namespace forte {

--- a/src/mrdsrg-spin-adapted/dsrg_mrpt_amp.cc
+++ b/src/mrdsrg-spin-adapted/dsrg_mrpt_amp.cc
@@ -28,6 +28,7 @@
 
 #include "boost/format.hpp"
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 
 #include "dsrg_mrpt.h"

--- a/src/mrdsrg-spin-adapted/dsrg_mrpt_comm.cc
+++ b/src/mrdsrg-spin-adapted/dsrg_mrpt_comm.cc
@@ -26,6 +26,7 @@
  * @END LICENSE
  */
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 
 #include "dsrg_mrpt.h"

--- a/src/mrdsrg-spin-integrated/active_dsrgpt2.cc
+++ b/src/mrdsrg-spin-integrated/active_dsrgpt2.cc
@@ -37,6 +37,7 @@
 #include "psi4/libmints/dipole.h"
 #include "psi4/libmints/petitelist.h"
 #include "psi4/libmints/dimension.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 
 #include "psi4/physconst.h"
 

--- a/src/mrdsrg-spin-integrated/dsrg_mrpt2.cc
+++ b/src/mrdsrg-spin-integrated/dsrg_mrpt2.cc
@@ -36,6 +36,8 @@
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libqt/qt.h"
 #include "psi4/libmints/dipole.h"
+#include "psi4/libpsi4util/libpsi4util.h"
+
 
 #include "../ci_rdm/ci_rdms.h"
 #include "../fci/fci.h"

--- a/src/mrdsrg-spin-integrated/dsrg_mrpt2_ms.cc
+++ b/src/mrdsrg-spin-integrated/dsrg_mrpt2_ms.cc
@@ -28,6 +28,8 @@
 
 #include <iomanip>
 
+#include "psi4/libpsi4util/libpsi4util.h"
+
 #include "../ci_rdm/ci_rdms.h"
 #include "../fci/fci_solver.h"
 #include "../fci_mo.h"

--- a/src/mrdsrg-spin-integrated/dsrg_mrpt3.cc
+++ b/src/mrdsrg-spin-integrated/dsrg_mrpt3.cc
@@ -34,6 +34,7 @@
 #include <fstream>
 #include <iostream>
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libpsio/psio.h"
 #include "psi4/libpsio/psio.hpp"

--- a/src/mrdsrg-spin-integrated/master_mrdsrg.cc
+++ b/src/mrdsrg-spin-integrated/master_mrdsrg.cc
@@ -1,5 +1,6 @@
 #include <numeric>
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/dipole.h"
@@ -431,10 +432,9 @@ void MASTER_DSRG::init_dm_ints() {
     outfile->Printf("\n    Preparing ambit tensors for dipole moments ...... ");
     dm_.clear();
     dm_nuc_ = std::vector<double>(3, 0.0);
-    SharedVector dm_nuc =
-        DipoleInt::nuclear_contribution(Process::environment.molecule(), Vector3(0.0, 0.0, 0.0));
+    Vector3 dm_nuc = Process::environment.molecule()->nuclear_dipole(Vector3(0.0, 0.0, 0.0));
     for (int i = 0; i < 3; ++i) {
-        dm_nuc_[i] = dm_nuc->get(i);
+        dm_nuc_[i] = dm_nuc[i];
         BlockedTensor dm_i = BTF_->build(tensor_type_, "Dipole " + dm_dirs_[i], spin_cases({"gg"}));
         dm_.emplace_back(dm_i);
     }

--- a/src/mrdsrg-spin-integrated/mrdsrg_amplitude.cc
+++ b/src/mrdsrg-spin-integrated/mrdsrg_amplitude.cc
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "psi4/psi4-dec.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 
 #include "../helpers.h"

--- a/src/mrdsrg-spin-integrated/mrdsrg_commutator.cc
+++ b/src/mrdsrg-spin-integrated/mrdsrg_commutator.cc
@@ -30,9 +30,12 @@
 #include <map>
 #include <vector>
 
-#include "psi4/libpsi4util/PsiOutStream.h"
-#include "../helpers.h"
 #include "boost/format.hpp"
+
+#include "psi4/libpsi4util/libpsi4util.h"
+#include "psi4/libpsi4util/PsiOutStream.h"
+
+#include "../helpers.h"
 #include "mrdsrg.h"
 
 namespace psi {

--- a/src/mrdsrg-spin-integrated/mrdsrg_nonpt.cc
+++ b/src/mrdsrg-spin-integrated/mrdsrg_nonpt.cc
@@ -33,8 +33,9 @@
 #include <memory>
 #include <vector>
 
-#include "psi4/libdiis/diismanager.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
+#include "psi4/libdiis/diismanager.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libqt/qt.h"
 

--- a/src/mrdsrg-spin-integrated/mrdsrg_pt.cc
+++ b/src/mrdsrg-spin-integrated/mrdsrg_pt.cc
@@ -32,8 +32,9 @@
 #include <memory>
 #include <vector>
 
-#include "psi4/libdiis/diismanager.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libdiis/diismanager.h"
 
 #include "../helpers.h"
 #include "boost/format.hpp"

--- a/src/mrdsrg-spin-integrated/three_dsrg_mrpt2.cc
+++ b/src/mrdsrg-spin-integrated/three_dsrg_mrpt2.cc
@@ -43,6 +43,7 @@
 #define GA_Nodeid() 0
 #endif
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/lib3index/dftensor.h"
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/molecule.h"

--- a/src/mrpt2.cc
+++ b/src/mrpt2.cc
@@ -27,6 +27,7 @@
  * @END LICENSE
  */
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/liboptions/liboptions.h"

--- a/src/operator.cc
+++ b/src/operator.cc
@@ -28,6 +28,7 @@
 
 #include <cmath>
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libmints/dimension.h"
 
 #include "operator.h"

--- a/src/options.cc
+++ b/src/options.cc
@@ -44,7 +44,7 @@
 namespace psi {
 namespace forte {
 
-void forte_options(std::string name, ForteOptions& foptions) {
+void forte_options(ForteOptions& foptions) {
 
     // Method-specific options
     set_FCI_options(foptions);

--- a/src/orbital-helper/es-nos.cc
+++ b/src/orbital-helper/es-nos.cc
@@ -27,6 +27,7 @@
  * @END LICENSE
  */
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/wavefunction.h"

--- a/src/orbitaloptimizer.cc
+++ b/src/orbitaloptimizer.cc
@@ -38,6 +38,7 @@
 #include "psi4/libqt/qt.h"
 #include "psi4/psifiles.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 
 #include "orbitaloptimizer.h"
 

--- a/src/pci/ewci.cc
+++ b/src/pci/ewci.cc
@@ -39,6 +39,7 @@
 #include "boost/format.hpp"
 #include "boost/math/special_functions/bessel.hpp"
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libmints/matrix.h"

--- a/src/pci/pci.cc
+++ b/src/pci/pci.cc
@@ -35,6 +35,7 @@
 #include "boost/format.hpp"
 #include "boost/math/special_functions/bessel.hpp"
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libmints/matrix.h"

--- a/src/pci/pci_hashvec.cc
+++ b/src/pci/pci_hashvec.cc
@@ -37,6 +37,7 @@
 #include "boost/format.hpp"
 #include "boost/math/special_functions/bessel.hpp"
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libmints/matrix.h"

--- a/src/pci/pci_simple.cc
+++ b/src/pci/pci_simple.cc
@@ -34,6 +34,7 @@
 #include "boost/format.hpp"
 #include "boost/math/special_functions/bessel.hpp"
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libciomr/libciomr.h"
 #include "psi4/libmints/matrix.h"

--- a/src/python_api.cc
+++ b/src/python_api.cc
@@ -44,31 +44,9 @@ namespace py = pybind11;
 namespace psi {
 namespace forte {
 
-/**
- * @brief Wrapper of the main forte function for the pybind11 interface
- */
-int api_forte_read_options(Options& options) {
-    //    Process::environment.options.set_read_globals(true);
-    int value = read_forte_options("FORTE", options); // options are not read by default
-    //    Process::environment.options.set_read_globals(false);
-    return value;
-}
-
-int add(int a, int b) { return a + b; }
-
-/**
- * @brief Wrapper of the main forte function for the pybind11 interface
- */
-SharedWavefunction api_run_forte(SharedWavefunction ref_wfn, Options& options) {
-    options.set_current_module("FORTE");
-    return run_forte(ref_wfn, options);
-}
-
 PYBIND11_MODULE(forte, m) {
     m.doc() = "pybind11 Forte module"; // module docstring
-    m.def("read_forte_options", &api_forte_read_options, "Read Forte options");
-    m.def("run_forte", &api_run_forte, "Run Forte plugin");
-    m.def("add", &add, "Run Forte plugin");
+    m.def("read_options", &read_options, "Read Forte options");
     m.def("forte_startup", &forte_startup);
     m.def("forte_cleanup", &forte_cleanup);
     m.def("forte_banner", &forte_banner, "Print forte banner");

--- a/src/python_api.cc
+++ b/src/python_api.cc
@@ -1,0 +1,95 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Forte: an open-source plugin to Psi4 (https://github.com/psi4/psi4)
+ * t    hat implements a variety of quantum chemistry methods for strongly
+ * correlated electrons.
+ *
+ * Copyright (c) 2012-2017 by its authors (see LICENSE, AUTHORS).
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ * @END LICENSE
+ */
+
+#ifndef _python_api_h_
+#define _python_api_h_
+
+#include <pybind11/pybind11.h>
+
+#include "psi4/libpsi4util/process.h"
+#include "psi4/libmints/wavefunction.h"
+
+#include "helpers.h"
+#include "integrals/integrals.h"
+#include "orbital-helper/localize.h"
+#include "forte.h"
+
+namespace py = pybind11;
+
+namespace psi {
+namespace forte {
+
+/**
+ * @brief Wrapper of the main forte function for the pybind11 interface
+ */
+int api_forte_read_options(Options& options) {
+    //    Process::environment.options.set_read_globals(true);
+    int value = read_forte_options("FORTE", options); // options are not read by default
+    //    Process::environment.options.set_read_globals(false);
+    return value;
+}
+
+int add(int a, int b) { return a + b; }
+
+/**
+ * @brief Wrapper of the main forte function for the pybind11 interface
+ */
+SharedWavefunction api_run_forte(SharedWavefunction ref_wfn, Options& options) {
+    options.set_current_module("FORTE");
+    return run_forte(ref_wfn, options);
+}
+
+PYBIND11_MODULE(forte, m) {
+    m.doc() = "pybind11 Forte module"; // module docstring
+    m.def("read_forte_options", &api_forte_read_options, "Read Forte options");
+    m.def("run_forte", &api_run_forte, "Run Forte plugin");
+    m.def("add", &add, "Run Forte plugin");
+    m.def("forte_startup", &forte_startup);
+    m.def("forte_cleanup", &forte_cleanup);
+    m.def("forte_banner", &forte_banner, "Print forte banner");
+    m.def("make_mo_space_info", &make_mo_space_info, "Make a MOSpaceInfo object");
+    m.def("make_aosubspace_projector", &make_aosubspace_projector, "Make a AOSubspace projector");
+    m.def("make_forte_integrals", &make_forte_integrals, "Make Forte integrals");
+    m.def("forte_old_methods", &forte_old_methods, "Run Forte methods");
+    // export MOSpaceInfo
+    py::class_<MOSpaceInfo, std::shared_ptr<MOSpaceInfo>>(m, "MOSpaceInfo")
+        .def("size", &MOSpaceInfo::size);
+
+    // export ForteIntegrals
+    py::class_<ForteIntegrals, std::shared_ptr<ForteIntegrals>>(m, "ForteIntegrals");
+
+    // export Localize
+    py::class_<LOCALIZE, std::shared_ptr<LOCALIZE>>(m, "LOCALIZE")
+        .def(py::init<std::shared_ptr<Wavefunction>, Options&, std::shared_ptr<ForteIntegrals>,
+                      std::shared_ptr<MOSpaceInfo>>())
+        .def("split_localize", &LOCALIZE::split_localize)
+        .def("full_localize", &LOCALIZE::split_localize);
+}
+}
+}
+#endif // _python_api_h_

--- a/src/python_api.cc
+++ b/src/python_api.cc
@@ -47,9 +47,9 @@ namespace forte {
 PYBIND11_MODULE(forte, m) {
     m.doc() = "pybind11 Forte module"; // module docstring
     m.def("read_options", &read_options, "Read Forte options");
-    m.def("forte_startup", &forte_startup);
-    m.def("forte_cleanup", &forte_cleanup);
-    m.def("forte_banner", &forte_banner, "Print forte banner");
+    m.def("startup", &startup);
+    m.def("cleanup", &cleanup);
+    m.def("banner", &banner, "Print forte banner");
     m.def("make_mo_space_info", &make_mo_space_info, "Make a MOSpaceInfo object");
     m.def("make_aosubspace_projector", &make_aosubspace_projector, "Make a AOSubspace projector");
     m.def("make_forte_integrals", &make_forte_integrals, "Make Forte integrals");

--- a/src/semi_canonicalize.cc
+++ b/src/semi_canonicalize.cc
@@ -36,6 +36,7 @@
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/vector.h"
 
+#include "psi4/libpsi4util/libpsi4util.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
 
 #include "blockedtensorfactory.h"

--- a/src/sparse_ci/sigma_vector.cc
+++ b/src/sparse_ci/sigma_vector.cc
@@ -32,7 +32,7 @@
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/vector.h"
 #include "psi4/libpsio/psio.hpp"
-#include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 
 #include "../forte-def.h"
 #include "../iterative_solvers.h"

--- a/src/sparse_ci/sparse_ci_solver.cc
+++ b/src/sparse_ci/sparse_ci_solver.cc
@@ -34,6 +34,7 @@
 #include "psi4/libmints/vector.h"
 #include "psi4/libpsio/psio.hpp"
 #include "psi4/libqt/qt.h"
+#include "psi4/libpsi4util/libpsi4util.h"
 
 #include "../forte-def.h"
 #include "../iterative_solvers.h"

--- a/tests/large_det/aci-1/input.dat
+++ b/tests/large_det/aci-1/input.dat
@@ -39,10 +39,10 @@ set forte {
 
 E, wfn = energy('scf', return_wfn=True)
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9,"SCF energy")
+compare_values(refscf, variable("CURRENT ENERGY"),9,"SCF energy")
 
 energy('forte', ref_wfn=wfn)
 
-compare_values(refaci, get_variable("ACI ENERGY"),9,"ACI energy")
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),9,"ACI+PT2 energy")
+compare_values(refaci, variable("ACI ENERGY"),9,"ACI energy")
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),9,"ACI+PT2 energy")
 

--- a/tests/methods/FT-CASCI-1/input.dat
+++ b/tests/methods/FT-CASCI-1/input.dat
@@ -39,7 +39,7 @@ set forte {
 
 
 energy('scf')
-#compare_values(refscf, get_variable("CURRENT ENERGY"),11, "SCF energy") #TEST
+#compare_values(refscf, variable("CURRENT ENERGY"),11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(reffci, get_variable("CURRENT ENERGY"),11, "FCI energy") #TEST
+compare_values(reffci, variable("CURRENT ENERGY"),11, "FCI energy") #TEST

--- a/tests/methods/aci-1/input.dat
+++ b/tests/methods/aci-1/input.dat
@@ -44,8 +44,8 @@ set forte {
 
 energy('scf')
 
-#compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+#compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),9, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),9, "ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST

--- a/tests/methods/aci-10/input.dat
+++ b/tests/methods/aci-10/input.dat
@@ -56,7 +56,7 @@ scf = energy('scf')
 compare_values(refscf, scf,10,"SCF Energy")
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),10,"ACI energy")
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8,"ACI+PT2 energy")
+compare_values(refaci, variable("ACI ENERGY"),10,"ACI energy")
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8,"ACI+PT2 energy")
 
 

--- a/tests/methods/aci-11/input.dat
+++ b/tests/methods/aci-11/input.dat
@@ -48,8 +48,8 @@ set forte {
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),9, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),7, "ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),9, "ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),7, "ACI+PT2 energy") #TEST

--- a/tests/methods/aci-12/input.dat
+++ b/tests/methods/aci-12/input.dat
@@ -45,8 +45,8 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),9, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),9, "ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST

--- a/tests/methods/aci-13/input.dat
+++ b/tests/methods/aci-13/input.dat
@@ -46,8 +46,8 @@ set forte {
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),9, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),7, "ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),9, "ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),7, "ACI+PT2 energy") #TEST

--- a/tests/methods/aci-14/input.dat
+++ b/tests/methods/aci-14/input.dat
@@ -44,9 +44,9 @@ set_num_threads(8)
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy")
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy")
 
 energy('forte')
 
-compare_values(refaci, get_variable("ACI ENERGY"),9, "ACI energy")
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy")
+compare_values(refaci, variable("ACI ENERGY"),9, "ACI energy")
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy")

--- a/tests/methods/aci-15/input.dat
+++ b/tests/methods/aci-15/input.dat
@@ -47,8 +47,8 @@ set forte {
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),9, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),7, "ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),9, "ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),7, "ACI+PT2 energy") #TEST

--- a/tests/methods/aci-16/input.dat
+++ b/tests/methods/aci-16/input.dat
@@ -35,7 +35,7 @@ set forte {
 
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"),11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(reffci, get_variable("CURRENT ENERGY"),11, "ACI energy") #TEST
+compare_values(reffci, variable("CURRENT ENERGY"),11, "ACI energy") #TEST

--- a/tests/methods/aci-17/input.dat
+++ b/tests/methods/aci-17/input.dat
@@ -43,8 +43,8 @@ set forte {
 }
 
 e_scf, scf_wfn = energy('scf', return_wfn=True)
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte', ref_wfn = scf_wfn)
-compare_values(refaci, get_variable("ACI ENERGY"),9, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),9, "ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST

--- a/tests/methods/aci-18/input.dat
+++ b/tests/methods/aci-18/input.dat
@@ -57,7 +57,7 @@ scf = energy('scf')
 compare_values(refscf, scf,10,"SCF Energy")
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),10,"ACI energy")
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8,"ACI+PT2 energy")
+compare_values(refaci, variable("ACI ENERGY"),10,"ACI energy")
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8,"ACI+PT2 energy")
 
 

--- a/tests/methods/aci-19/input.dat
+++ b/tests/methods/aci-19/input.dat
@@ -57,7 +57,7 @@ scf = energy('scf')
 compare_values(refscf, scf,10,"SCF Energy")
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),10,"ACI energy")
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8,"ACI+PT2 energy")
+compare_values(refaci, variable("ACI ENERGY"),10,"ACI energy")
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8,"ACI+PT2 energy")
 
 

--- a/tests/methods/aci-2/input.dat
+++ b/tests/methods/aci-2/input.dat
@@ -40,8 +40,8 @@ set forte {
 
 energy('mcscf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),9, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),9, "ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST

--- a/tests/methods/aci-3/input.dat
+++ b/tests/methods/aci-3/input.dat
@@ -39,8 +39,8 @@ set forte {
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),9, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),9, "ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST

--- a/tests/methods/aci-4/input.dat
+++ b/tests/methods/aci-4/input.dat
@@ -45,8 +45,8 @@ set forte {
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),9, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),9, "ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST

--- a/tests/methods/aci-5/input.dat
+++ b/tests/methods/aci-5/input.dat
@@ -43,8 +43,8 @@ set forte {
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),9, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),9, "ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST

--- a/tests/methods/aci-6/input.dat
+++ b/tests/methods/aci-6/input.dat
@@ -43,9 +43,9 @@ set forte {
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy")
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy")
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),7, "ACI energy")
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),7, "ACI+PT2 energy")
+compare_values(refaci, variable("ACI ENERGY"),7, "ACI energy")
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),7, "ACI+PT2 energy")
 

--- a/tests/methods/aci-7/input.dat
+++ b/tests/methods/aci-7/input.dat
@@ -45,8 +45,8 @@ set forte {
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),9, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),9, "ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST

--- a/tests/methods/aci-8/input.dat
+++ b/tests/methods/aci-8/input.dat
@@ -41,8 +41,8 @@ set forte {
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),9, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),9, "ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST

--- a/tests/methods/aci-9/input.dat
+++ b/tests/methods/aci-9/input.dat
@@ -37,7 +37,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),10, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),10, "ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),10, "ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),10, "ACI+PT2 energy") #TEST

--- a/tests/methods/aci-dsrg-mrpt2-1/input.dat
+++ b/tests/methods/aci-dsrg-mrpt2-1/input.dat
@@ -37,7 +37,7 @@ set forte{
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrhf,get_variable("CURRENT ENERGY"),10,"SCF energy")
+compare_values(refrhf,variable("CURRENT ENERGY"),10,"SCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),8,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),8,"DSRG-MRPT2 energy")

--- a/tests/methods/aci-dsrg-mrpt2-2/input.dat
+++ b/tests/methods/aci-dsrg-mrpt2-2/input.dat
@@ -38,7 +38,7 @@ set forte{
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrhf,get_variable("CURRENT ENERGY"),10,"SCF energy")
+compare_values(refrhf,variable("CURRENT ENERGY"),10,"SCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/aci-dsrg-mrpt2-3/input.dat
+++ b/tests/methods/aci-dsrg-mrpt2-3/input.dat
@@ -40,7 +40,7 @@ set forte{
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrhf,get_variable("CURRENT ENERGY"),10,"SCF energy")
+compare_values(refrhf,variable("CURRENT ENERGY"),10,"SCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10,"ACI-DSRG-MRPT2 relaxed energy")
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10,"ACI-DSRG-MRPT2 relaxed energy")

--- a/tests/methods/aci-dsrg-mrpt2-4/input.dat
+++ b/tests/methods/aci-dsrg-mrpt2-4/input.dat
@@ -67,10 +67,10 @@ set_num_threads(8)
 
 e, scf_wfn = energy('scf', return_wfn=True)
 
-compare_values(escf,get_variable("CURRENT ENERGY"), 9, "SCF energy") 
+compare_values(escf,variable("CURRENT ENERGY"), 9, "SCF energy") 
 
 energy('forte', ref_wfn=scf_wfn)
-compare_values(eaci,get_variable("CURRENT ENERGY"), 9, "ACI-DSRG-MRPT2 energy") 
+compare_values(eaci,variable("CURRENT ENERGY"), 9, "ACI-DSRG-MRPT2 energy") 
 
 
 

--- a/tests/methods/aci-dsrg-mrpt2-5/input.dat
+++ b/tests/methods/aci-dsrg-mrpt2-5/input.dat
@@ -70,11 +70,11 @@ set_num_threads(8)
 
 e, scf_wfn = energy('scf', return_wfn=True)
 
-compare_values(escf,get_variable("CURRENT ENERGY"), 9, "SCF energy") 
+compare_values(escf,variable("CURRENT ENERGY"), 9, "SCF energy") 
 
 energy('forte', ref_wfn=scf_wfn)
-compare_values(efix,get_variable("UNRELAXED ENERGY"), 9, "ACI-DSRG-MRPT2 fixed energy")
-compare_values(eaci,get_variable("CURRENT ENERGY"), 9, "ACI-DSRG-MRPT2 relaxed energy") 
+compare_values(efix,variable("UNRELAXED ENERGY"), 9, "ACI-DSRG-MRPT2 fixed energy")
+compare_values(eaci,variable("CURRENT ENERGY"), 9, "ACI-DSRG-MRPT2 relaxed energy") 
 
 
 

--- a/tests/methods/aci-dsrg-mrpt3-1/input.dat
+++ b/tests/methods/aci-dsrg-mrpt3-1/input.dat
@@ -50,7 +50,7 @@ set forte{
 }
 
 Ecasscf, wfn = energy('casscf', return_wfn=True)
-compare_values(refcasscf,get_variable("CURRENT ENERGY"),9,"MCSCF energy") #TEST
+compare_values(refcasscf,variable("CURRENT ENERGY"),9,"MCSCF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt3,get_variable("CURRENT ENERGY"),7,"DSRG-MRPT3 relaxed energy") #TEST
+compare_values(refdsrgpt3,variable("CURRENT ENERGY"),7,"DSRG-MRPT3 relaxed energy") #TEST

--- a/tests/methods/aci-mrcisd-1/input.dat
+++ b/tests/methods/aci-mrcisd-1/input.dat
@@ -46,7 +46,7 @@ set forte {
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9,"SCF energy")
+compare_values(refscf, variable("CURRENT ENERGY"),9,"SCF energy")
 energy('forte')
-compare_values(refen, get_variable("MRCISD ENERGY"), 9, "MR-CISD energy")
+compare_values(refen, variable("MRCISD ENERGY"), 9, "MR-CISD energy")
 

--- a/tests/methods/aci-mrcisd-2/input.dat
+++ b/tests/methods/aci-mrcisd-2/input.dat
@@ -88,7 +88,7 @@ D   1   1.00
 
 
 energy('scf')
-compare_values(refrohf,get_variable("CURRENT ENERGY"),10,"SCF energy") #TEST
+compare_values(refrohf,variable("CURRENT ENERGY"),10,"SCF energy") #TEST
 
 energy('forte')
-compare_values(refmrci,get_variable("MRCISD ENERGY"),10,"MRCISD energy") #TEST
+compare_values(refmrci,variable("MRCISD ENERGY"),10,"MRCISD energy") #TEST

--- a/tests/methods/aci-mrdsrg-ldsrg2-df/input.dat
+++ b/tests/methods/aci-mrdsrg-ldsrg2-df/input.dat
@@ -52,7 +52,7 @@ set forte{
 }
 
 Emcscf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrg,get_variable("CURRENT ENERGY"),8,"MRDSRG relaxed energy") #TEST
+compare_values(refdsrg,variable("CURRENT ENERGY"),8,"MRDSRG relaxed energy") #TEST

--- a/tests/methods/aci_scf-1/input.dat
+++ b/tests/methods/aci_scf-1/input.dat
@@ -55,7 +55,7 @@ set forte{
 }
 
 
-#compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy")
+#compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy")
 
 casscf = energy('forte')
-compare_values(refcasscf,get_variable("CURRENT ENERGY"),6,"CASSCF energy")
+compare_values(refcasscf,variable("CURRENT ENERGY"),6,"CASSCF energy")

--- a/tests/methods/aci_scf-3/input.dat
+++ b/tests/methods/aci_scf-3/input.dat
@@ -60,7 +60,7 @@ set forte {
 
 
 energy('forte', ref_wfn=refwfn)
-#compare_values(refaci, get_variable("ACI ENERGY"),10,"ACI energy")
-#compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8,"ACI+PT2 energy")
+#compare_values(refaci, variable("ACI ENERGY"),10,"ACI energy")
+#compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8,"ACI+PT2 energy")
 
 

--- a/tests/methods/actv-dsrg-5-actv-independence/input.dat
+++ b/tests/methods/actv-dsrg-5-actv-independence/input.dat
@@ -39,7 +39,7 @@ set forte{
 
 Escf, wfn = energy('scf', return_wfn=True)
 Edsrg = energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
 
 # now test CD-DSRG-MRPT2
 set forte{
@@ -47,7 +47,7 @@ set forte{
   cholesky_tolerance      8
 }
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),7,"CD-DSRG-MRPT2 energy")
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),7,"CD-DSRG-MRPT2 energy")
 
 # now do single reference DSRG-PT2
 set forte{

--- a/tests/methods/actv-dsrg-ipea-1/input.dat
+++ b/tests/methods/actv-dsrg-ipea-1/input.dat
@@ -18,7 +18,7 @@ set {
   maxiter        100
 }
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refscf,get_variable("CURRENT ENERGY"),8,"SCF energy") #TEST
+compare_values(refscf,variable("CURRENT ENERGY"),8,"SCF energy") #TEST
 
 set forte{
   job_type           active-dsrgpt2
@@ -34,4 +34,4 @@ set forte{
   dsrg_s             0.5
 }
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrg,get_variable("CURRENT ENERGY"),8,"DSRG energy of Ag state") #TEST
+compare_values(refdsrg,variable("CURRENT ENERGY"),8,"DSRG energy of Ag state") #TEST

--- a/tests/methods/actv-dsrg-ipea-2/input.dat
+++ b/tests/methods/actv-dsrg-ipea-2/input.dat
@@ -21,7 +21,7 @@ set {
 }
 Escf, wfn = energy('scf', return_wfn=True)
 oeprop(wfn,"MO_EXTENTS")
-compare_values(refscf,get_variable("CURRENT ENERGY"),8,"SCF energy") #TEST
+compare_values(refscf,variable("CURRENT ENERGY"),8,"SCF energy") #TEST
 
 set forte{
   job_type           active-dsrgpt2
@@ -38,4 +38,4 @@ set forte{
 # diag_algorithm     full    # full may not work when diffused orbital is added
 }
 Edsrg, wfn = energy('forte', ref_wfn=wfn, return_wfn=True)
-compare_values(refdsrg_b1,get_variable("CURRENT ENERGY"),8,"DSRG energy of B1 state") #TEST
+compare_values(refdsrg_b1,variable("CURRENT ENERGY"),8,"DSRG energy of B1 state") #TEST

--- a/tests/methods/ambit-1/input.dat
+++ b/tests/methods/ambit-1/input.dat
@@ -18,4 +18,4 @@ set forte {
   job_type test_ambit
 }
 energy('forte')
-compare_values(0.0, get_variable("AMBIT MAX ERROR"), 10, "Ambit max error") #TEST
+compare_values(0.0, variable("AMBIT MAX ERROR"), 10, "Ambit max error") #TEST

--- a/tests/methods/ao-df-dsrg-mrpt2-1/input.dat
+++ b/tests/methods/ao-df-dsrg-mrpt2-1/input.dat
@@ -42,6 +42,6 @@ set forte{
 #
 #ref = energy('scf')
 forte_energy = energy('forte')
-compare_values(df_mp2,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(df_mp2,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
 
 

--- a/tests/methods/asci-1/input.dat
+++ b/tests/methods/asci-1/input.dat
@@ -16,11 +16,10 @@ C 1 1.27273
                                          
 set {                                    
   scf_type pk                            
-  multiplicity 1                         
+  #multiplicity 1                         
   basis cc-pvdz                      
   reference rohf
 }                                        
-                                         
                                          
 set forte {                              
   multiplicity 1

--- a/tests/methods/asci-1/input.dat
+++ b/tests/methods/asci-1/input.dat
@@ -37,6 +37,6 @@ set forte {
 }                                        
                                          
 Escf, scf_wfn = energy('scf', return_wfn=True)
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy")
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy")
 energy('forte', ref_wfn = scf_wfn) 
-compare_values(refasci,get_variable("ASCI ENERGY"),9,"ASCI ENERGY")
+compare_values(refasci,variable("ASCI ENERGY"),9,"ASCI ENERGY")

--- a/tests/methods/casci-1/input.dat
+++ b/tests/methods/casci-1/input.dat
@@ -30,6 +30,6 @@ set forte{
 }
 
 energy('mcscf')
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
 energy('forte')
-compare_values(reflci, get_variable("LAMBDA-CI ENERGY"),10, "Lambda-CI energy") #TEST
+compare_values(reflci, variable("LAMBDA-CI ENERGY"),10, "Lambda-CI energy") #TEST

--- a/tests/methods/casci-2/input.dat
+++ b/tests/methods/casci-2/input.dat
@@ -30,6 +30,6 @@ set forte{
 }
 
 energy('mcscf')
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
 energy('forte')
-compare_values(reflci, get_variable("LAMBDA-CI ENERGY"),10, "Lambda-CI energy") #TEST
+compare_values(reflci, variable("LAMBDA-CI ENERGY"),10, "Lambda-CI energy") #TEST

--- a/tests/methods/casci-3/input.dat
+++ b/tests/methods/casci-3/input.dat
@@ -31,6 +31,6 @@ set forte {
 }
 
 energy('mcscf')
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
 energy('forte')
-compare_values(reflci, get_variable("LAMBDA-CI ENERGY"),10, "Lambda-CI energy") #TEST
+compare_values(reflci, variable("LAMBDA-CI ENERGY"),10, "Lambda-CI energy") #TEST

--- a/tests/methods/casci-4/input.dat
+++ b/tests/methods/casci-4/input.dat
@@ -31,6 +31,6 @@ set forte {
 }
 
 energy('mcscf')
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
 energy('forte')
-compare_values(reflci, get_variable("LAMBDA-CI ENERGY"),10, "Lambda-CI energy") #TEST
+compare_values(reflci, variable("LAMBDA-CI ENERGY"),10, "Lambda-CI energy") #TEST

--- a/tests/methods/casci-5-fc/input.dat
+++ b/tests/methods/casci-5-fc/input.dat
@@ -30,6 +30,6 @@ set forte {
 }
 
 energy('mcscf')
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
 energy('forte')
-compare_values(reflci, get_variable("LAMBDA-CI ENERGY"),10, "Lambda-CI energy") #TEST
+compare_values(reflci, variable("LAMBDA-CI ENERGY"),10, "Lambda-CI energy") #TEST

--- a/tests/methods/casci-6-fc/input.dat
+++ b/tests/methods/casci-6-fc/input.dat
@@ -30,6 +30,6 @@ set forte {
 }
 
 energy('mcscf')
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
 energy('forte')
-compare_values(reflci, get_variable("LAMBDA-CI ENERGY"),10, "Lambda-CI energy") #TEST
+compare_values(reflci, variable("LAMBDA-CI ENERGY"),10, "Lambda-CI energy") #TEST

--- a/tests/methods/casci-7-fc/input.dat
+++ b/tests/methods/casci-7-fc/input.dat
@@ -31,6 +31,6 @@ set forte {
 }
 
 energy('mcscf')
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
 energy('forte')
-compare_values(reflci, get_variable("LAMBDA-CI ENERGY"),10, "Lambda-CI energy") #TEST
+compare_values(reflci, variable("LAMBDA-CI ENERGY"),10, "Lambda-CI energy") #TEST

--- a/tests/methods/casci-8-fc/input.dat
+++ b/tests/methods/casci-8-fc/input.dat
@@ -31,6 +31,6 @@ set forte {
 }
 
 energy('mcscf')
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
 energy('forte')
-compare_values(reflci, get_variable("LAMBDA-CI ENERGY"),10, "Lambda-CI energy") #TEST
+compare_values(reflci, variable("LAMBDA-CI ENERGY"),10, "Lambda-CI energy") #TEST

--- a/tests/methods/casscf-5/input.dat
+++ b/tests/methods/casscf-5/input.dat
@@ -59,4 +59,4 @@ set forte {
 
 
 my_casscf = energy('forte')
-compare_values(my_casscf, get_variable("CURRENT ENERGY"),6,"CASSCF energy")
+compare_values(my_casscf, variable("CURRENT ENERGY"),6,"CASSCF energy")

--- a/tests/methods/casscf-6/input.dat
+++ b/tests/methods/casscf-6/input.dat
@@ -47,7 +47,7 @@ set forte{
    CASSCF_DO_DIIS           false
 }
 
-#compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy")
+#compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy")
 
 casscf = energy('forte')
-compare_values(refcasscf,get_variable("CURRENT ENERGY"),6,"CASSCF energy")
+compare_values(refcasscf,variable("CURRENT ENERGY"),6,"CASSCF energy")

--- a/tests/methods/casscf-8/input.dat
+++ b/tests/methods/casscf-8/input.dat
@@ -32,7 +32,7 @@ set {
 
 Escf, wfnSCF = energy('scf', return_wfn=True)
 Ecasscf, wfn = energy('casscf', ref_wfn=wfnSCF, return_wfn=True)
-compare_values(refcasscf,get_variable("CURRENT ENERGY"),10,"PSI4 CASSCF energy")
+compare_values(refcasscf,variable("CURRENT ENERGY"),10,"PSI4 CASSCF energy")
 
 set forte {
   job_type             casscf
@@ -48,7 +48,7 @@ set forte {
   casscf_diis_freq     4
 }
 Ecasscf, wfn = energy('forte', ref_wfn=wfnSCF, return_wfn=True)
-compare_values(refcasscf,get_variable("CURRENT ENERGY"),10,"FORTE CASSCF energy")
+compare_values(refcasscf,variable("CURRENT ENERGY"),10,"FORTE CASSCF energy")
 
 set forte {
   job_type           dsrg-mrpt2
@@ -64,4 +64,4 @@ set forte {
 }
 
 Eforte, wfn = energy('forte', ref_wfn=wfn, return_wfn=True)
-compare_values(refpt2_relax,get_variable("CURRENT ENERGY"),8,"DSRG-MRPT2 relaxed energy")
+compare_values(refpt2_relax,variable("CURRENT ENERGY"),8,"DSRG-MRPT2 relaxed energy")

--- a/tests/methods/casscf/input.dat
+++ b/tests/methods/casscf/input.dat
@@ -16,7 +16,7 @@ molecule {
   no_reorient
 }
 
-set globals{
+set globals {
    scf_type             out_of_core
    MCSCF_E_CONVERGENCE  8
    MCSCF_R_CONVERGENCE  6
@@ -30,10 +30,9 @@ set globals{
    mcscf_type           conv
 }
 refscf = energy('casscf')
-#compare_values(refscf, scf, 6, "SCF ENERGY")
 
-energy('scf')
 set scf_type direct
+
 set forte{
    job_type             casscf
    CASSCF_REFERENCE      true

--- a/tests/methods/cd-dsrg-mrpt2-1/input.dat
+++ b/tests/methods/cd-dsrg-mrpt2-1/input.dat
@@ -75,7 +75,7 @@ S   1   1.00
 }
 
 scf_energy,scf_wfn = energy('mcscf', return_wfn = True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
 
 energy('forte', ref_wfn = scf_wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy") #TEST
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy") #TEST

--- a/tests/methods/cd-dsrg-mrpt2-2/input.dat
+++ b/tests/methods/cd-dsrg-mrpt2-2/input.dat
@@ -45,7 +45,7 @@ set forte{
 }
 
 refmcscf, refwfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy")
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy")
 
 energy('forte', ref_wfn = refwfn )
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/cd-dsrg-mrpt2-3/input.dat
+++ b/tests/methods/cd-dsrg-mrpt2-3/input.dat
@@ -38,7 +38,7 @@ set forte{
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrhf,get_variable("CURRENT ENERGY"),10,"SCF energy")
+compare_values(refrhf,variable("CURRENT ENERGY"),10,"SCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/cd-dsrg-mrpt2-4/input.dat
+++ b/tests/methods/cd-dsrg-mrpt2-4/input.dat
@@ -37,7 +37,7 @@ set forte{
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrhf,get_variable("CURRENT ENERGY"),9,"SCF energy")
+compare_values(refrhf,variable("CURRENT ENERGY"),9,"SCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),8,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),8,"DSRG-MRPT2 energy")

--- a/tests/methods/cd-dsrg-mrpt2-5/input.dat
+++ b/tests/methods/cd-dsrg-mrpt2-5/input.dat
@@ -53,7 +53,7 @@ set forte{
 }
 
 scf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy")
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy")
 
 energy('forte', ref_wfn = wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/cd-dsrg-mrpt2-6/input.dat
+++ b/tests/methods/cd-dsrg-mrpt2-6/input.dat
@@ -92,7 +92,7 @@ set forte {
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrohf,get_variable("CURRENT ENERGY"),10,"ROHF energy") #TEST
+compare_values(refrohf,variable("CURRENT ENERGY"),10,"ROHF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),8, "MRDSRG-PT2 relaxed energy") #TEST
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),8, "MRDSRG-PT2 relaxed energy") #TEST

--- a/tests/methods/cd-dsrg-mrpt2-7-sa/input.dat
+++ b/tests/methods/cd-dsrg-mrpt2-7-sa/input.dat
@@ -89,7 +89,7 @@ set forte{
 Emcscf, wfn = energy('casscf', return_wfn=True)
 
 Esa = energy('forte', ref_wfn=wfn)
-compare_values(refpt2full,get_variable("CURRENT ENERGY"),8,"SA-DSRG-MRPT2 FULL energy root 0")
+compare_values(refpt2full,variable("CURRENT ENERGY"),8,"SA-DSRG-MRPT2 FULL energy root 0")
 
 set forte {
   job_type           three-dsrg-mrpt2

--- a/tests/methods/cis-aci-1/input.dat
+++ b/tests/methods/cis-aci-1/input.dat
@@ -36,7 +36,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),10, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),10, "ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),10, "ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),10, "ACI+PT2 energy") #TEST

--- a/tests/methods/ct-1/input.dat
+++ b/tests/methods/ct-1/input.dat
@@ -25,6 +25,6 @@ set forte{
 }
 
 energy('scf')
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
 energy('forte')
-compare_values(refct, get_variable("CURRENT ENERGY"),10, "SR-CTSD energy") #TEST
+compare_values(refct, variable("CURRENT ENERGY"),10, "SR-CTSD energy") #TEST

--- a/tests/methods/ct-2/input.dat
+++ b/tests/methods/ct-2/input.dat
@@ -28,6 +28,6 @@ set forte{
 }
 
 energy('scf')
-compare_values(refscf, get_variable("SCF total energy"),8, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),8, "SCF energy") #TEST
 energy('forte')
-compare_values(refct, get_variable("CURRENT ENERGY"),8, "SR-CTSD energy") #TEST
+compare_values(refct, variable("CURRENT ENERGY"),8, "SR-CTSD energy") #TEST

--- a/tests/methods/ct-3/input.dat
+++ b/tests/methods/ct-3/input.dat
@@ -30,6 +30,6 @@ set forte{
 
 set basis cc-pVDZ
 energy('scf')
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
 energy('forte')
-compare_values(refct, get_variable("CURRENT ENERGY"),10, "SR-CTSD energy") #TEST
+compare_values(refct, variable("CURRENT ENERGY"),10, "SR-CTSD energy") #TEST

--- a/tests/methods/ct-4/input.dat
+++ b/tests/methods/ct-4/input.dat
@@ -29,6 +29,6 @@ set forte {
 
 set basis cc-pVDZ
 energy('scf')
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
 energy('forte')
-compare_values(refct, get_variable("CURRENT ENERGY"),10, "SR-CTSD energy") #TEST
+compare_values(refct, variable("CURRENT ENERGY"),10, "SR-CTSD energy") #TEST

--- a/tests/methods/ct-5/input.dat
+++ b/tests/methods/ct-5/input.dat
@@ -27,6 +27,6 @@ set forte{
 set basis cc-pVDZ
 
 energy('scf')
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
 energy('forte')
-compare_values(refct, get_variable("CURRENT ENERGY"),10, "SR-CTSD energy") #TEST
+compare_values(refct, variable("CURRENT ENERGY"),10, "SR-CTSD energy") #TEST

--- a/tests/methods/ct-6/input.dat
+++ b/tests/methods/ct-6/input.dat
@@ -30,6 +30,6 @@ set forte {
 
 set basis cc-pVDZ
 energy('scf')
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
 energy('forte')
-compare_values(refct, get_variable("CURRENT ENERGY"),10, "SR-CTSD energy") #TEST
+compare_values(refct, variable("CURRENT ENERGY"),10, "SR-CTSD energy") #TEST

--- a/tests/methods/ct-7-fc/input.dat
+++ b/tests/methods/ct-7-fc/input.dat
@@ -30,6 +30,6 @@ set forte{
 }
 
 energy('scf')
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
 energy('forte')
-compare_values(refct, get_variable("CURRENT ENERGY"),10, "SR-CTSD energy") #TEST
+compare_values(refct, variable("CURRENT ENERGY"),10, "SR-CTSD energy") #TEST

--- a/tests/methods/df-aci-dsrg-mrpt2-1/input.dat
+++ b/tests/methods/df-aci-dsrg-mrpt2-1/input.dat
@@ -57,4 +57,4 @@ scf, wfn = energy('mcscf', return_wfn=True)
 compare_values(refmcscf,scf,10,"SCF Energy")
 
 energy('forte', ref_wfn = wfn)
-compare_values(refdsrgpt2_jk_rd,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2_jk_rd,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/df-aci-dsrg-mrpt2-2/input.dat
+++ b/tests/methods/df-aci-dsrg-mrpt2-2/input.dat
@@ -52,4 +52,4 @@ scf, wfn = energy('mcscf', return_wfn=True)
 energy('forte', ref_wfn = wfn)
 
 compare_values(refmcscf,scf,10,"MCSCF energy")
-compare_values(refdsrgpt2_jk_rd, get_variable("CURRENT ENERGY"),10,"DF-DSRG-MRPT2 energy")
+compare_values(refdsrgpt2_jk_rd, variable("CURRENT ENERGY"),10,"DF-DSRG-MRPT2 energy")

--- a/tests/methods/df-dsrg-mrpt2-1/input.dat
+++ b/tests/methods/df-dsrg-mrpt2-1/input.dat
@@ -68,4 +68,4 @@ S   1   1.00
 }
 
 forte_energy = energy('forte')
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/df-dsrg-mrpt2-2/input.dat
+++ b/tests/methods/df-dsrg-mrpt2-2/input.dat
@@ -49,4 +49,4 @@ Escf, wfn = energy('mcscf', return_wfn=True)
 energy('forte', ref_wfn=wfn)
 
 compare_values(refmcscf,Escf,10,"MCSCF energy")
-compare_values(refdsrgpt2_jk_rd,get_variable("CURRENT ENERGY"),10,"DF-DSRG-MRPT2 energy")
+compare_values(refdsrgpt2_jk_rd,variable("CURRENT ENERGY"),10,"DF-DSRG-MRPT2 energy")

--- a/tests/methods/df-dsrg-mrpt2-3/input.dat
+++ b/tests/methods/df-dsrg-mrpt2-3/input.dat
@@ -42,4 +42,4 @@ Escf, wfn = energy('scf', return_wfn=True)
 compare_values(refrhf,Escf,10,"SCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/df-dsrg-mrpt2-4/input.dat
+++ b/tests/methods/df-dsrg-mrpt2-4/input.dat
@@ -41,4 +41,4 @@ Escf, wfn = energy('scf', return_wfn=True)
 compare_values(refrhf,Escf,10,"SCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2_jk_rd,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2_jk_rd,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/df-dsrg-mrpt2-5/input.dat
+++ b/tests/methods/df-dsrg-mrpt2-5/input.dat
@@ -56,4 +56,4 @@ scf, wfn = energy('mcscf', return_wfn=True)
 compare_values(refmcscf, scf,10,"SCF Energy")
 
 energy('forte', ref_wfn = wfn)
-compare_values(refdsrgpt2_jk_rd, get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2_jk_rd, variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/df-dsrg-mrpt2-6/input.dat
+++ b/tests/methods/df-dsrg-mrpt2-6/input.dat
@@ -43,4 +43,4 @@ Escf, wfn = energy('scf', return_wfn=True)
 compare_values(refrhf,Escf,10,"SCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2_ref_relax,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2_ref_relax,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/df-dsrg-mrpt2-threading1/input.dat
+++ b/tests/methods/df-dsrg-mrpt2-threading1/input.dat
@@ -57,4 +57,4 @@ compare_values(refmcscf, scf,10,"SCF Energy")
 set_num_threads(1)
 
 energy('forte', ref_wfn = wfn)
-compare_values(refdsrgpt2, get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2, variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/df-dsrg-mrpt2-threading2/input.dat
+++ b/tests/methods/df-dsrg-mrpt2-threading2/input.dat
@@ -56,4 +56,4 @@ compare_values(refmcscf, scf,10,"SCF Energy")
 set_num_threads(2)
 
 energy('forte', ref_wfn = wfn)
-compare_values(refdsrgpt2, get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2, variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/df-dsrg-mrpt2-threading4/input.dat
+++ b/tests/methods/df-dsrg-mrpt2-threading4/input.dat
@@ -56,4 +56,4 @@ compare_values(refmcscf, scf,10,"SCF Energy")
 set_num_threads(4)
 
 energy('forte', ref_wfn = wfn)
-compare_values(refdsrgpt2, get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2, variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/diskdf-dsrg-mrpt2-3/input.dat
+++ b/tests/methods/diskdf-dsrg-mrpt2-3/input.dat
@@ -41,4 +41,4 @@ set forte{
 Escf, wfn = energy('scf', return_wfn=True)
 compare_values(refrhf,Escf,10,"SCF energy")
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/diskdf-dsrg-mrpt2-4/input.dat
+++ b/tests/methods/diskdf-dsrg-mrpt2-4/input.dat
@@ -43,5 +43,5 @@ Escf, wfn = energy('scf', return_wfn=True)
 compare_values(refrhf, Escf, 10, "SCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refpt2_u, get_variable("UNRELAXED ENERGY"), 10, "unrelaxed DSRG-MRPT2 energy")
-compare_values(refpt2_pr, get_variable("CURRENT ENERGY"), 10, "DSRG-MRPT2 energy")
+compare_values(refpt2_u, variable("UNRELAXED ENERGY"), 10, "unrelaxed DSRG-MRPT2 energy")
+compare_values(refpt2_pr, variable("CURRENT ENERGY"), 10, "DSRG-MRPT2 energy")

--- a/tests/methods/diskdf-dsrg-mrpt2-5/input.dat
+++ b/tests/methods/diskdf-dsrg-mrpt2-5/input.dat
@@ -56,4 +56,4 @@ Escf, wfn = energy('scf', return_wfn=True)
 #compare_values(refmcscf, scf,10,"SCF Energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2, get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2, variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/diskdf-dsrg-mrpt2-threading1/input.dat
+++ b/tests/methods/diskdf-dsrg-mrpt2-threading1/input.dat
@@ -57,4 +57,4 @@ compare_values(refmcscf, scf,10,"SCF Energy")
 set_num_threads(1)
 
 energy('forte', ref_wfn = wfn)
-compare_values(refdsrgpt2, get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2, variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/diskdf-dsrg-mrpt2-threading4/input.dat
+++ b/tests/methods/diskdf-dsrg-mrpt2-threading4/input.dat
@@ -56,4 +56,4 @@ compare_values(refmcscf, scf,10,"SCF Energy")
 set_num_threads(4)
 
 energy('forte', ref_wfn = wfn)
-compare_values(refdsrgpt2, get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2, variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/dsrg-1/input.dat
+++ b/tests/methods/dsrg-1/input.dat
@@ -27,7 +27,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf,get_variable("CURRENT ENERGY"),8,"SCF energy") #TEST
+compare_values(refscf,variable("CURRENT ENERGY"),8,"SCF energy") #TEST
 
 energy('forte')
-compare_values(refdsrg,get_variable("CURRENT ENERGY"),8,"DSRGSD energy") #TEST
+compare_values(refdsrg,variable("CURRENT ENERGY"),8,"DSRGSD energy") #TEST

--- a/tests/methods/dsrg-2/input.dat
+++ b/tests/methods/dsrg-2/input.dat
@@ -31,7 +31,7 @@ set forte {
 set basis DZ
 
 energy('scf')
-compare_values(refscf,get_variable("CURRENT ENERGY"),10,"SCF energy") #TEST
+compare_values(refscf,variable("CURRENT ENERGY"),10,"SCF energy") #TEST
 
 energy('forte')
-compare_values(refct,get_variable("CURRENT ENERGY"),10,"SR-CTSD energy") #TEST
+compare_values(refct,variable("CURRENT ENERGY"),10,"SR-CTSD energy") #TEST

--- a/tests/methods/dsrg-mrpt2-1/input.dat
+++ b/tests/methods/dsrg-mrpt2-1/input.dat
@@ -73,7 +73,7 @@ S   1   1.00
 }
 
 scf_energy, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
 
 energy('forte',ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy") #TEST
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy") #TEST

--- a/tests/methods/dsrg-mrpt2-10-CO/input.dat
+++ b/tests/methods/dsrg-mrpt2-10-CO/input.dat
@@ -37,7 +37,7 @@ set {
 }
 
 Ecasscf, wfn_cas = energy('casscf', return_wfn=True)
-compare_values(refcasscf,get_variable("CURRENT ENERGY"),10,"CASSCF energy")
+compare_values(refcasscf,variable("CURRENT ENERGY"),10,"CASSCF energy")
 
 set forte {
   job_type           dsrg-mrpt2
@@ -54,7 +54,7 @@ set forte {
 }
 
 Eforte, wfn_cas = energy('forte', ref_wfn=wfn_cas, return_wfn=True)
-compare_values(refpt2,get_variable("UNRELAXED ENERGY"),9,"DSRG-MRPT2 unrelaxed energy")
-compare_values(refpt2_relax,get_variable("PARTIALLY RELAXED ENERGY"),9,"DSRG-MRPT2 partially relaxed energy")
-compare_values(refdm,get_variable("UNRELAXED DIPOLE"),5,"DSRG-MRPT2 dipole moment unrelaxed ref")
-compare_values(refdm_relax,get_variable("PARTIALLY RELAXED DIPOLE"),5,"DSRG-MRPT2 dipole moment partially relaxed ref")
+compare_values(refpt2,variable("UNRELAXED ENERGY"),9,"DSRG-MRPT2 unrelaxed energy")
+compare_values(refpt2_relax,variable("PARTIALLY RELAXED ENERGY"),9,"DSRG-MRPT2 partially relaxed energy")
+compare_values(refdm,variable("UNRELAXED DIPOLE"),5,"DSRG-MRPT2 dipole moment unrelaxed ref")
+compare_values(refdm_relax,variable("PARTIALLY RELAXED DIPOLE"),5,"DSRG-MRPT2 dipole moment partially relaxed ref")

--- a/tests/methods/dsrg-mrpt2-2/input.dat
+++ b/tests/methods/dsrg-mrpt2-2/input.dat
@@ -44,7 +44,7 @@ set forte{
 }
 
 Emcscf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy")
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy")
 
 energy('forte',ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/dsrg-mrpt2-3/input.dat
+++ b/tests/methods/dsrg-mrpt2-3/input.dat
@@ -40,7 +40,7 @@ set forte{
 }
 
 energy('scf')
-compare_values(refrhf,get_variable("CURRENT ENERGY"),10,"SCF energy")
+compare_values(refrhf,variable("CURRENT ENERGY"),10,"SCF energy")
 
 energy('forte')
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/dsrg-mrpt2-4/input.dat
+++ b/tests/methods/dsrg-mrpt2-4/input.dat
@@ -35,7 +35,7 @@ set forte{
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrhf,get_variable("CURRENT ENERGY"),10,"SCF energy")
+compare_values(refrhf,variable("CURRENT ENERGY"),10,"SCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),8,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),8,"DSRG-MRPT2 energy")

--- a/tests/methods/dsrg-mrpt2-5/input.dat
+++ b/tests/methods/dsrg-mrpt2-5/input.dat
@@ -47,7 +47,7 @@ set forte{
 }
 
 scf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy")
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/dsrg-mrpt2-6/input.dat
+++ b/tests/methods/dsrg-mrpt2-6/input.dat
@@ -34,7 +34,7 @@ set {
 }
 
 Ecasscf, wfn_cas = energy('casscf', return_wfn=True)
-compare_values(refcasscf,get_variable("CURRENT ENERGY"),10,"CASSCF energy") #TEST
+compare_values(refcasscf,variable("CURRENT ENERGY"),10,"CASSCF energy") #TEST
 
 set forte {
   job_type           dsrg-mrpt2
@@ -52,4 +52,4 @@ set forte {
 }
 
 Eforte, wfn_cas = energy('forte', ref_wfn=wfn_cas, return_wfn=True)
-compare_values(refpt2_relax,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 relaxed energy") #TEST
+compare_values(refpt2_relax,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 relaxed energy") #TEST

--- a/tests/methods/dsrg-mrpt2-7-casscf-natorbs/input.dat
+++ b/tests/methods/dsrg-mrpt2-7-casscf-natorbs/input.dat
@@ -46,11 +46,11 @@ set forte {
 }
 
 Ecasscf, wfn_cas = energy('casscf', return_wfn=True)
-compare_values(refcasscf, get_variable("CURRENT ENERGY"), 10, "CASSCF energy (canonical orbitals)")
+compare_values(refcasscf, variable("CURRENT ENERGY"), 10, "CASSCF energy (canonical orbitals)")
 
 Eforte, wfn = energy('forte', ref_wfn=wfn_cas, return_wfn=True)
-compare_values(refpt2, get_variable("UNRELAXED ENERGY"), 10, "DSRG-MRPT2 urelaxed energy")
-compare_values(refpt2_relax, get_variable("PARTIALLY RELAXED ENERGY"), 10,
+compare_values(refpt2, variable("UNRELAXED ENERGY"), 10, "DSRG-MRPT2 urelaxed energy")
+compare_values(refpt2_relax, variable("PARTIALLY RELAXED ENERGY"), 10,
                "DSRG-MRPT2 partially relaxed energy")
 
 # try CASSCF with natual orbital
@@ -58,11 +58,11 @@ set {
   nat_orbs true
 }
 Ecasscf, wfn_cas = energy('casscf', return_wfn=True)
-compare_values(refcasscf, get_variable("CURRENT ENERGY"), 10, "CASSCF energy (natural orbitals)")
+compare_values(refcasscf, variable("CURRENT ENERGY"), 10, "CASSCF energy (natural orbitals)")
 
 set forte {
   cas_type           fci
 }
 Eforte, wfn = energy('forte', ref_wfn=wfn_cas, return_wfn=True)
-compare_values(refpt2_relax, get_variable("CURRENT ENERGY"), 6,
+compare_values(refpt2_relax, variable("CURRENT ENERGY"), 6,
                "DSRG-MRPT2 partially relaxed energy")

--- a/tests/methods/dsrg-mrpt2-8-sa/input.dat
+++ b/tests/methods/dsrg-mrpt2-8-sa/input.dat
@@ -91,10 +91,10 @@ set forte{
 Emcscf, wfn = energy('casscf', return_wfn=True)
 
 energy('forte',ref_wfn=wfn)
-compare_values(refpt2sub,get_variable("CURRENT ENERGY"),8,"SA-DSRG-MRPT2 SUB energy root 0")
+compare_values(refpt2sub,variable("CURRENT ENERGY"),8,"SA-DSRG-MRPT2 SUB energy root 0")
 
 set forte{
   dsrg_multi_state   sa_full
 }
 energy('forte',ref_wfn=wfn)
-compare_values(refpt2full,get_variable("CURRENT ENERGY"),8,"SA-DSRG-MRPT2 FULL energy root 0")
+compare_values(refpt2full,variable("CURRENT ENERGY"),8,"SA-DSRG-MRPT2 FULL energy root 0")

--- a/tests/methods/dsrg-mrpt2-uno/input.dat
+++ b/tests/methods/dsrg-mrpt2-uno/input.dat
@@ -48,7 +48,7 @@ set forte{
 }
 
 energy('scf')
-compare_values(old_scf,get_variable("CURRENT ENERGY"),9,"MCSCF energy")
+compare_values(old_scf,variable("CURRENT ENERGY"),9,"MCSCF energy")
 
 energy('forte')
-compare_values(old_dsrgmrpt2,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(old_dsrgmrpt2,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/dsrg-mrpt3-1/input.dat
+++ b/tests/methods/dsrg-mrpt3-1/input.dat
@@ -46,7 +46,7 @@ set forte{
 }
 
 Emcscf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt3,get_variable("CURRENT ENERGY"),8,"DSRG-MRPT3 relaxed energy") #TEST
+compare_values(refdsrgpt3,variable("CURRENT ENERGY"),8,"DSRG-MRPT3 relaxed energy") #TEST

--- a/tests/methods/dsrg-mrpt3-2/input.dat
+++ b/tests/methods/dsrg-mrpt3-2/input.dat
@@ -48,7 +48,7 @@ set forte{
 }
 
 Emcscf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt3,get_variable("CURRENT ENERGY"),7,"DSRG-MRPT3 relaxed energy") #TEST
+compare_values(refdsrgpt3,variable("CURRENT ENERGY"),7,"DSRG-MRPT3 relaxed energy") #TEST

--- a/tests/methods/dsrg-mrpt3-3/input.dat
+++ b/tests/methods/dsrg-mrpt3-3/input.dat
@@ -48,7 +48,7 @@ set forte{
 }
 
 Ecasscf, wfn = energy('casscf', return_wfn=True)
-compare_values(refcasscf,get_variable("CURRENT ENERGY"),9,"MCSCF energy") #TEST
+compare_values(refcasscf,variable("CURRENT ENERGY"),9,"MCSCF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt3,get_variable("CURRENT ENERGY"),8,"DSRG-MRPT3 relaxed energy") #TEST
+compare_values(refdsrgpt3,variable("CURRENT ENERGY"),8,"DSRG-MRPT3 relaxed energy") #TEST

--- a/tests/methods/dsrg-mrpt3-4/input.dat
+++ b/tests/methods/dsrg-mrpt3-4/input.dat
@@ -45,7 +45,7 @@ set forte {
 }
 
 Ecas, wfn = energy('casscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"CASSCF energy") #TEST
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"CASSCF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt3,get_variable("CURRENT ENERGY"),8,"DSRG-MRPT3 relaxed energy") #TEST
+compare_values(refdsrgpt3,variable("CURRENT ENERGY"),8,"DSRG-MRPT3 relaxed energy") #TEST

--- a/tests/methods/dsrg-mrpt3-5/input.dat
+++ b/tests/methods/dsrg-mrpt3-5/input.dat
@@ -90,4 +90,4 @@ set forte{
 Emcscf, wfn = energy('casscf', return_wfn=True)
 
 energy('forte',ref_wfn=wfn)
-compare_values(refdsrgpt3,get_variable("CURRENT ENERGY"),9,"SA-DSRG-MRPT3 energy root 0")
+compare_values(refdsrgpt3,variable("CURRENT ENERGY"),9,"SA-DSRG-MRPT3 energy root 0")

--- a/tests/methods/dsrg-mrpt3-6-sa/input.dat
+++ b/tests/methods/dsrg-mrpt3-6-sa/input.dat
@@ -51,4 +51,4 @@ set forte{
   dsrg_multi_state   sa_full
 }
 energy('forte',ref_wfn=wfn)
-compare_values(refpt3full,get_variable("CURRENT ENERGY"),8,"SA-DSRG-PT3 FULL energy root 0")
+compare_values(refpt3full,variable("CURRENT ENERGY"),8,"SA-DSRG-PT3 FULL energy root 0")

--- a/tests/methods/dsrg-mrpt3-7-CO/input.dat
+++ b/tests/methods/dsrg-mrpt3-7-CO/input.dat
@@ -31,7 +31,7 @@ set {
 }
 
 Ecasscf, wfn_cas = energy('casscf', return_wfn=True)
-compare_values(refcasscf,get_variable("CURRENT ENERGY"),10,"CASSCF energy")
+compare_values(refcasscf,variable("CURRENT ENERGY"),10,"CASSCF energy")
 
 set forte {
   job_type           dsrg-mrpt3
@@ -48,7 +48,7 @@ set forte {
 }
 
 Eforte, wfn_cas = energy('forte', ref_wfn=wfn_cas, return_wfn=True)
-compare_values(refpt3,get_variable("UNRELAXED ENERGY"),9,"DSRG-MRPT3 unrelaxed energy")
-compare_values(refpt3_relax,get_variable("PARTIALLY RELAXED ENERGY"),9,"DSRG-MRPT3 partially relaxed energy")
-compare_values(dmpt3,get_variable("UNRELAXED DIPOLE"),5,"DSRG-MRPT3 dipole moment unrelaxed ref")
-compare_values(dmpt3_relax,get_variable("PARTIALLY RELAXED DIPOLE"),5,"DSRG-MRPT3 dipole moment partially relaxed ref")
+compare_values(refpt3,variable("UNRELAXED ENERGY"),9,"DSRG-MRPT3 unrelaxed energy")
+compare_values(refpt3_relax,variable("PARTIALLY RELAXED ENERGY"),9,"DSRG-MRPT3 partially relaxed energy")
+compare_values(dmpt3,variable("UNRELAXED DIPOLE"),5,"DSRG-MRPT3 dipole moment unrelaxed ref")
+compare_values(dmpt3_relax,variable("PARTIALLY RELAXED DIPOLE"),5,"DSRG-MRPT3 dipole moment partially relaxed ref")

--- a/tests/methods/dwms-dsrgpt-1-sa/input.dat
+++ b/tests/methods/dwms-dsrgpt-1-sa/input.dat
@@ -85,11 +85,11 @@ set forte{
 }
 
 Emcscf, wfn = energy('casscf', return_wfn=True)
-compare_values(Emcscf_avg,get_variable("CURRENT ENERGY"),8,"SA-CASSCF energy")
+compare_values(Emcscf_avg,variable("CURRENT ENERGY"),8,"SA-CASSCF energy")
 
 energy('forte', ref_wfn=wfn)
-E0 = get_variable("ENERGY ROOT 0")
-E1 = get_variable("ENERGY ROOT 1")
+E0 = variable("ENERGY ROOT 0")
+E1 = variable("ENERGY ROOT 1")
 compare_values(Ept2_root0,E0,8,"SA-DSRG-PT2c energy on root 0")
 compare_values(Ept2_root1,E1,8,"SA-DSRG-PT2c energy on root 1")
 
@@ -99,5 +99,5 @@ set forte{
   dwms_algorithm     sa
 }
 energy('forte', ref_wfn=wfn)
-compare_values(E0,get_variable("ENERGY ROOT 0"),8,"DWSA-DSRG-PT2 energy on root 0")
-compare_values(E1,get_variable("ENERGY ROOT 1"),8,"DWSA-DSRG-PT2 energy on root 1")
+compare_values(E0,variable("ENERGY ROOT 0"),8,"DWSA-DSRG-PT2 energy on root 0")
+compare_values(E1,variable("ENERGY ROOT 1"),8,"DWSA-DSRG-PT2 energy on root 1")

--- a/tests/methods/dwms-dsrgpt-2-sa/input.dat
+++ b/tests/methods/dwms-dsrgpt-2-sa/input.dat
@@ -93,11 +93,11 @@ set forte{
 }
 
 Emcscf, wfn = energy('casscf', return_wfn=True)
-compare_values(Emcscf_avg,get_variable("CURRENT ENERGY"),8,"SA-CASSCF energy")
+compare_values(Emcscf_avg,variable("CURRENT ENERGY"),8,"SA-CASSCF energy")
 
 energy('forte', ref_wfn=wfn)
-E0 = get_variable("ENERGY ROOT 0")
-E1 = get_variable("ENERGY ROOT 1")
+E0 = variable("ENERGY ROOT 0")
+E1 = variable("ENERGY ROOT 1")
 compare_values(Ept2_root0,E0,8,"DWSA-DSRG-PT2 (DF) energy on root 0")
 compare_values(Ept2_root1,E1,8,"DWSA-DSRG-PT2 (DF) energy on root 1")
 
@@ -106,8 +106,8 @@ set forte {
 }
 
 energy('forte', ref_wfn=wfn)
-E0 = get_variable("ENERGY ROOT 0")
-E1 = get_variable("ENERGY ROOT 1")
+E0 = variable("ENERGY ROOT 0")
+E1 = variable("ENERGY ROOT 1")
 compare_values(Ept2xsa_root0,E0,8,"DWXSA-DSRG-PT2 (DF) energy on root 0")
 compare_values(Ept2xsa_root1,E1,8,"DWXSA-DSRG-PT2 (DF) energy on root 1")
 
@@ -117,8 +117,8 @@ set forte{
 }
 
 energy('forte', ref_wfn=wfn)
-E0 = get_variable("ENERGY ROOT 0")
-E1 = get_variable("ENERGY ROOT 1")
+E0 = variable("ENERGY ROOT 0")
+E1 = variable("ENERGY ROOT 1")
 compare_values(Ept2Hbar3_root0,E0,8,"DWSA-DSRG-PT2 (DF, HBAR3) energy on root 0")
 compare_values(Ept2Hbar3_root1,E1,8,"DWSA-DSRG-PT2 (DF, HBAR3) energy on root 1")
 
@@ -127,7 +127,7 @@ set forte{
 }
 
 energy('forte', ref_wfn=wfn)
-E0 = get_variable("ENERGY ROOT 0")
-E1 = get_variable("ENERGY ROOT 1")
+E0 = variable("ENERGY ROOT 0")
+E1 = variable("ENERGY ROOT 1")
 compare_values(Ept2Hbar3_root0,E0,8,"DWSA-DSRG-PT2 (DiskDF, HBAR3) energy on root 0")
 compare_values(Ept2Hbar3_root1,E1,8,"DWSA-DSRG-PT2 (DiskDF, HBAR3) energy on root 1")

--- a/tests/methods/dwms-dsrgpt-3-sa/input.dat
+++ b/tests/methods/dwms-dsrgpt-3-sa/input.dat
@@ -90,11 +90,11 @@ set forte{
 }
 
 Emcscf, wfn = energy('casscf', return_wfn=True)
-compare_values(Emcscf_avg,get_variable("CURRENT ENERGY"),8,"SA-CASSCF energy")
+compare_values(Emcscf_avg,variable("CURRENT ENERGY"),8,"SA-CASSCF energy")
 
 energy('forte', ref_wfn=wfn)
-E0 = get_variable("ENERGY ROOT 0")
-E1 = get_variable("ENERGY ROOT 1")
+E0 = variable("ENERGY ROOT 0")
+E1 = variable("ENERGY ROOT 1")
 compare_values(Ept3_root0,E0,8,"DWSA-DSRG-PT3 energy on root 0")
 compare_values(Ept3_root1,E1,8,"DWSA-DSRG-PT3 energy on root 1")
 
@@ -107,8 +107,8 @@ set forte{
 }
 
 energy('forte', ref_wfn=wfn)
-E0 = get_variable("ENERGY ROOT 0")
-E1 = get_variable("ENERGY ROOT 1")
+E0 = variable("ENERGY ROOT 0")
+E1 = variable("ENERGY ROOT 1")
 compare_values(Ept3_root0,E0,8,"DWSA-DSRG-PT3 (CD) energy on root 0")
 compare_values(Ept3_root1,E1,8,"DWSA-DSRG-PT3 (CD) energy on root 1")
 
@@ -117,7 +117,7 @@ set forte{
 }
 
 energy('forte', ref_wfn=wfn)
-E0 = get_variable("ENERGY ROOT 0")
-E1 = get_variable("ENERGY ROOT 1")
+E0 = variable("ENERGY ROOT 0")
+E1 = variable("ENERGY ROOT 1")
 compare_values(Ept3xsa_root0,E0,8,"DWXSA-DSRG-PT3 (CD) energy on root 0")
 compare_values(Ept3xsa_root1,E1,8,"DWXSA-DSRG-PT3 (CD) energy on root 1")

--- a/tests/methods/dwms-dsrgpt-4-sa/input.dat
+++ b/tests/methods/dwms-dsrgpt-4-sa/input.dat
@@ -90,11 +90,11 @@ set forte{
 }
 
 Emcscf, wfn = energy('casscf', return_wfn=True)
-compare_values(Emcscf_avg,get_variable("CURRENT ENERGY"),8,"SA-CASSCF energy")
+compare_values(Emcscf_avg,variable("CURRENT ENERGY"),8,"SA-CASSCF energy")
 
 energy('forte', ref_wfn=wfn)
-E0 = get_variable("ENERGY ROOT 0")
-E1 = get_variable("ENERGY ROOT 1")
+E0 = variable("ENERGY ROOT 0")
+E1 = variable("ENERGY ROOT 1")
 compare_values(Ept2_root0,E0,8,"DWSA-DSRG-PT2 (PT2 REFERENCE) energy on root 0")
 compare_values(Ept2_root1,E1,8,"DWSA-DSRG-PT2 (PT2 REFERENCE) energy on root 1")
 
@@ -104,7 +104,7 @@ set forte {
 }
 
 energy('forte', ref_wfn=wfn)
-E0 = get_variable("ENERGY ROOT 0")
-E1 = get_variable("ENERGY ROOT 1")
+E0 = variable("ENERGY ROOT 0")
+E1 = variable("ENERGY ROOT 1")
 compare_values(Ept3_root0,E0,8,"DWSA-DSRG-PT3 (PT3 REFERENCE) energy on root 0")
 compare_values(Ept3_root1,E1,8,"DWSA-DSRG-PT3 (PT3 REFERENCE) energy on root 1")

--- a/tests/methods/dwms-dsrgpt-5-ms/input.dat
+++ b/tests/methods/dwms-dsrgpt-5-ms/input.dat
@@ -12,8 +12,8 @@ def compare_energy_local(name, xms=False):
     Eref0, Eref1 = Ept2_root0, Ept2_root1
     if xms:
         Eref0, Eref1 = Ept2_root0x, Ept2_root1x
-    E0 = get_variable("ENERGY ROOT 0")
-    E1 = get_variable("ENERGY ROOT 1")
+    E0 = variable("ENERGY ROOT 0")
+    E1 = variable("ENERGY ROOT 1")
     compare_values(Eref0, E0, 8, name+"-DSRG-PT2 energy on root 0")
     compare_values(Eref1, E1, 8, name+"-DSRG-PT2 energy on root 1")
 
@@ -83,7 +83,7 @@ set globals{
 }
 
 Emcscf, wfn = energy('casscf', return_wfn=True)
-compare_values(Emcscf_avg,get_variable("CURRENT ENERGY"),8,"SA-CASSCF energy")
+compare_values(Emcscf_avg,variable("CURRENT ENERGY"),8,"SA-CASSCF energy")
 
 set forte{
   job_type           dsrg-mrpt2

--- a/tests/methods/dwms-dsrgpt-6-ms/input.dat
+++ b/tests/methods/dwms-dsrgpt-6-ms/input.dat
@@ -93,11 +93,11 @@ set forte{
 }
 
 Emcscf, wfn = energy('casscf', return_wfn=True)
-compare_values(Emcscf_avg,get_variable("CURRENT ENERGY"),8,"SA-CASSCF energy")
+compare_values(Emcscf_avg,variable("CURRENT ENERGY"),8,"SA-CASSCF energy")
 
 energy('forte', ref_wfn=wfn)
-E0 = get_variable("ENERGY ROOT 0")
-E1 = get_variable("ENERGY ROOT 1")
+E0 = variable("ENERGY ROOT 0")
+E1 = variable("ENERGY ROOT 1")
 compare_values(Ept2ms_0,E0,8,"DWMS-DSRG-PT2 (DF) energy on root 0")
 compare_values(Ept2ms_1,E1,8,"DWMS-DSRG-PT2 (DF) energy on root 1")
 
@@ -106,8 +106,8 @@ set forte {
 }
 
 energy('forte', ref_wfn=wfn)
-E0 = get_variable("ENERGY ROOT 0")
-E1 = get_variable("ENERGY ROOT 1")
+E0 = variable("ENERGY ROOT 0")
+E1 = variable("ENERGY ROOT 1")
 compare_values(Ept2xms_0,E0,8,"DWXMS-DSRG-PT2 (DF) energy on root 0")
 compare_values(Ept2xms_1,E1,8,"DWXMS-DSRG-PT2 (DF) energy on root 1")
 
@@ -117,8 +117,8 @@ set forte{
 }
 
 energy('forte', ref_wfn=wfn)
-E0 = get_variable("ENERGY ROOT 0")
-E1 = get_variable("ENERGY ROOT 1")
+E0 = variable("ENERGY ROOT 0")
+E1 = variable("ENERGY ROOT 1")
 compare_values(Ept2msHbar3_0,E0,8,"DWMS-DSRG-PT2 (DF, HBAR3) energy on root 0")
 compare_values(Ept2msHbar3_1,E1,8,"DWMS-DSRG-PT2 (DF, HBAR3) energy on root 1")
 
@@ -127,7 +127,7 @@ set forte{
 }
 
 energy('forte', ref_wfn=wfn)
-E0 = get_variable("ENERGY ROOT 0")
-E1 = get_variable("ENERGY ROOT 1")
+E0 = variable("ENERGY ROOT 0")
+E1 = variable("ENERGY ROOT 1")
 compare_values(Ept2msHbar3_0,E0,8,"DWMS-DSRG-PT2 (DiskDF, HBAR3) energy on root 0")
 compare_values(Ept2msHbar3_1,E1,8,"DWMS-DSRG-PT2 (DiskDF, HBAR3) energy on root 1")

--- a/tests/methods/dwms-dsrgpt-7-ms/input.dat
+++ b/tests/methods/dwms-dsrgpt-7-ms/input.dat
@@ -77,7 +77,7 @@ set globals{
 }
 
 Emcscf, wfn = energy('casscf', return_wfn=True)
-compare_values(Emcscf_avg,get_variable("CURRENT ENERGY"),8,"SA-CASSCF energy")
+compare_values(Emcscf_avg,variable("CURRENT ENERGY"),8,"SA-CASSCF energy")
 
 set forte{
   job_type           dwms-dsrgpt2
@@ -95,8 +95,8 @@ set forte{
 }
 
 energy('forte', ref_wfn=wfn)
-E0 = get_variable("ENERGY ROOT 0")
-E1 = get_variable("ENERGY ROOT 1")
+E0 = variable("ENERGY ROOT 0")
+E1 = variable("ENERGY ROOT 1")
 compare_values(Ept2_root0,E0,8,"DWMS-DSRG-PT2 (PT2 REFERENCE) energy on root 0")
 compare_values(Ept2_root1,E1,8,"DWMS-DSRG-PT2 (PT2 REFERENCE) energy on root 1")
 
@@ -105,8 +105,8 @@ set forte {
 }
 
 energy('forte', ref_wfn=wfn)
-E0 = get_variable("ENERGY ROOT 0")
-E1 = get_variable("ENERGY ROOT 1")
+E0 = variable("ENERGY ROOT 0")
+E1 = variable("ENERGY ROOT 1")
 compare_values(Ept2x_root0,E0,8,"DWXMS-DSRG-PT2 (PT2 REFERENCE) energy on root 0")
 compare_values(Ept2x_root1,E1,8,"DWXMS-DSRG-PT2 (PT2 REFERENCE) energy on root 1")
 
@@ -116,7 +116,7 @@ set forte {
 }
 
 energy('forte', ref_wfn=wfn)
-E0 = get_variable("ENERGY ROOT 0")
-E1 = get_variable("ENERGY ROOT 1")
+E0 = variable("ENERGY ROOT 0")
+E1 = variable("ENERGY ROOT 1")
 compare_values(Ept3_root0,E0,8,"DWMS-DSRG-PT2 (PT3 REFERENCE) energy on root 0")
 compare_values(Ept3_root1,E1,8,"DWMS-DSRG-PT2 (PT3 REFERENCE) energy on root 1")

--- a/tests/methods/dwms-dsrgpt-8-separated/input.dat
+++ b/tests/methods/dwms-dsrgpt-8-separated/input.dat
@@ -84,13 +84,13 @@ set forte{
 }
 
 Emcscf, wfn = energy('casscf', return_wfn=True)
-compare_values(Emcscf_avg,get_variable("CURRENT ENERGY"),8,"SA-CASSCF energy")
+compare_values(Emcscf_avg,variable("CURRENT ENERGY"),8,"SA-CASSCF energy")
 
 Ept2_root0 = -106.93005699411140
 Ept2_root1 = -106.91457748207812
 energy('forte',ref_wfn=wfn)
-compare_values(Ept2_root0,get_variable("ENERGY ROOT 0"),8,"CASCI/DWMS(sH0)-DSRG-PT2 energy on root 0")
-compare_values(Ept2_root1,get_variable("ENERGY ROOT 1"),8,"CASCI/DWMS(sH0)-DSRG-PT2 energy on root 1")
+compare_values(Ept2_root0,variable("ENERGY ROOT 0"),8,"CASCI/DWMS(sH0)-DSRG-PT2 energy on root 0")
+compare_values(Ept2_root1,variable("ENERGY ROOT 1"),8,"CASCI/DWMS(sH0)-DSRG-PT2 energy on root 1")
 
 set forte{
   dwms_algorithm sh-1
@@ -98,8 +98,8 @@ set forte{
 Ept2_root0 = -106.93005699410999
 Ept2_root1 = -106.91457784175027
 energy('forte',ref_wfn=wfn)
-compare_values(Ept2_root0,get_variable("ENERGY ROOT 0"),8,"CASCI/DWMS(sH1)-DSRG-PT2 energy on root 0")
-compare_values(Ept2_root1,get_variable("ENERGY ROOT 1"),8,"CASCI/DWMS(sH1)-DSRG-PT2 energy on root 1")
+compare_values(Ept2_root0,variable("ENERGY ROOT 0"),8,"CASCI/DWMS(sH1)-DSRG-PT2 energy on root 0")
+compare_values(Ept2_root1,variable("ENERGY ROOT 1"),8,"CASCI/DWMS(sH1)-DSRG-PT2 energy on root 1")
 
 set forte{
   dwms_algorithm sh-0
@@ -108,8 +108,8 @@ set forte{
 Ept2_root0 = -106.92994534239719
 Ept2_root1 = -106.91463499737895
 energy('forte',ref_wfn=wfn)
-compare_values(Ept2_root0,get_variable("ENERGY ROOT 0"),8,"PT2/DWMS(sH0)-DSRG-PT2 energy on root 0")
-compare_values(Ept2_root1,get_variable("ENERGY ROOT 1"),8,"PT2/DWMS(sH0)-DSRG-PT2 energy on root 1")
+compare_values(Ept2_root0,variable("ENERGY ROOT 0"),8,"PT2/DWMS(sH0)-DSRG-PT2 energy on root 0")
+compare_values(Ept2_root1,variable("ENERGY ROOT 1"),8,"PT2/DWMS(sH0)-DSRG-PT2 energy on root 1")
 
 set forte{
   dwms_algorithm sh-1
@@ -118,5 +118,5 @@ set forte{
 Ept2_root0 = -106.92994534239851
 Ept2_root1 = -106.91463499781882
 energy('forte',ref_wfn=wfn)
-compare_values(Ept2_root0,get_variable("ENERGY ROOT 0"),8,"PT2/DWMS(sH1)-DSRG-PT2 energy on root 0")
-compare_values(Ept2_root1,get_variable("ENERGY ROOT 1"),8,"PT2/DWMS(sH1)-DSRG-PT2 energy on root 1")
+compare_values(Ept2_root0,variable("ENERGY ROOT 0"),8,"PT2/DWMS(sH1)-DSRG-PT2 energy on root 0")
+compare_values(Ept2_root1,variable("ENERGY ROOT 1"),8,"PT2/DWMS(sH1)-DSRG-PT2 energy on root 1")

--- a/tests/methods/dwms-dsrgpt-9-sa-C6H6/input.dat
+++ b/tests/methods/dwms-dsrgpt-9-sa-C6H6/input.dat
@@ -38,7 +38,7 @@ set {
   docc           [6,3,1,1,0,1,5,4]
 }
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(Escf,get_variable("CURRENT ENERGY"),8,"DF-SCF(RHF) energy")
+compare_values(Escf,variable("CURRENT ENERGY"),8,"DF-SCF(RHF) energy")
 
 set forte{
   job_type           dwms-dsrgpt2
@@ -58,5 +58,5 @@ set forte{
 energy('forte', ref_wfn=wfn)
 for i in range(7):
     msg = "DWMS-DSRG-PT2 energy on root {}".format(i)
-    E = get_variable("ENERGY ROOT {}".format(i))
+    E = variable("ENERGY ROOT {}".format(i))
     compare_values(Ept2[i], E, 8, msg)

--- a/tests/methods/fapici-1/input.dat
+++ b/tests/methods/fapici-1/input.dat
@@ -36,7 +36,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refapifci, get_variable("APIFCI ENERGY"), 11, "Fast APIFCI energy") #TEST
+compare_values(refapifci, variable("APIFCI ENERGY"), 11, "Fast APIFCI energy") #TEST

--- a/tests/methods/fci-1/input.dat
+++ b/tests/methods/fci-1/input.dat
@@ -24,7 +24,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"),11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(reffci, get_variable("CURRENT ENERGY"),11, "FCI energy") #TEST
+compare_values(reffci, variable("CURRENT ENERGY"),11, "FCI energy") #TEST

--- a/tests/methods/fci-2/input.dat
+++ b/tests/methods/fci-2/input.dat
@@ -24,7 +24,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"),11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(reffci, get_variable("CURRENT ENERGY"),11, "FCI energy") #TEST
+compare_values(reffci, variable("CURRENT ENERGY"),11, "FCI energy") #TEST

--- a/tests/methods/fci-3/input.dat
+++ b/tests/methods/fci-3/input.dat
@@ -33,7 +33,7 @@ set forte {
 
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"),11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(reffci, get_variable("CURRENT ENERGY"),11, "FCI energy") #TEST
+compare_values(reffci, variable("CURRENT ENERGY"),11, "FCI energy") #TEST

--- a/tests/methods/fci-4/input.dat
+++ b/tests/methods/fci-4/input.dat
@@ -34,7 +34,7 @@ set forte {
 
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"),11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(reffci, get_variable("CURRENT ENERGY"),11, "FCI energy") #TEST
+compare_values(reffci, variable("CURRENT ENERGY"),11, "FCI energy") #TEST

--- a/tests/methods/fci-5/input.dat
+++ b/tests/methods/fci-5/input.dat
@@ -10,7 +10,6 @@ ref_rohf = -3.8510304164778151
 #Reference value in wavenumbers
 ref_split = (-3.851214594496629 - -3.851030416685039) * 219474.63
 
-
 memory 1 GB
 molecule HHeH {
 0   3

--- a/tests/methods/fci-6/input.dat
+++ b/tests/methods/fci-6/input.dat
@@ -29,7 +29,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(ref_scf, get_variable("CURRENT ENERGY"),11, "SCF energy") #TEST
+compare_values(ref_scf, variable("CURRENT ENERGY"),11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(ref_fci, get_variable("CURRENT ENERGY"),9, "FCI energy") #TEST
+compare_values(ref_fci, variable("CURRENT ENERGY"),9, "FCI energy") #TEST

--- a/tests/methods/fci-7/input.dat
+++ b/tests/methods/fci-7/input.dat
@@ -20,7 +20,7 @@ set {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"),11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),11, "SCF energy") #TEST
 
 set forte {
   job_type fci
@@ -29,7 +29,7 @@ set forte {
 }
 
 energy('forte')
-compare_values(reffci, get_variable("CURRENT ENERGY"),11, "FCI energy (M_S =  1/2)") #TEST
+compare_values(reffci, variable("CURRENT ENERGY"),11, "FCI energy (M_S =  1/2)") #TEST
 
 set forte {
   job_type fci
@@ -38,7 +38,7 @@ set forte {
 }
 
 energy('forte')
-compare_values(reffci, get_variable("CURRENT ENERGY"),11, "FCI energy (M_S = -1/2)") #TEST
+compare_values(reffci, variable("CURRENT ENERGY"),11, "FCI energy (M_S = -1/2)") #TEST
 
 clean()
 
@@ -55,7 +55,7 @@ units bohr
 }
 
 scf_triplet = energy('scf')
-compare_values(refscf_triplet, get_variable("CURRENT ENERGY"),11, "SCF energy") #TEST
+compare_values(refscf_triplet, variable("CURRENT ENERGY"),11, "SCF energy") #TEST
 
 set forte {
   job_type fci
@@ -64,7 +64,7 @@ set forte {
 }
 
 energy('forte')
-compare_values(reffci_triplet, get_variable("CURRENT ENERGY"),11, "FCI energy (M_S =  1)") #TEST
+compare_values(reffci_triplet, variable("CURRENT ENERGY"),11, "FCI energy (M_S =  1)") #TEST
 
 set forte {
   job_type fci
@@ -73,7 +73,7 @@ set forte {
 }
 
 energy('forte')
-compare_values(reffci_triplet, get_variable("CURRENT ENERGY"),11, "FCI energy (M_S =  0)") #TEST
+compare_values(reffci_triplet, variable("CURRENT ENERGY"),11, "FCI energy (M_S =  0)") #TEST
 
 set forte {
   job_type fci
@@ -82,4 +82,4 @@ set forte {
 }
 
 energy('forte')
-compare_values(reffci_triplet, get_variable("CURRENT ENERGY"),11, "FCI energy (M_S = -1)") #TEST
+compare_values(reffci_triplet, variable("CURRENT ENERGY"),11, "FCI energy (M_S = -1)") #TEST

--- a/tests/methods/fci-one-electron/input.dat
+++ b/tests/methods/fci-one-electron/input.dat
@@ -35,7 +35,7 @@ set forte{
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"),10, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),10, "SCF energy") #TEST
 
 energy('forte')
-compare_values(reffci, get_variable("CURRENT ENERGY"),10, "FCI energy") #TEST
+compare_values(reffci, variable("CURRENT ENERGY"),10, "FCI energy") #TEST

--- a/tests/methods/fci-rdms-1/input.dat
+++ b/tests/methods/fci-rdms-1/input.dat
@@ -27,10 +27,10 @@ set forte {
 energy('scf')
 energy('forte')
 
-compare_values(0.0, get_variable("AAAA 2-RDM ERROR"),12, "AAAA 2-RDM") #TEST
-compare_values(0.0, get_variable("BBBB 2-RDM ERROR"),12, "BBBB 2-RDM") #TEST
-compare_values(0.0, get_variable("ABAB 2-RDM ERROR"),12, "ABAB 2-RDM") #TEST
-compare_values(0.0, get_variable("AABAAB 3-RDM ERROR"),12, "AABAAB 3-RDM") #TEST
-compare_values(0.0, get_variable("ABBABB 3-RDM ERROR"),12, "ABBABB 3-RDM") #TEST
-compare_values(0.0, get_variable("AAAAAA 3-RDM ERROR"),12, "AAAAAA 3-RDM") #TEST
-compare_values(0.0, get_variable("BBBBBB 3-RDM ERROR"),12, "BBBBBB 3-RDM") #TEST
+compare_values(0.0, variable("AAAA 2-RDM ERROR"),12, "AAAA 2-RDM") #TEST
+compare_values(0.0, variable("BBBB 2-RDM ERROR"),12, "BBBB 2-RDM") #TEST
+compare_values(0.0, variable("ABAB 2-RDM ERROR"),12, "ABAB 2-RDM") #TEST
+compare_values(0.0, variable("AABAAB 3-RDM ERROR"),12, "AABAAB 3-RDM") #TEST
+compare_values(0.0, variable("ABBABB 3-RDM ERROR"),12, "ABBABB 3-RDM") #TEST
+compare_values(0.0, variable("AAAAAA 3-RDM ERROR"),12, "AAAAAA 3-RDM") #TEST
+compare_values(0.0, variable("BBBBBB 3-RDM ERROR"),12, "BBBBBB 3-RDM") #TEST

--- a/tests/methods/fci-rdms-2/input.dat
+++ b/tests/methods/fci-rdms-2/input.dat
@@ -27,10 +27,10 @@ set forte {
 energy('scf')
 energy('forte')
 
-compare_values(0.0, get_variable("AAAA 2-RDM ERROR"),12, "AAAA 2-RDM") #TEST
-compare_values(0.0, get_variable("BBBB 2-RDM ERROR"),12, "BBBB 2-RDM") #TEST
-compare_values(0.0, get_variable("ABAB 2-RDM ERROR"),12, "ABAB 2-RDM") #TEST
-compare_values(0.0, get_variable("AABAAB 3-RDM ERROR"),12, "AABAAB 3-RDM") #TEST
-compare_values(0.0, get_variable("ABBABB 3-RDM ERROR"),12, "ABBABB 3-RDM") #TEST
-compare_values(0.0, get_variable("AAAAAA 3-RDM ERROR"),12, "AAAAAA 3-RDM") #TEST
-compare_values(0.0, get_variable("BBBBBB 3-RDM ERROR"),12, "BBBBBB 3-RDM") #TEST
+compare_values(0.0, variable("AAAA 2-RDM ERROR"),12, "AAAA 2-RDM") #TEST
+compare_values(0.0, variable("BBBB 2-RDM ERROR"),12, "BBBB 2-RDM") #TEST
+compare_values(0.0, variable("ABAB 2-RDM ERROR"),12, "ABAB 2-RDM") #TEST
+compare_values(0.0, variable("AABAAB 3-RDM ERROR"),12, "AABAAB 3-RDM") #TEST
+compare_values(0.0, variable("ABBABB 3-RDM ERROR"),12, "ABBABB 3-RDM") #TEST
+compare_values(0.0, variable("AAAAAA 3-RDM ERROR"),12, "AAAAAA 3-RDM") #TEST
+compare_values(0.0, variable("BBBBBB 3-RDM ERROR"),12, "BBBBBB 3-RDM") #TEST

--- a/tests/methods/fciqmc/input.dat
+++ b/tests/methods/fciqmc/input.dat
@@ -34,7 +34,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(reffciqmc, get_variable("CURRENT ENERGY"), 3, "FCIQMC energy") #TEST
+compare_values(reffciqmc, variable("CURRENT ENERGY"), 3, "FCIQMC energy") #TEST

--- a/tests/methods/integrals-1/input.dat
+++ b/tests/methods/integrals-1/input.dat
@@ -29,5 +29,5 @@ set forte {
 }
 
 energy('forte')
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"),10, "SCF energy") #TEST
-compare_values(reffci, get_variable("CURRENT ENERGY"),10, "FCI energy") #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"),10, "SCF energy") #TEST
+compare_values(reffci, variable("CURRENT ENERGY"),10, "FCI energy") #TEST

--- a/tests/methods/integrals-2/input.dat
+++ b/tests/methods/integrals-2/input.dat
@@ -39,5 +39,5 @@ set forte {
 }
 
 energy('forte')
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"),10, "SCF energy") #TEST
-compare_values(reffci, get_variable("CURRENT ENERGY"),10, "FCI energy") #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"),10, "SCF energy") #TEST
+compare_values(reffci, variable("CURRENT ENERGY"),10, "FCI energy") #TEST

--- a/tests/methods/integrals-3/input.dat
+++ b/tests/methods/integrals-3/input.dat
@@ -30,5 +30,5 @@ set forte {
 }
 
 energy('forte')
-compare_values(refscf, variable("SCF TOTAL ENERGY"),10, "SCF energy") #TEST
-compare_values(reffci, variable("CURRENT ENERGY"),10, "FCI energy") #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 9, "SCF energy") #TEST
+compare_values(reffci, variable("CURRENT ENERGY"), 9, "FCI energy") #TEST

--- a/tests/methods/integrals-3/input.dat
+++ b/tests/methods/integrals-3/input.dat
@@ -30,5 +30,5 @@ set forte {
 }
 
 energy('forte')
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"),10, "SCF energy") #TEST
-compare_values(reffci, get_variable("CURRENT ENERGY"),10, "FCI energy") #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"),10, "SCF energy") #TEST
+compare_values(reffci, variable("CURRENT ENERGY"),10, "FCI energy") #TEST

--- a/tests/methods/integrals-4/input.dat
+++ b/tests/methods/integrals-4/input.dat
@@ -31,5 +31,5 @@ set forte {
 }
 
 energy('forte')
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"),10, "SCF energy") #TEST
-compare_values(reffci, get_variable("CURRENT ENERGY"),9, "FCI energy") #TEST
+compare_values(refscf, variable("SCF TOTAL ENERGY"),10, "SCF energy") #TEST
+compare_values(reffci, variable("CURRENT ENERGY"),9, "FCI energy") #TEST

--- a/tests/methods/integrals-5/input.dat
+++ b/tests/methods/integrals-5/input.dat
@@ -31,5 +31,5 @@ set forte {
 }
 
 energy('forte')
-#compare_values(refscf, get_variable("SCF TOTAL ENERGY"),10, "SCF energy") #TEST
-compare_values(reffci, get_variable("CURRENT ENERGY"),9, "FCI energy") #TEST
+#compare_values(refscf, variable("SCF TOTAL ENERGY"),10, "SCF energy") #TEST
+compare_values(reffci, variable("CURRENT ENERGY"),9, "FCI energy") #TEST

--- a/tests/methods/lambda+sd-ci-1/input.dat
+++ b/tests/methods/lambda+sd-ci-1/input.dat
@@ -31,5 +31,5 @@ set libadaptive {
 energy('mcscf')
 energy('libadaptive')
 
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
-compare_values(reflci, get_variable("LAMBDA+SD-CI ENERGY"),10, "Lambda-CI energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(reflci, variable("LAMBDA+SD-CI ENERGY"),10, "Lambda-CI energy") #TEST

--- a/tests/methods/lambda+sd-ci-2/input.dat
+++ b/tests/methods/lambda+sd-ci-2/input.dat
@@ -31,5 +31,5 @@ set libadaptive {
 energy('mcscf')
 energy('libadaptive')
 
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
-compare_values(reflci, get_variable("LAMBDA+SD-CI ENERGY"),10, "Lambda-CI energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(reflci, variable("LAMBDA+SD-CI ENERGY"),10, "Lambda-CI energy") #TEST

--- a/tests/methods/mr-dsrg-pt2-1/input.dat
+++ b/tests/methods/mr-dsrg-pt2-1/input.dat
@@ -72,7 +72,7 @@ S   1   1.00
 }
 
 scf_energy, wfn = energy('casscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10, "MR-DSRG-PT2 energy") #TEST
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10, "MR-DSRG-PT2 energy") #TEST

--- a/tests/methods/mr-dsrg-pt2-2/input.dat
+++ b/tests/methods/mr-dsrg-pt2-2/input.dat
@@ -71,7 +71,7 @@ S   1   1.00
 }
 
 Emcscf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
 
 energy('forte',ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10,"MR-DSRG-PT2 energy") #TEST
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10,"MR-DSRG-PT2 energy") #TEST

--- a/tests/methods/mr-dsrg-pt2-3/input.dat
+++ b/tests/methods/mr-dsrg-pt2-3/input.dat
@@ -72,7 +72,7 @@ S   1   1.00
 }
 
 Emcscf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10,"MR-DSRG-PT2 energy") #TEST
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10,"MR-DSRG-PT2 energy") #TEST

--- a/tests/methods/mr-dsrg-pt2-4/input.dat
+++ b/tests/methods/mr-dsrg-pt2-4/input.dat
@@ -73,7 +73,7 @@ S   1   1.00
 }
 
 Emcscf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")

--- a/tests/methods/mr-srg-pt2-1/input.dat
+++ b/tests/methods/mr-srg-pt2-1/input.dat
@@ -46,7 +46,7 @@ set forte{
 }
 
 Emcscf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refsrgpt2,get_variable("CURRENT ENERGY"),8,"SRG-MRPT2 energy") #TEST
+compare_values(refsrgpt2,variable("CURRENT ENERGY"),8,"SRG-MRPT2 energy") #TEST

--- a/tests/methods/mr-srg-pt2-2/input.dat
+++ b/tests/methods/mr-srg-pt2-2/input.dat
@@ -44,7 +44,7 @@ set forte{
 }
 
 Ecas, wfn = energy('casscf', return_wfn=True)
-compare_values(refcasscf,get_variable("CURRENT ENERGY"),10,"CASSCF energy") #TEST
+compare_values(refcasscf,variable("CURRENT ENERGY"),10,"CASSCF energy") #TEST
 
 Esrgpt2_ode = energy('forte', ref_wfn=wfn)
 compare_values(Esrgpt2_mb,Esrgpt2_ode,6,"SRG-MRPT2 energy") #TEST

--- a/tests/methods/mrdsrg-ldsrg2-df-1/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-df-1/input.dat
@@ -78,9 +78,9 @@ set forte {
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrohf,get_variable("CURRENT ENERGY"),10,"ROHF energy")
+compare_values(refrohf,variable("CURRENT ENERGY"),10,"ROHF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refudsrg,get_variable("UNRELAXED ENERGY"),8,"MRDSRG unrelaxed energy")
-compare_values(refprdsrg,get_variable("PARTIALLY RELAXED ENERGY"),8,"MRDSRG partially relaxed energy")
-compare_values(refrdsrg,get_variable("RELAXED ENERGY"),8,"MRDSRG relaxed energy")
+compare_values(refudsrg,variable("UNRELAXED ENERGY"),8,"MRDSRG unrelaxed energy")
+compare_values(refprdsrg,variable("PARTIALLY RELAXED ENERGY"),8,"MRDSRG partially relaxed energy")
+compare_values(refrdsrg,variable("RELAXED ENERGY"),8,"MRDSRG relaxed energy")

--- a/tests/methods/mrdsrg-ldsrg2-df-2/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-df-2/input.dat
@@ -52,9 +52,9 @@ set forte{
 }
 
 Emcscf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy")
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refudsrg,get_variable("UNRELAXED ENERGY"),8,"MRDSRG unrelaxed energy")
-compare_values(refprdsrg,get_variable("PARTIALLY RELAXED ENERGY"),8,"MRDSRG partially relaxed energy")
-compare_values(refrdsrg,get_variable("RELAXED ENERGY"),8,"MRDSRG relaxed energy")
+compare_values(refudsrg,variable("UNRELAXED ENERGY"),8,"MRDSRG unrelaxed energy")
+compare_values(refprdsrg,variable("PARTIALLY RELAXED ENERGY"),8,"MRDSRG partially relaxed energy")
+compare_values(refrdsrg,variable("RELAXED ENERGY"),8,"MRDSRG relaxed energy")

--- a/tests/methods/mrdsrg-ldsrg2-df-3/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-df-3/input.dat
@@ -39,7 +39,7 @@ set forte{
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrhf,get_variable("CURRENT ENERGY"),10,"SCF energy")
+compare_values(refrhf,variable("CURRENT ENERGY"),10,"SCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refudsrg,get_variable("UNRELAXED ENERGY"),10,"MRDSRG unrelaxed energy")
+compare_values(refudsrg,variable("UNRELAXED ENERGY"),10,"MRDSRG unrelaxed energy")

--- a/tests/methods/mrdsrg-ldsrg2-df-nivo-1/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-df-nivo-1/input.dat
@@ -79,9 +79,9 @@ set forte {
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrohf,get_variable("CURRENT ENERGY"),10,"ROHF energy")
+compare_values(refrohf,variable("CURRENT ENERGY"),10,"ROHF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refudsrg,get_variable("UNRELAXED ENERGY"),8,"MRDSRG unrelaxed energy")
-compare_values(refprdsrg,get_variable("PARTIALLY RELAXED ENERGY"),8,"MRDSRG partially relaxed energy")
-compare_values(refrdsrg,get_variable("RELAXED ENERGY"),8,"MRDSRG relaxed energy")
+compare_values(refudsrg,variable("UNRELAXED ENERGY"),8,"MRDSRG unrelaxed energy")
+compare_values(refprdsrg,variable("PARTIALLY RELAXED ENERGY"),8,"MRDSRG partially relaxed energy")
+compare_values(refrdsrg,variable("RELAXED ENERGY"),8,"MRDSRG relaxed energy")

--- a/tests/methods/mrdsrg-ldsrg2-df-nivo-2/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-df-nivo-2/input.dat
@@ -53,9 +53,9 @@ set forte{
 }
 
 Emcscf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy")
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refudsrg,get_variable("UNRELAXED ENERGY"),8,"MRDSRG unrelaxed energy")
-compare_values(refprdsrg,get_variable("PARTIALLY RELAXED ENERGY"),8,"MRDSRG partially relaxed energy")
-compare_values(refrdsrg,get_variable("RELAXED ENERGY"),8,"MRDSRG relaxed energy")
+compare_values(refudsrg,variable("UNRELAXED ENERGY"),8,"MRDSRG unrelaxed energy")
+compare_values(refprdsrg,variable("PARTIALLY RELAXED ENERGY"),8,"MRDSRG partially relaxed energy")
+compare_values(refrdsrg,variable("RELAXED ENERGY"),8,"MRDSRG relaxed energy")

--- a/tests/methods/mrdsrg-ldsrg2-df-nivo-3/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-df-nivo-3/input.dat
@@ -40,7 +40,7 @@ set forte{
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrhf,get_variable("CURRENT ENERGY"),10,"SCF energy")
+compare_values(refrhf,variable("CURRENT ENERGY"),10,"SCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refudsrg,get_variable("UNRELAXED ENERGY"),10,"MRDSRG unrelaxed energy")
+compare_values(refudsrg,variable("UNRELAXED ENERGY"),10,"MRDSRG unrelaxed energy")

--- a/tests/methods/mrdsrg-ldsrg2-df-seq-1/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-df-seq-1/input.dat
@@ -79,9 +79,9 @@ set forte {
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrohf,get_variable("CURRENT ENERGY"),10,"ROHF energy")
+compare_values(refrohf,variable("CURRENT ENERGY"),10,"ROHF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refudsrg,get_variable("UNRELAXED ENERGY"),8,"MRDSRG unrelaxed energy")
-compare_values(refprdsrg,get_variable("PARTIALLY RELAXED ENERGY"),8,"MRDSRG partially relaxed energy")
-compare_values(refrdsrg,get_variable("RELAXED ENERGY"),8,"MRDSRG relaxed energy")
+compare_values(refudsrg,variable("UNRELAXED ENERGY"),8,"MRDSRG unrelaxed energy")
+compare_values(refprdsrg,variable("PARTIALLY RELAXED ENERGY"),8,"MRDSRG partially relaxed energy")
+compare_values(refrdsrg,variable("RELAXED ENERGY"),8,"MRDSRG relaxed energy")

--- a/tests/methods/mrdsrg-ldsrg2-df-seq-2/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-df-seq-2/input.dat
@@ -53,9 +53,9 @@ set forte{
 }
 
 Emcscf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy")
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refudsrg,get_variable("UNRELAXED ENERGY"),8,"MRDSRG unrelaxed energy")
-compare_values(refprdsrg,get_variable("PARTIALLY RELAXED ENERGY"),8,"MRDSRG partially relaxed energy")
-compare_values(refrdsrg,get_variable("RELAXED ENERGY"),8,"MRDSRG relaxed energy")
+compare_values(refudsrg,variable("UNRELAXED ENERGY"),8,"MRDSRG unrelaxed energy")
+compare_values(refprdsrg,variable("PARTIALLY RELAXED ENERGY"),8,"MRDSRG partially relaxed energy")
+compare_values(refrdsrg,variable("RELAXED ENERGY"),8,"MRDSRG relaxed energy")

--- a/tests/methods/mrdsrg-ldsrg2-df-seq-3/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-df-seq-3/input.dat
@@ -43,7 +43,7 @@ set forte{
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrhf,get_variable("CURRENT ENERGY"),10,"SCF energy")
+compare_values(refrhf,variable("CURRENT ENERGY"),10,"SCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refudsrg,get_variable("UNRELAXED ENERGY"),10,"MRDSRG unrelaxed energy")
+compare_values(refudsrg,variable("UNRELAXED ENERGY"),10,"MRDSRG unrelaxed energy")

--- a/tests/methods/mrdsrg-ldsrg2-df-seq-4/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-df-seq-4/input.dat
@@ -43,10 +43,10 @@ set forte{
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrhf,get_variable("CURRENT ENERGY"),10,"SCF energy")
+compare_values(refrhf,variable("CURRENT ENERGY"),10,"SCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refudsrg,get_variable("UNRELAXED ENERGY"),8,"MRDSRG unrelaxed energy")
-compare_values(refprdsrg,get_variable("PARTIALLY RELAXED ENERGY"),8,"MRDSRG partially relaxed energy")
-compare_values(refrdsrg,get_variable("RELAXED ENERGY"),8,"MRDSRG relaxed energy")
-compare_values(reffrdsrg,get_variable("FULLY RELAXED ENERGY"),8,"MRDSRG fully relaxed energy")
+compare_values(refudsrg,variable("UNRELAXED ENERGY"),8,"MRDSRG unrelaxed energy")
+compare_values(refprdsrg,variable("PARTIALLY RELAXED ENERGY"),8,"MRDSRG partially relaxed energy")
+compare_values(refrdsrg,variable("RELAXED ENERGY"),8,"MRDSRG relaxed energy")
+compare_values(reffrdsrg,variable("FULLY RELAXED ENERGY"),8,"MRDSRG fully relaxed energy")

--- a/tests/methods/mrdsrg-ldsrg2-df-seq-linear-1/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-df-seq-linear-1/input.dat
@@ -78,7 +78,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refrohf,get_variable("CURRENT ENERGY"),10,"ROHF energy") #TEST
+compare_values(refrohf,variable("CURRENT ENERGY"),10,"ROHF energy") #TEST
 
 energy('forte')
-compare_values(refdsrg,get_variable("CURRENT ENERGY"),8, "MRDSRG relaxed energy") #TEST
+compare_values(refdsrg,variable("CURRENT ENERGY"),8, "MRDSRG relaxed energy") #TEST

--- a/tests/methods/mrdsrg-ldsrg2-df-seq-linear-2/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-df-seq-linear-2/input.dat
@@ -52,7 +52,7 @@ set forte{
 }
 
 Emcscf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrg,get_variable("CURRENT ENERGY"),8,"MRDSRG relaxed energy") #TEST
+compare_values(refdsrg,variable("CURRENT ENERGY"),8,"MRDSRG relaxed energy") #TEST

--- a/tests/methods/mrdsrg-ldsrg2-df-seq-linear-3/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-df-seq-linear-3/input.dat
@@ -41,7 +41,7 @@ set forte{
 }
 
 energy('scf')
-compare_values(refrhf,get_variable("CURRENT ENERGY"),10,"SCF energy")
+compare_values(refrhf,variable("CURRENT ENERGY"),10,"SCF energy")
 
 energy('forte')
-compare_values(refdsrg,get_variable("CURRENT ENERGY"),10,"MRDSRG energy")
+compare_values(refdsrg,variable("CURRENT ENERGY"),10,"MRDSRG energy")

--- a/tests/methods/mrdsrg-ldsrg2-df-seq-nivo-1/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-df-seq-nivo-1/input.dat
@@ -79,8 +79,8 @@ set forte {
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrohf,get_variable("CURRENT ENERGY"),10,"ROHF energy")
+compare_values(refrohf,variable("CURRENT ENERGY"),10,"ROHF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refudsrg,get_variable("UNRELAXED ENERGY"),8, "MRDSRG unrelaxed energy")
-compare_values(refprdsrg,get_variable("PARTIALLY RELAXED ENERGY"),8, "MRDSRG partially relaxed energy")
+compare_values(refudsrg,variable("UNRELAXED ENERGY"),8, "MRDSRG unrelaxed energy")
+compare_values(refprdsrg,variable("PARTIALLY RELAXED ENERGY"),8, "MRDSRG partially relaxed energy")

--- a/tests/methods/mrdsrg-ldsrg2-df-seq-nivo-2/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-df-seq-nivo-2/input.dat
@@ -52,9 +52,9 @@ set forte{
 }
 
 Emcscf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy")
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refudsrg,get_variable("UNRELAXED ENERGY"),8,"MRDSRG unrelaxed energy")
-compare_values(refprdsrg,get_variable("PARTIALLY RELAXED ENERGY"),8,"MRDSRG partially relaxed energy")
-compare_values(refrdsrg,get_variable("RELAXED ENERGY"),8,"MRDSRG relaxed energy")
+compare_values(refudsrg,variable("UNRELAXED ENERGY"),8,"MRDSRG unrelaxed energy")
+compare_values(refprdsrg,variable("PARTIALLY RELAXED ENERGY"),8,"MRDSRG partially relaxed energy")
+compare_values(refrdsrg,variable("RELAXED ENERGY"),8,"MRDSRG relaxed energy")

--- a/tests/methods/mrdsrg-ldsrg2-df-seq-nivo-3/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-df-seq-nivo-3/input.dat
@@ -42,7 +42,7 @@ set forte{
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrhf,get_variable("CURRENT ENERGY"),10,"SCF energy")
+compare_values(refrhf,variable("CURRENT ENERGY"),10,"SCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrg,get_variable("CURRENT ENERGY"),8,"MRDSRG unrelaxed energy")
+compare_values(refdsrg,variable("CURRENT ENERGY"),8,"MRDSRG unrelaxed energy")

--- a/tests/methods/mrdsrg-ldsrg2-qc-1/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-qc-1/input.dat
@@ -49,7 +49,7 @@ set forte{
 }
 
 Emcscf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrg,get_variable("CURRENT ENERGY"),8,"MRDSRG fully relaxed energy") #TEST
+compare_values(refdsrg,variable("CURRENT ENERGY"),8,"MRDSRG fully relaxed energy") #TEST

--- a/tests/methods/mrdsrg-ldsrg2-qc-2/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-qc-2/input.dat
@@ -47,7 +47,7 @@ set forte{
 }
 
 Emcscf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrg,get_variable("CURRENT ENERGY"),8,"MRDSRG relaxed energy") #TEST
+compare_values(refdsrg,variable("CURRENT ENERGY"),8,"MRDSRG relaxed energy") #TEST

--- a/tests/methods/mrdsrg-ldsrg2-qc-df-2/input.dat
+++ b/tests/methods/mrdsrg-ldsrg2-qc-df-2/input.dat
@@ -49,7 +49,7 @@ set forte{
 }
 
 Emcscf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrg,get_variable("CURRENT ENERGY"),8,"MRDSRG relaxed energy") #TEST
+compare_values(refdsrg,variable("CURRENT ENERGY"),8,"MRDSRG relaxed energy") #TEST

--- a/tests/methods/mrdsrg-pt2-1/input.dat
+++ b/tests/methods/mrdsrg-pt2-1/input.dat
@@ -71,7 +71,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refrohf,get_variable("CURRENT ENERGY"),10,"ROHF energy") #TEST
+compare_values(refrohf,variable("CURRENT ENERGY"),10,"ROHF energy") #TEST
 
 energy('forte')
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),8, "MRDSRG-PT2 relaxed energy") #TEST
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),8, "MRDSRG-PT2 relaxed energy") #TEST

--- a/tests/methods/mrdsrg-pt2-2/input.dat
+++ b/tests/methods/mrdsrg-pt2-2/input.dat
@@ -73,7 +73,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refrohf,get_variable("CURRENT ENERGY"),10,"ROHF energy") #TEST
+compare_values(refrohf,variable("CURRENT ENERGY"),10,"ROHF energy") #TEST
 
 energy('forte')
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),10, "MRDSRG-PT2 relaxed energy") #TEST
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),10, "MRDSRG-PT2 relaxed energy") #TEST

--- a/tests/methods/mrdsrg-pt2-3/input.dat
+++ b/tests/methods/mrdsrg-pt2-3/input.dat
@@ -74,7 +74,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refrohf,get_variable("CURRENT ENERGY"),10,"ROHF energy") #TEST
+compare_values(refrohf,variable("CURRENT ENERGY"),10,"ROHF energy") #TEST
 
 energy('forte')
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),8,"MRDSRG-PT2 relaxed energy") #TEST
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),8,"MRDSRG-PT2 relaxed energy") #TEST

--- a/tests/methods/mrdsrg-pt2-4/input.dat
+++ b/tests/methods/mrdsrg-pt2-4/input.dat
@@ -47,7 +47,7 @@ set forte{
 }
 
 Emcscf, wfn = energy('mcscf', return_wfn=True)
-compare_values(refmcscf,get_variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
+compare_values(refmcscf,variable("CURRENT ENERGY"),10,"MCSCF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),8,"MRDSRG fully relaxed energy") #TEST
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),8,"MRDSRG fully relaxed energy") #TEST

--- a/tests/methods/mrdsrg-srgpt2-1/input.dat
+++ b/tests/methods/mrdsrg-srgpt2-1/input.dat
@@ -72,7 +72,7 @@ set forte {
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrohf,get_variable("CURRENT ENERGY"),10,"ROHF energy") #TEST
+compare_values(refrohf,variable("CURRENT ENERGY"),10,"ROHF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),8, "MRDSRG-PT2 relaxed energy") #TEST
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),8, "MRDSRG-PT2 relaxed energy") #TEST

--- a/tests/methods/mrdsrg-srgpt2-2/input.dat
+++ b/tests/methods/mrdsrg-srgpt2-2/input.dat
@@ -73,7 +73,7 @@ set forte {
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrohf,get_variable("CURRENT ENERGY"),10,"ROHF energy") #TEST
+compare_values(refrohf,variable("CURRENT ENERGY"),10,"ROHF energy") #TEST
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrgpt2,get_variable("CURRENT ENERGY"),8, "MRDSRG-PT2 relaxed energy") #TEST
+compare_values(refdsrgpt2,variable("CURRENT ENERGY"),8, "MRDSRG-PT2 relaxed energy") #TEST

--- a/tests/methods/pci-1/input.dat
+++ b/tests/methods/pci-1/input.dat
@@ -27,9 +27,9 @@ set forte {
   pci_e_convergence 12
 }
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refpci, get_variable("PCI ENERGY"), 11, "PCI energy") #TEST
-compare_values(refpostdiag, get_variable("PCI POST DIAG ENERGY"), 10, "PCI POST DIAG ENERGY") #TEST
+compare_values(refpci, variable("PCI ENERGY"), 11, "PCI energy") #TEST
+compare_values(refpostdiag, variable("PCI POST DIAG ENERGY"), 10, "PCI POST DIAG ENERGY") #TEST
 

--- a/tests/methods/pci-2/input.dat
+++ b/tests/methods/pci-2/input.dat
@@ -26,7 +26,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refpci, get_variable("PCI ENERGY"), 11, "PCI energy") #TEST
+compare_values(refpci, variable("PCI ENERGY"), 11, "PCI energy") #TEST

--- a/tests/methods/pci-3/input.dat
+++ b/tests/methods/pci-3/input.dat
@@ -26,8 +26,8 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refpci, get_variable("PCI ENERGY"), 11, "PCI energy") #TEST
+compare_values(refpci, variable("PCI ENERGY"), 11, "PCI energy") #TEST
 

--- a/tests/methods/pci-4/input.dat
+++ b/tests/methods/pci-4/input.dat
@@ -35,7 +35,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refpci, get_variable("PCI ENERGY"), 10, "PCI energy") #TEST
+compare_values(refpci, variable("PCI ENERGY"), 10, "PCI energy") #TEST

--- a/tests/methods/pci-5/input.dat
+++ b/tests/methods/pci-5/input.dat
@@ -38,7 +38,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refpci, get_variable("PCI ENERGY"), 7, "PCI energy") #TEST
+compare_values(refpci, variable("PCI ENERGY"), 7, "PCI energy") #TEST

--- a/tests/methods/pci-6/input.dat
+++ b/tests/methods/pci-6/input.dat
@@ -35,7 +35,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refpci, get_variable("PCI ENERGY"), 10, "PCI energy") #TEST
+compare_values(refpci, variable("PCI ENERGY"), 10, "PCI energy") #TEST

--- a/tests/methods/pci-7/input.dat
+++ b/tests/methods/pci-7/input.dat
@@ -38,8 +38,8 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refpci, get_variable("PCI ENERGY"), 10, "PCI energy") #TEST
-compare_values(refpostdiag, get_variable("PCI POST DIAG ENERGY"), 10, "POST DIAG energy") #TEST
+compare_values(refpci, variable("PCI ENERGY"), 10, "PCI energy") #TEST
+compare_values(refpostdiag, variable("PCI POST DIAG ENERGY"), 10, "POST DIAG energy") #TEST

--- a/tests/methods/pci-8/input.dat
+++ b/tests/methods/pci-8/input.dat
@@ -33,7 +33,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refpci, get_variable("PCI ENERGY"), 10, "PCI energy") #TEST
+compare_values(refpci, variable("PCI ENERGY"), 10, "PCI energy") #TEST

--- a/tests/methods/pci-9/input.dat
+++ b/tests/methods/pci-9/input.dat
@@ -34,7 +34,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refpci, get_variable("PCI ENERGY"), 11, "PCI energy") #TEST
+compare_values(refpci, variable("PCI ENERGY"), 11, "PCI energy") #TEST

--- a/tests/methods/pci_hashvec-1/input.dat
+++ b/tests/methods/pci_hashvec-1/input.dat
@@ -28,9 +28,9 @@ set forte {
   PCI_STOP_HIGHER_NEW_LOW true
 }
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refpci, get_variable("PCI ENERGY"), 11, "PCI energy") #TEST
-compare_values(refpostdiag, get_variable("PCI POST DIAG ENERGY"), 10, "PCI POST DIAG ENERGY") #TEST
+compare_values(refpci, variable("PCI ENERGY"), 11, "PCI energy") #TEST
+compare_values(refpostdiag, variable("PCI POST DIAG ENERGY"), 10, "PCI POST DIAG ENERGY") #TEST
 

--- a/tests/methods/pci_hashvec-2/input.dat
+++ b/tests/methods/pci_hashvec-2/input.dat
@@ -26,7 +26,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"), 10, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"), 10, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refpci, get_variable("PCI ENERGY"), 9, "PCI energy") #TEST
+compare_values(refpci, variable("PCI ENERGY"), 9, "PCI energy") #TEST

--- a/tests/methods/pci_hashvec-3/input.dat
+++ b/tests/methods/pci_hashvec-3/input.dat
@@ -35,7 +35,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refpci, get_variable("PCI ENERGY"), 10, "PCI energy") #TEST
+compare_values(refpci, variable("PCI ENERGY"), 10, "PCI energy") #TEST

--- a/tests/methods/pci_hashvec-4/input.dat
+++ b/tests/methods/pci_hashvec-4/input.dat
@@ -36,7 +36,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refpci, get_variable("PCI ENERGY"), 9, "PCI energy") #TEST
+compare_values(refpci, variable("PCI ENERGY"), 9, "PCI energy") #TEST

--- a/tests/methods/pci_hashvec-5/input.dat
+++ b/tests/methods/pci_hashvec-5/input.dat
@@ -33,7 +33,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refpci, get_variable("PCI ENERGY"), 11, "PCI energy") #TEST
+compare_values(refpci, variable("PCI ENERGY"), 11, "PCI energy") #TEST

--- a/tests/methods/pci_hashvec-6/input.dat
+++ b/tests/methods/pci_hashvec-6/input.dat
@@ -33,7 +33,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf, get_variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"), 11, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refpci, get_variable("PCI ENERGY"), 11, "PCI energy") #TEST
+compare_values(refpci, variable("PCI ENERGY"), 11, "PCI energy") #TEST

--- a/tests/methods/test-dist-df/input.dat
+++ b/tests/methods/test-dist-df/input.dat
@@ -54,7 +54,7 @@ scf, wfn = energy('mcscf', return_wfn=True)
 compare_values(refmcscf, scf,10,"SCF Energy")
 
 energy('forte', ref_wfn = wfn)
-#compare_values(refdsrgpt2_jk_rd, get_variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
+#compare_values(refdsrgpt2_jk_rd, variable("CURRENT ENERGY"),10,"DSRG-MRPT2 energy")
 compare_values(0.0, 0.0, 1, "TEST_DISTRIBUTED_SUCCESS")
 
 

--- a/tests/methods/v2rdm-dsrg-mrpt2-1/input.dat
+++ b/tests/methods/v2rdm-dsrg-mrpt2-1/input.dat
@@ -51,8 +51,8 @@ set forte{
 
 activate(N2)
 Ev2rdm, wfn = energy('v2rdm-casscf', return_wfn=True)
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 8, "SCF total energy")
-compare_values(refv2rdm, get_variable("CURRENT ENERGY"), 4, "v2RDM-CASSCF total energy")
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 8, "SCF total energy")
+compare_values(refv2rdm, variable("CURRENT ENERGY"), 4, "v2RDM-CASSCF total energy")
 
 energy('forte',ref_wfn=wfn)
-compare_values(refpt2, get_variable("CURRENT ENERGY"), 4, "DSRG-MRPT2 total energy")
+compare_values(refpt2, variable("CURRENT ENERGY"), 4, "DSRG-MRPT2 total energy")

--- a/tests/methods/v2rdm-dsrg-mrpt2-2/input.dat
+++ b/tests/methods/v2rdm-dsrg-mrpt2-2/input.dat
@@ -50,11 +50,11 @@ set forte{
 
 activate(N2)
 Ev2rdm, wfn = energy('v2rdm-casscf', return_wfn=True)
-compare_values(refscf, get_variable("SCF TOTAL ENERGY"), 8, "SCF total energy")
-compare_values(refv2rdm, get_variable("CURRENT ENERGY"), 4, "v2RDM-CASSCF total energy")
+compare_values(refscf, variable("SCF TOTAL ENERGY"), 8, "SCF total energy")
+compare_values(refv2rdm, variable("CURRENT ENERGY"), 4, "v2RDM-CASSCF total energy")
 
 Ept2_noavg = energy('forte',ref_wfn=wfn)
-compare_values(refpt2, get_variable("CURRENT ENERGY"), 4, "DSRG-MRPT2 total energy")
+compare_values(refpt2, variable("CURRENT ENERGY"), 4, "DSRG-MRPT2 total energy")
 
 set forte{
   avg_dens_spin          true

--- a/tests/obsolete/ex-aci-2/input.dat
+++ b/tests/obsolete/ex-aci-2/input.dat
@@ -38,8 +38,8 @@ set forte {
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),9, "EX-ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "EX-ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),9, "EX-ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "EX-ACI+PT2 energy") #TEST

--- a/tests/obsolete/ex-aci-3/input.dat
+++ b/tests/obsolete/ex-aci-3/input.dat
@@ -43,8 +43,8 @@ set forte {
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),9, "ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),9, "ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST

--- a/tests/obsolete/ex-aci-4/input.dat
+++ b/tests/obsolete/ex-aci-4/input.dat
@@ -39,8 +39,8 @@ set forte {
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),9, "EX-ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "EX-ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),9, "EX-ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "EX-ACI+PT2 energy") #TEST

--- a/tests/obsolete/ex-aci-5/input.dat
+++ b/tests/obsolete/ex-aci-5/input.dat
@@ -42,9 +42,9 @@ set forte {
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy")
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy")
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),7, "EX-ACI energy")
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),7, "EX_ACI+PT2 energy")
+compare_values(refaci, variable("ACI ENERGY"),7, "EX-ACI energy")
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),7, "EX_ACI+PT2 energy")
 

--- a/tests/obsolete/ex-aci-6/input.dat
+++ b/tests/obsolete/ex-aci-6/input.dat
@@ -43,8 +43,8 @@ set forte {
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refaci, get_variable("ACI ENERGY"),9, "EX-ACI energy") #TEST
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),8, "EX-ACI+PT2 energy") #TEST
+compare_values(refaci, variable("ACI ENERGY"),9, "EX-ACI energy") #TEST
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "EX-ACI+PT2 energy") #TEST

--- a/tests/obsolete/ex-aci-7/input.dat
+++ b/tests/obsolete/ex-aci-7/input.dat
@@ -43,8 +43,8 @@ set forte {
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
-compare_values(refaci, get_variable("EX-ACI ENERGY"),9, "EX-ACI energy") #TEST
-compare_values(refacipt2, get_variable("EX-ACI+PT2 ENERGY"),8, "EX-ACI+PT2 energy") #TEST
+compare_values(refaci, variable("EX-ACI ENERGY"),9, "EX-ACI energy") #TEST
+compare_values(refacipt2, variable("EX-ACI+PT2 ENERGY"),8, "EX-ACI+PT2 energy") #TEST

--- a/tests/obsolete/sr-lctsd-1/input.dat
+++ b/tests/obsolete/sr-lctsd-1/input.dat
@@ -22,5 +22,5 @@ set libadaptive {
 
 energy('sr-lctsd')
 
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
-compare_values(refct, get_variable("CURRENT ENERGY"),10, "SR-CTSD energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refct, variable("CURRENT ENERGY"),10, "SR-CTSD energy") #TEST

--- a/tests/obsolete/sr-lctsd-2/input.dat
+++ b/tests/obsolete/sr-lctsd-2/input.dat
@@ -26,5 +26,5 @@ set libadaptive {
 
 energy('sr-lctsd')
 
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
-compare_values(refct, get_variable("CURRENT ENERGY"),10, "SR-CTSD energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refct, variable("CURRENT ENERGY"),10, "SR-CTSD energy") #TEST

--- a/tests/obsolete/sr-srgsd-1/input.dat
+++ b/tests/obsolete/sr-srgsd-1/input.dat
@@ -27,5 +27,5 @@ set libadaptive {
 
 energy('sr-srgsd')
 
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
-compare_values(refsrg, get_variable("CURRENT ENERGY"),10, "SR-SRGSD energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refsrg, variable("CURRENT ENERGY"),10, "SR-SRGSD energy") #TEST

--- a/tests/obsolete/srg-1/input.dat
+++ b/tests/obsolete/srg-1/input.dat
@@ -26,5 +26,5 @@ set libadaptive {
 
 energy('srg')
 
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
-compare_values(refsrg, get_variable("CURRENT ENERGY"),10, "SR-SRGSD energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refsrg, variable("CURRENT ENERGY"),10, "SR-SRGSD energy") #TEST

--- a/tests/obsolete/srg-2/input.dat
+++ b/tests/obsolete/srg-2/input.dat
@@ -27,5 +27,5 @@ set libadaptive {
 
 energy('srg')
 
-compare_values(refscf, get_variable("SCF total energy"),10, "SCF energy") #TEST
-compare_values(refsrg, get_variable("CURRENT ENERGY"),10, "SR-SRGSD energy") #TEST
+compare_values(refscf, variable("SCF total energy"),10, "SCF energy") #TEST
+compare_values(refsrg, variable("CURRENT ENERGY"),10, "SR-SRGSD energy") #TEST

--- a/tests/performance/aci-1/input.dat
+++ b/tests/performance/aci-1/input.dat
@@ -38,10 +38,10 @@ set forte {
 
 energy('scf')
 
-compare_values(refscf, get_variable("CURRENT ENERGY"),9,"SCF energy")
+compare_values(refscf, variable("CURRENT ENERGY"),9,"SCF energy")
 
 energy('forte')
 
-compare_values(refaci, get_variable("ACI ENERGY"),9,"ACI energy")
-compare_values(refacipt2, get_variable("ACI+PT2 ENERGY"),9,"ACI+PT2 energy")
+compare_values(refaci, variable("ACI ENERGY"),9,"ACI energy")
+compare_values(refacipt2, variable("ACI+PT2 ENERGY"),9,"ACI+PT2 energy")
 

--- a/tests/performance/diskdf-dsrg-mrpt2-1/input.dat
+++ b/tests/performance/diskdf-dsrg-mrpt2-1/input.dat
@@ -59,6 +59,6 @@ scf = energy('scf')
 compare_values(refrohf, scf,8,"SCF Energy")
 
 energy('forte')
-compare_values(refdsrgpt2, get_variable("CURRENT ENERGY"),8,"DSRG-MRPT2 energy")
+compare_values(refdsrgpt2, variable("CURRENT ENERGY"),8,"DSRG-MRPT2 energy")
 
 

--- a/tests/performance/fci-1/input.dat
+++ b/tests/performance/fci-1/input.dat
@@ -25,7 +25,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf,get_variable("CURRENT ENERGY"),10,"SCF energy")
+compare_values(refscf,variable("CURRENT ENERGY"),10,"SCF energy")
 
 energy('forte')
-compare_values(reffci,get_variable("CURRENT ENERGY"),10,"FCI energy")
+compare_values(reffci,variable("CURRENT ENERGY"),10,"FCI energy")

--- a/tests/performance/mrdsrg-ldsrg2-df-seq-nivo-1/input.dat
+++ b/tests/performance/mrdsrg-ldsrg2-df-seq-nivo-1/input.dat
@@ -42,7 +42,7 @@ set forte{
 }
 
 Escf, wfn = energy('scf', return_wfn=True)
-compare_values(refrhf,get_variable("CURRENT ENERGY"),10,"SCF energy")
+compare_values(refrhf,variable("CURRENT ENERGY"),10,"SCF energy")
 
 energy('forte', ref_wfn=wfn)
-compare_values(refdsrg,get_variable("CURRENT ENERGY"),8,"MRDSRG unrelaxed energy")
+compare_values(refdsrg,variable("CURRENT ENERGY"),8,"MRDSRG unrelaxed energy")

--- a/tests/performance/pci-1/input.dat
+++ b/tests/performance/pci-1/input.dat
@@ -31,7 +31,7 @@ set forte {
 }
 
 energy('scf')
-compare_values(refscf,get_variable("CURRENT ENERGY"),10,"SCF energy")
+compare_values(refscf,variable("CURRENT ENERGY"),10,"SCF energy")
 
 energy('forte')
-compare_values(refpci, get_variable("PCI ENERGY"), 11, "PCI energy") #TEST
+compare_values(refpci, variable("PCI ENERGY"), 11, "PCI energy") #TEST

--- a/tests/pytest/test_aci.py
+++ b/tests/pytest/test_aci.py
@@ -13,7 +13,7 @@ def test_psi4_basic():
     psi4.set_options({'basis': "cc-pVDZ"})
     psi4.energy('scf')
 
-    assert psi4.compare_values(-76.0266327341067125, psi4.get_variable('SCF TOTAL ENERGY'), 6, 'SCF energy')
+    assert psi4.compare_values(-76.0266327341067125, psi4.variable('SCF TOTAL ENERGY'), 6, 'SCF energy')
 
 
 # LAB 25 May 2017 segfaulting after PQ-space in both psithon and psiapi forms
@@ -58,11 +58,11 @@ def test_psi4_basic():
 #    })
 #
 #    psi4.energy('scf')
-#    assert psi4.compare_values(refscf, psi4.get_variable("CURRENT ENERGY"),9, "SCF energy")
+#    assert psi4.compare_values(refscf, psi4.variable("CURRENT ENERGY"),9, "SCF energy")
 #
 #    psi4.energy('forte')
-#    assert psi4.compare_values(refaci, psi4.get_variable("ACI ENERGY"),9, "ACI energy")
-#    assert psi4.compare_values(refacipt2, psi4.get_variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy")
+#    assert psi4.compare_values(refaci, psi4.variable("ACI ENERGY"),9, "ACI energy")
+#    assert psi4.compare_values(refacipt2, psi4.variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy")
 
 
 def test_aci_10():
@@ -120,6 +120,6 @@ def test_aci_10():
     assert psi4.compare_values(refscf, scf,10,"SCF Energy")
 
     psi4.energy('forte')
-    assert psi4.compare_values(refaci, psi4.get_variable("ACI ENERGY"),10,"ACI energy")
-    assert psi4.compare_values(refacipt2, psi4.get_variable("ACI+PT2 ENERGY"),8,"ACI+PT2 energy")
+    assert psi4.compare_values(refaci, psi4.variable("ACI ENERGY"),10,"ACI energy")
+    assert psi4.compare_values(refacipt2, psi4.variable("ACI+PT2 ENERGY"),8,"ACI+PT2 energy")
 


### PR DESCRIPTION
## Description
This PR moves forte driver functions to Python by pybind11.

## PR User Notes
- [x] The Forte main function is now reproduced in python
- [x] Needs psi4 (commit 335343d)
- [x] Fix compilation problem due missing include files for psi4::Timer 

## PR Checklist
- [ ] Added tests of new features
- [x] Removed comments in code and input files
- [x] Documented source code
- [x] Checked for redundant headers
- [ ] Checked for consistency in the formatting of the output file
- [ ] Documented new features in the manual
- [x] Ready to go!