### PR TITLE
fix warnings in semicanonical and aosubspace

### DIFF
--- a/src/cc/cc.cc
+++ b/src/cc/cc.cc
@@ -42,7 +42,7 @@ namespace forte {
 CC::CC(SharedWavefunction ref_wfn, Options& options, std::shared_ptr<ForteIntegrals> ints,
        std::shared_ptr<MOSpaceInfo> mo_space_info)
     : Wavefunction(options), ints_(ints), mo_space_info_(mo_space_info),
-      BTF_(new BlockedTensorFactory(options)), tensor_type_(CoreTensor) {
+      BTF_(new BlockedTensorFactory()), tensor_type_(CoreTensor) {
     set_reference_wavefunction(ref_wfn);
     startup();
 }

--- a/src/helpers/blockedtensorfactory.cc
+++ b/src/helpers/blockedtensorfactory.cc
@@ -43,12 +43,11 @@
 namespace psi {
 namespace forte {
 
-BlockedTensorFactory::BlockedTensorFactory(Options& options)
-
-{
+BlockedTensorFactory::BlockedTensorFactory() {
     memory_ = Process::environment.get_memory() / 1073741824.0;
     number_of_tensors_ = 0;
 }
+
 BlockedTensorFactory::~BlockedTensorFactory() {
     if (print_memory_) {
         memory_summary();
@@ -73,15 +72,18 @@ ambit::BlockedTensor BlockedTensorFactory::build(ambit::TensorType storage, cons
 
     return BT;
 }
+
 void BlockedTensorFactory::add_mo_space(const std::string& name, const std::string& mo_indices,
                                         std::vector<size_t> mos, ambit::SpinType spin) {
     ambit::BlockedTensor::add_mo_space(name, mo_indices, mos, spin);
     molabel_to_index_[name] = mos;
 }
+
 void BlockedTensorFactory::add_mo_space(const std::string& name, const std::string& mo_indices,
                                         std::vector<std::pair<size_t, ambit::SpinType>> mo_spin) {
     ambit::BlockedTensor::add_mo_space(name, mo_indices, mo_spin);
 }
+
 void BlockedTensorFactory::add_composite_mo_space(const std::string& name,
                                                   const std::string& mo_indices,
                                                   const std::vector<std::string>& subspaces) {
@@ -162,6 +164,7 @@ std::vector<std::string> BlockedTensorFactory::generate_indices(const std::strin
 
     return return_string;
 }
+
 void BlockedTensorFactory::memory_information(ambit::BlockedTensor BT, bool is_local_variable) {
     double size_of_tensor = 0.0;
     std::vector<std::string> BTblocks = BT.block_labels();
@@ -191,6 +194,7 @@ void BlockedTensorFactory::memory_summary() {
     }
     outfile->Printf("\n Memory left over: %8.6f GB\n", memory_);
 }
+
 std::vector<std::string>
 BlockedTensorFactory::spin_cases_avoid(const std::vector<std::string>& in_str_vec,
                                        int how_many_active) {
@@ -217,6 +221,7 @@ BlockedTensorFactory::spin_cases_avoid(const std::vector<std::string>& in_str_ve
     }
     return out_str_vec;
 }
+
 void BlockedTensorFactory::memory_summary_per_block(ambit::BlockedTensor& tensor) {
 
     std::vector<std::string> Tensor_label = tensor.block_labels();
@@ -226,5 +231,5 @@ void BlockedTensorFactory::memory_summary_per_block(ambit::BlockedTensor& tensor
         outfile->Printf("\n %s   %8.8f GB", block.c_str(), memory_per_block);
     }
 }
-}
-}
+} // namespace forte
+} // namespace psi

--- a/src/helpers/blockedtensorfactory.h
+++ b/src/helpers/blockedtensorfactory.h
@@ -64,7 +64,7 @@ class BlockedTensorFactory {
     std::map<std::string, std::vector<size_t>> molabel_to_index_;
 
   public:
-    BlockedTensorFactory(Options& options);
+    BlockedTensorFactory();
     ~BlockedTensorFactory();
     /* -- Builds a block tensor
     //@params  storage-> Core, disk, or agnostic (program decides) Core has been

--- a/src/mrdsrg-so/mrdsrg_so.cc
+++ b/src/mrdsrg-so/mrdsrg_so.cc
@@ -43,7 +43,7 @@ namespace forte {
 MRDSRG_SO::MRDSRG_SO(Reference reference, Options& options, std::shared_ptr<ForteIntegrals> ints,
                      std::shared_ptr<MOSpaceInfo> mo_space_info)
     : Wavefunction(options), reference_(reference), ints_(ints), mo_space_info_(mo_space_info),
-      tensor_type_(CoreTensor), BTF(new BlockedTensorFactory(options)) {
+      tensor_type_(CoreTensor), BTF(new BlockedTensorFactory()) {
     // Copy the wavefunction information
     //    shallow_copy(ref_wfn);
 

--- a/src/mrdsrg-so/so-mrdsrg.cc
+++ b/src/mrdsrg-so/so-mrdsrg.cc
@@ -52,7 +52,7 @@ namespace forte {
 SOMRDSRG::SOMRDSRG(Reference reference, SharedWavefunction ref_wfn, Options& options,
                    std::shared_ptr<ForteIntegrals> ints, std::shared_ptr<MOSpaceInfo> mo_space_info)
     : Wavefunction(options), reference_(reference), ints_(ints), mo_space_info_(mo_space_info),
-      tensor_type_(CoreTensor), BTF(new BlockedTensorFactory(options)) {
+      tensor_type_(CoreTensor), BTF(new BlockedTensorFactory()) {
     // Copy the wavefunction information
     shallow_copy(ref_wfn);
     reference_wavefunction_ = ref_wfn;

--- a/src/mrdsrg-spin-integrated/master_mrdsrg.cc
+++ b/src/mrdsrg-spin-integrated/master_mrdsrg.cc
@@ -15,7 +15,7 @@ MASTER_DSRG::MASTER_DSRG(Reference reference, SharedWavefunction ref_wfn, Option
                          std::shared_ptr<ForteIntegrals> ints,
                          std::shared_ptr<MOSpaceInfo> mo_space_info)
     : DynamicCorrelationSolver(reference, ref_wfn, options, ints, mo_space_info),
-      BTF_(new BlockedTensorFactory(options)), tensor_type_(ambit::CoreTensor) {
+      BTF_(new BlockedTensorFactory()), tensor_type_(ambit::CoreTensor) {
     reference_wavefunction_ = ref_wfn;
     startup();
 }

--- a/src/orbital-helpers/aosubspace.cc
+++ b/src/orbital-helpers/aosubspace.cc
@@ -100,7 +100,8 @@ SharedMatrix create_aosubspace_projector(SharedWavefunction wfn, Options& option
     return Ps;
 }
 
-AOSubspace::AOSubspace(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basis) {
+AOSubspace::AOSubspace(std::shared_ptr<Molecule> molecule, std::shared_ptr<BasisSet> basis)
+    : molecule_(molecule), basis_(basis) {
     startup();
 }
 
@@ -408,5 +409,5 @@ void AOSubspace::parse_basis_set() {
         element_count[Z] += 1; // increase the element count
     }
 }
-}
-}
+} // namespace forte
+} // namespace psi

--- a/src/orbital-helpers/semi_canonicalize.cc
+++ b/src/orbital-helpers/semi_canonicalize.cc
@@ -51,10 +51,10 @@ using namespace ambit;
 
 SemiCanonical::SemiCanonical(std::shared_ptr<Wavefunction> wfn,
                              std::shared_ptr<ForteIntegrals> ints,
-                             std::shared_ptr<MOSpaceInfo> mo_space_info, const bool& quiet)
-    : mo_space_info_(mo_space_info), ints_(ints), wfn_(wfn), quiet_(quiet) {
+                             std::shared_ptr<MOSpaceInfo> mo_space_info, bool quiet_banner)
+    : mo_space_info_(mo_space_info), ints_(ints), wfn_(wfn) {
 
-    if (!quiet) {
+    if (!quiet_banner) {
         print_method_banner({"Semi-Canonical Orbitals",
                              "Chenyang Li, Jeffrey B. Schriber and Francesco A. Evangelista"});
     }
@@ -524,5 +524,5 @@ void SemiCanonical::transform_reference(ambit::Tensor& Ua, ambit::Tensor& Ub, Re
         }
     }
 }
-}
-} // End Namespaces
+} // namespace forte
+} // namespace psi

--- a/src/orbital-helpers/semi_canonicalize.h
+++ b/src/orbital-helpers/semi_canonicalize.h
@@ -49,9 +49,16 @@ namespace forte {
  */
 class SemiCanonical {
   public:
-    // => Constructor <= //
+    /**
+     * @brief SemiCanonical Constructor
+     * @param ref_wfn The reference wavefunction object
+     * @param ints ForteInegrals
+     * @param options PSI4 and FORTE options
+     * @param mo_space_info MOSpaceInfo
+     * @param quiet_banner Method banner is not printed if set to true
+     */
     SemiCanonical(std::shared_ptr<Wavefunction> wfn, std::shared_ptr<ForteIntegrals> ints,
-                  std::shared_ptr<MOSpaceInfo> mo_space_info, const bool& quiet = false);
+                  std::shared_ptr<MOSpaceInfo> mo_space_info, bool quiet_banner = false);
 
     /// Transforms integrals and reference
     void semicanonicalize(Reference& reference, const int& max_rdm_level = 3,
@@ -94,9 +101,6 @@ class SemiCanonical {
     std::shared_ptr<ForteIntegrals> ints_;
 
     std::shared_ptr<Wavefunction> wfn_;
-
-    // quiet printing
-    bool quiet_;
 
     // All orbitals
     Dimension nmopi_;
@@ -168,7 +172,7 @@ class SemiCanonical {
     void build_transformation_matrices(SharedMatrix& Ua, SharedMatrix& Ub, ambit::Tensor& Ua_t,
                                        ambit::Tensor& Ub_t);
 };
-}
-} // End Namespaces
+} // namespace forte
+} // namespace psi
 
 #endif // _mp2_nos_h_


### PR DESCRIPTION
## Description
Fix warnings in semicanonical and aosubspace. A contribution to Issue #96.

## User Notes
Here are the warnings left on my computer:
- fci/fci_vector_hamiltonian.cc, line 41, unused `required_list`
- fci/fci_vector.cc, line 373, compare int with unsigned long
- mrdsrg-spin-integrated/three_dsrg_mrpt2.cc, unused `nproc`. I do not think this should be fixed.

## Checklist
- [x] Ready to go!
