### PR TITLE
Very small fix in ACI

### DIFF
--- a/src/sci/aci.cc
+++ b/src/sci/aci.cc
@@ -1283,7 +1283,7 @@ void AdaptiveCI::prune_q_space(DeterminantHashVec& PQ_space, DeterminantHashVec&
     const det_hashvec& detmap = PQ_space.wfn_hash();
     for (size_t i = 0, max_i = detmap.size(); i < max_i; ++i) {
         double criteria = 0.0;
-        if (ex_alg_ == "AVERAGE") {
+        if ( (nroot_ > 1) and ex_alg_ == "AVERAGE") {
             for (int n = 0; n < nav; ++n) {
                 if (pq_function_ == "MAX") {
                     criteria = std::max(criteria, std::fabs(evecs->get(i, n)));

--- a/tests/methods/aci-14/input.dat
+++ b/tests/methods/aci-14/input.dat
@@ -12,9 +12,9 @@ C  0.00000 0.00000 1.24253
 set {
   basis 6-31g*
   scf_type pk
-  e_convergence 10
-  d_convergence 10
-  r_convergence 10
+  e_convergence 12
+  d_convergence 12
+  r_convergence 12
   docc [2,0,0,0,0,2,1,1]
   guess gwh
 }


### PR DESCRIPTION
## Description
This PR fixes a minor inconsistency in the pruning algorithm that could potentially lead to inefficiencies. This is only a potential issue during the computation of the ground state during multiroot computations when only one root is called at a time.

This code is tested in ACI-14, which should now pass consistently due to decreased convergence thresholds

## Checklist
- [X] Fix potential issue in pruning during specialized excited state procedure
- [X] Added tests of new features
- [X] makes test aci-14 pass every time
- [x] Ready to go!
