### PR TITLE
Exposed Determinant class.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ if(MAX_DET_ORB)
     add_definitions(-DMAX_DET_ORB=${MAX_DET_ORB})
 else()
     add_definitions(-DMAX_DET_ORB=64)
+    add_definitions(-DSMALL_BITSET)
 endif()
 
 if(ENABLE_MPI)

--- a/src/python_api.cc
+++ b/src/python_api.cc
@@ -185,7 +185,9 @@ PYBIND11_MODULE(forte, m) {
 
     // export ForteIntegrals
     py::class_<ForteIntegrals, std::shared_ptr<ForteIntegrals>>(m, "ForteIntegrals")
-        .def("rotate_orbitals", &ForteIntegrals::rotate_orbitals);
+        .def("rotate_orbitals", &ForteIntegrals::rotate_orbitals)
+        .def("nmo", &ForteIntegrals::nmo)
+        .def("ncmo", &ForteIntegrals::ncmo);
 
     // export StateInfo
     py::class_<StateInfo, std::shared_ptr<StateInfo>>(m, "StateInfo")

--- a/src/python_api.cc
+++ b/src/python_api.cc
@@ -129,7 +129,18 @@ void export_Determinant(py::module& m) {
         .def("get_alfa_bits", &Determinant::get_alfa_bits, "Get alpha bits")
         .def("get_beta_bits", &Determinant::get_beta_bits, "Get beta bits")
         .def_readonly_static("num_str_bits", &Determinant::num_str_bits)
-        .def_readonly_static("num_det_bits", &Determinant::num_det_bits);
+        .def_readonly_static("num_det_bits", &Determinant::num_det_bits)
+        .def("get_alfa_bit", &Determinant::get_alfa_bit, "n"_a, "Get the value of an alpha bit")
+        .def("get_beta_bit", &Determinant::get_beta_bit, "n"_a, "Get the value of an beta bit")
+        .def("set_alfa_bit", &Determinant::set_alfa_bit, "n"_a, "value"_a,
+             "Set the value of an alpha bit")
+        .def("set_beta_bit", &Determinant::set_beta_bit, "n"_a, "value"_a,
+             "Set the value of an beta bit")
+        .def("create_alfa_bit", &Determinant::create_alfa_bit, "n"_a, "Create an alpha bit")
+        .def("create_beta_bit", &Determinant::create_beta_bit, "n"_a, "Create an beta bit")
+        .def("destroy_alfa_bit", &Determinant::destroy_alfa_bit, "n"_a, "Destroy an alpha bit")
+        .def("destroy_beta_bit", &Determinant::destroy_beta_bit, "n"_a, "Destroy an beta bit")
+        .def("str", &Determinant::str, "Get the string representation of the Slater determinant");
 }
 
 ///// Export the FCISolver class

--- a/src/python_api.cc
+++ b/src/python_api.cc
@@ -131,25 +131,17 @@ void export_Determinant(py::module& m) {
         .def_readonly_static("num_str_bits", &Determinant::num_str_bits)
         .def_readonly_static("num_det_bits", &Determinant::num_det_bits)
         .def("get_alfa_bit", &Determinant::get_alfa_bit, "n"_a, "Get the value of an alpha bit")
-        .def("get_beta_bit", &Determinant::get_beta_bit, "n"_a, "Get the value of an beta bit")
+        .def("get_beta_bit", &Determinant::get_beta_bit, "n"_a, "Get the value of a beta bit")
         .def("set_alfa_bit", &Determinant::set_alfa_bit, "n"_a, "value"_a,
              "Set the value of an alpha bit")
         .def("set_beta_bit", &Determinant::set_beta_bit, "n"_a, "value"_a,
              "Set the value of an beta bit")
         .def("create_alfa_bit", &Determinant::create_alfa_bit, "n"_a, "Create an alpha bit")
-        .def("create_beta_bit", &Determinant::create_beta_bit, "n"_a, "Create an beta bit")
+        .def("create_beta_bit", &Determinant::create_beta_bit, "n"_a, "Create a beta bit")
         .def("destroy_alfa_bit", &Determinant::destroy_alfa_bit, "n"_a, "Destroy an alpha bit")
-        .def("destroy_beta_bit", &Determinant::destroy_beta_bit, "n"_a, "Destroy an beta bit")
+        .def("destroy_beta_bit", &Determinant::destroy_beta_bit, "n"_a, "Destroy a beta bit")
         .def("str", &Determinant::str, "Get the string representation of the Slater determinant");
 }
-
-///// Export the FCISolver class
-// void export_FCISolver(py::module& m) {
-//    py::class_<FCISolver>(m, "FCISolver")
-//        .def(py::init<StateInfo, std::shared_ptr<MOSpaceInfo>,
-//                      std::shared_ptr<ActiveSpaceIntegrals>>())
-//        .def("compute_energy", &FCISolver::compute_energy);
-//}
 
 // TODO: export more classes using the function above
 PYBIND11_MODULE(forte, m) {

--- a/src/python_api.cc
+++ b/src/python_api.cc
@@ -110,14 +110,6 @@ void export_ActiveSpaceSolver(py::module& m) {
           "Compute the average energy given the energies and weights of each state");
 }
 
-/// Export the ActiveSpaceIntegrals class
-void export_ActiveSpaceIntegrals(py::module& m) {
-    py::class_<ActiveSpaceIntegrals>(m, "ActiveSpaceIntegrals")
-        .def(py::init<std::shared_ptr<ForteIntegrals>, std::shared_ptr<MOSpaceInfo>>())
-        .def("slater_rules", &ActiveSpaceIntegrals::slater_rules,
-             "Compute the matrix element of the Hamiltonian between two determinants");
-}
-
 /// Export the OrbitalTransform class
 void export_OrbitalTransform(py::module& m) {
     py::class_<OrbitalTransform>(m, "OrbitalTransform")
@@ -225,7 +217,15 @@ PYBIND11_MODULE(forte, m) {
     // export ActiveSpaceIntegrals
     py::class_<ActiveSpaceIntegrals, std::shared_ptr<ActiveSpaceIntegrals>>(m,
                                                                             "ActiveSpaceIntegrals")
-        .def(py::init<std::shared_ptr<ForteIntegrals>, std::shared_ptr<MOSpaceInfo>>());
+        .def(py::init<std::shared_ptr<ForteIntegrals>, std::shared_ptr<MOSpaceInfo>>())
+        .def("slater_rules", &ActiveSpaceIntegrals::slater_rules,
+             "Compute the matrix element of the Hamiltonian between two determinants")
+        .def("nuclear_repulsion_energy", &ActiveSpaceIntegrals::nuclear_repulsion_energy,
+             "Get nuclear repulsion energy")
+        .def("frozen_core_energy", &ActiveSpaceIntegrals::frozen_core_energy,
+             "Get the frozen core energy (contribution from FROZEN_DOCC)")
+        .def("scalar_energy", &ActiveSpaceIntegrals::scalar_energy,
+             "Get the scalar_energy energy (contribution from RESTRICTED_DOCC)");
 
     // export SemiCanonical
     py::class_<SemiCanonical>(m, "SemiCanonical")

--- a/src/python_api.cc
+++ b/src/python_api.cc
@@ -54,6 +54,7 @@
 #include "base_classes/scf_info.h"
 #include "mrdsrg-helper/run_dsrg.h"
 #include "mrdsrg-spin-integrated/master_mrdsrg.h"
+#include "sparse_ci/determinant.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -117,6 +118,20 @@ void export_OrbitalTransform(py::module& m) {
         .def("get_Ub", &OrbitalTransform::get_Ub, "Get Ub rotation");
 }
 
+constexpr int Determinant::num_str_bits;
+constexpr int Determinant::num_det_bits;
+
+/// Export the Determinant class
+void export_Determinant(py::module& m) {
+    py::class_<Determinant>(m, "Determinant")
+        .def(py::init<>())
+        .def(py::init<const std::vector<bool>&, const std::vector<bool>&>())
+        .def("get_alfa_bits", &Determinant::get_alfa_bits, "Get alpha bits")
+        .def("get_beta_bits", &Determinant::get_beta_bits, "Get beta bits")
+        .def_readonly_static("num_str_bits", &Determinant::num_str_bits)
+        .def_readonly_static("num_det_bits", &Determinant::num_det_bits);
+}
+
 ///// Export the FCISolver class
 // void export_FCISolver(py::module& m) {
 //    py::class_<FCISolver>(m, "FCISolver")
@@ -159,6 +174,8 @@ PYBIND11_MODULE(forte, m) {
     export_ActiveSpaceSolver(m);
 
     export_OrbitalTransform(m);
+
+    export_Determinant(m);
 
     //    export_FCISolver(m);
 

--- a/src/python_api.cc
+++ b/src/python_api.cc
@@ -110,6 +110,14 @@ void export_ActiveSpaceSolver(py::module& m) {
           "Compute the average energy given the energies and weights of each state");
 }
 
+/// Export the ActiveSpaceIntegrals class
+void export_ActiveSpaceIntegrals(py::module& m) {
+    py::class_<ActiveSpaceIntegrals>(m, "ActiveSpaceIntegrals")
+        .def(py::init<std::shared_ptr<ForteIntegrals>, std::shared_ptr<MOSpaceInfo>>())
+        .def("slater_rules", &ActiveSpaceIntegrals::slater_rules,
+             "Compute the matrix element of the Hamiltonian between two determinants");
+}
+
 /// Export the OrbitalTransform class
 void export_OrbitalTransform(py::module& m) {
     py::class_<OrbitalTransform>(m, "OrbitalTransform")

--- a/src/python_api.cc
+++ b/src/python_api.cc
@@ -213,7 +213,7 @@ PYBIND11_MODULE(forte, m) {
         .def("slater_rules", &ActiveSpaceIntegrals::slater_rules,
              "Compute the matrix element of the Hamiltonian between two determinants")
         .def("nuclear_repulsion_energy", &ActiveSpaceIntegrals::nuclear_repulsion_energy,
-             "Get nuclear repulsion energy")
+             "Get the nuclear repulsion energy")
         .def("frozen_core_energy", &ActiveSpaceIntegrals::frozen_core_energy,
              "Get the frozen core energy (contribution from FROZEN_DOCC)")
         .def("scalar_energy", &ActiveSpaceIntegrals::scalar_energy,

--- a/src/sparse_ci/stl_bitset_determinant.cc
+++ b/src/sparse_ci/stl_bitset_determinant.cc
@@ -78,6 +78,14 @@ STLBitsetDeterminant::STLBitsetDeterminant(const std::vector<bool>& occupation_a
 
 const STLBitsetDeterminant::bit_t& STLBitsetDeterminant::bits() const { return bits_; }
 
+std::bitset<STLBitsetDeterminant::num_str_bits> STLBitsetDeterminant::get_alfa_bits() const {
+    return std::bitset<STLBitsetDeterminant::num_str_bits>(bits_.to_string(), 0, STLBitsetDeterminant::num_str_bits);
+}
+
+std::bitset<STLBitsetDeterminant::num_str_bits> STLBitsetDeterminant::get_beta_bits() const {
+    return std::bitset<STLBitsetDeterminant::num_str_bits>(bits_.to_string(), STLBitsetDeterminant::num_str_bits);
+}
+
 bool STLBitsetDeterminant::less_than(const STLBitsetDeterminant& rhs,
                                      const STLBitsetDeterminant& lhs) {
     // check beta first

--- a/src/sparse_ci/stl_bitset_determinant.h
+++ b/src/sparse_ci/stl_bitset_determinant.h
@@ -86,6 +86,10 @@ class STLBitsetDeterminant {
 
     /// Return the bitset
     const bit_t& bits() const;
+    /// Return the alpha bitset
+    std::bitset<num_str_bits> get_alfa_bits() const;
+    /// Return the beta bitset
+    std::bitset<num_str_bits> get_beta_bits() const;
 
     /// Equal operator
     bool operator==(const STLBitsetDeterminant& lhs) const;

--- a/tests/pytest/fci_solver.ipynb
+++ b/tests/pytest/fci_solver.ipynb
@@ -113,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mo_space_info = forte.make_mo_space_info(wfn, options)"
+    "forte.forte_options.update_psi_options(options)"
    ]
   },
   {
@@ -122,7 +122,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ints = forte.make_forte_integrals(wfn, options, mo_space_info)"
+    "mo_space_info = forte.make_mo_space_info(wfn, forte.forte_options)"
    ]
   },
   {
@@ -131,8 +131,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# actv_dim, core_mo, actv_mo, state, ints, mo_space_info, guess_per_root, print, psi_options\n",
-    "solver = forte.FCISolver(dim, [], list(range(7)), state, ints, mo_space_info, 10, 1, options)"
+    "ints = forte.make_forte_integrals(wfn, options, mo_space_info)"
    ]
   },
   {
@@ -141,27 +140,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# forte.forte_old_methods(wfn, options, ints, mo_space_info)"
+    "# actv_dim, core_mo, actv_mo, state, ints, mo_space_info, guess_per_root, print, psi_options\n",
+    "active_space_solver_type = options.get_str('ACTIVE_SPACE_SOLVER')\n",
+    "as_ints = forte.make_active_space_ints(mo_space_info, ints, \"ACTIVE\", [\"RESTRICTED_DOCC\"]);"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "-75.01315470114668"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "solver.compute_energy()"
+    "# forte.forte_old_methods(wfn, options, ints, mo_space_info)"
    ]
   },
   {
@@ -172,7 +162,7 @@
     {
      "data": {
       "text/plain": [
-       "'NONE'"
+       "7"
       ]
      },
      "execution_count": 16,
@@ -181,7 +171,7 @@
     }
    ],
    "source": [
-    "options.get_str(\"JOB_TYPE\")"
+    "ints.ncmo()"
    ]
   },
   {


### PR DESCRIPTION
## Description
This PR exposes the Determinant Class.

## Exposed members
- [x] `Determinant::num_str_bits`
- [x] `Determinant::num_det_bits`
- [x] `Determinant()`
- [x] `Determinant(const std::vector<bool>& occupation_a, const std::vector<bool>& occupation_b)`
- [x] `Determinant::get_alfa_bits()`
- [x] `Determinant::get_beta_bits()`
- [x] `Determinant::set_alfa_bits()`
- [x] `Determinant::set_beta_bits()`
- [x] `Determinant::create_alfa_bits()`
- [x] `Determinant::create_beta_bits()`
- [x] `Determinant::destroy_alfa_bits()`
- [x] `Determinant::destroy_beta_bits()`
- [x] `Determinant::str()`
- [x] `ForteIntegrals::nmo()`
- [x] `ForteIntegrals::ncmo()`
- [x] `ActiveSpaceIntegrals(std::shared_ptr<ForteIntegrals> ints, std::shared_ptr<MOSpaceInfo> mospace_info)`
- [x] `ActiveSpaceIntegrals::slater_rules()`

## Example usage
```python
>>> import forte
>>> forte.Determinant.num_str_bits
64
>>> forte.Determinant.num_det_bits
128
>>> a = forte.Determinant([True,False,True],[False,True,True])
>>> a.get_alfa_bits()
5
>>> a.get_beta_bits()
6
>>> bin(a.get_beta_bits())[:1:-1]
'011'
>>> b = forte.Determinant()
>>> b.get_alfa_bits()
0
```

## User Notes
- [x] Corrected a bug in CMakeList to reenable `UI64Determinants`.

## Unsolved issue
- This PR currently only works with `UI64Determinants`, because the return type `std::bitset` of `STLBitsetDeterminant::get_alfa_bits()` is not cast successfully to python.
Error message: `TypeError: Unable to convert function return value to a Python type! The signature was
	(self: forte.forte.Determinant) -> std::__1::bitset<64ul>`

## Checklist
- [x] Ready to go!