### PR TITLE
adapt for psi4 MathOpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(forte_DESCRIPTION  "Quantum Chemistry Methods for Strongly Correlated Electr
 set(forte_URL          "https://github.com/evangelistalab/forte")
 set(forte_LICENSE      "GPL-3.0+")
 set(CMAKE_CXX_STANDARD 17)
+set(TargetOpenMP_FIND_COMPONENTS "CXX")
 
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)

--- a/src/mrdsrg-spin-integrated/three_dsrg_mrpt2.cc
+++ b/src/mrdsrg-spin-integrated/three_dsrg_mrpt2.cc
@@ -2703,7 +2703,7 @@ double THREE_DSRG_MRPT2::E_VT2_2_one_active() {
     double Eccva = 0;
     double Eacvv = 0;
     int nthread = 1;
-//    int thread = 0;
+    int thread = 0;
 #ifdef _OPENMP
     nthread = omp_get_max_threads();
     thread = omp_get_thread_num();


### PR DESCRIPTION
## Description
Solve the problem of "Could NOT find TargetOpenMP" when using psi4.


## Checklist
- [x] Ready to go!
