### PR TITLE
Fix AVAS when SIGMA = 1.0

### DIFF
--- a/src/orbital-helpers/avas.cc
+++ b/src/orbital-helpers/avas.cc
@@ -210,8 +210,10 @@ void make_avas(psi::SharedWavefunction ref_wfn, psi::Options& options, psi::Shar
                 }
             }
         } else {
+            // tollerance on the sum of singular values (for border cases, e.g. sigma = 1.0)
             double sum_tollerance = 1.0e-9;
-            double include_tollerance = 1.0e-6;
+            // threshold for including an orbital
+            double include_threshold = 1.0e-6;
             outfile->Printf("\n  AVAS selection based cumulative threshold (sigma)\n");
             double s_act_sum = 0.0;
             for (const auto& mo_tuple : sorted_mos) {
@@ -227,7 +229,7 @@ void make_avas(psi::SharedWavefunction ref_wfn, psi::Options& options, psi::Shar
                 // partial sum of singular values and the total sum of singular
                 // values
                 if ((fraction <= avas_sigma + sum_tollerance) and
-                    (std::fabs(sigma) > include_tollerance)) {
+                    (std::fabs(sigma) > include_threshold)) {
                     if (is_occ) {
                         occ_act.push_back(p);
                     } else {

--- a/src/orbital-helpers/avas.cc
+++ b/src/orbital-helpers/avas.cc
@@ -210,6 +210,8 @@ void make_avas(psi::SharedWavefunction ref_wfn, psi::Options& options, psi::Shar
                 }
             }
         } else {
+            double sum_tollerance = 1.0e-9;
+            double include_tollerance = 1.0e-6;
             outfile->Printf("\n  AVAS selection based cumulative threshold (sigma)\n");
             double s_act_sum = 0.0;
             for (const auto& mo_tuple : sorted_mos) {
@@ -224,7 +226,8 @@ void make_avas(psi::SharedWavefunction ref_wfn, psi::Options& options, psi::Shar
                 // the
                 // partial sum of singular values and the total sum of singular
                 // values
-                if ((fraction <= avas_sigma) and (std::fabs(sigma) > 1.0e-6)) {
+                if ((fraction <= avas_sigma + sum_tollerance) and
+                    (std::fabs(sigma) > include_tollerance)) {
                     if (is_occ) {
                         occ_act.push_back(p);
                     } else {


### PR DESCRIPTION
## Description
Avoid problems with roundoff errors when AVAS_SIGMA = 1.0. To solve the problem I check that the sum of singular values `sum_i s_i <= avas_sigma + 1.0e-9`. So when `avas_sigma = 1.0` all orbitals are included. To avoid including orbitals with small singular value, I make sure that only orbitals with `s_i > 1.0e-6` are included in the list of actives. 

## Checklist
- [x] Added tests of new features
- [ ] Resolves #143
- [ ] Ready to go!