### PR TITLE
Do not store an IntegralTransform object in the ForteIntegrals class

### DIFF
--- a/src/integrals/conventional_integrals.h
+++ b/src/integrals/conventional_integrals.h
@@ -85,9 +85,6 @@ class ConventionalIntegrals : public ForteIntegrals {
   private:
     // ==> Class data <==
 
-    /// The IntegralTransform object used by this class
-    std::shared_ptr<psi::IntegralTransform> integral_transform_;
-
     /// Two-electron integrals stored as a vector
     std::vector<double> aphys_tei_aa;
     std::vector<double> aphys_tei_ab;
@@ -96,7 +93,7 @@ class ConventionalIntegrals : public ForteIntegrals {
     // ==> Class private functions <==
 
     /// Transform the integrals
-    void transform_integrals();
+    std::shared_ptr<psi::IntegralTransform> transform_integrals();
     void resort_four(std::vector<double>& tei, std::vector<size_t>& map);
 
     /// An addressing function to for two-electron integrals

--- a/src/integrals/integrals.h
+++ b/src/integrals/integrals.h
@@ -111,7 +111,6 @@ class ForteIntegrals {
     /// Virtual destructor to enable deletion of a Derived* through a Base*
     virtual ~ForteIntegrals() = default;
 
-  public:
     // ==> Class Interface <==
 
     /// Return Ca


### PR DESCRIPTION
## Description
This PR fixes a problem where a psi4 DPD buffer was never properly closed

## Checklist
- [x] Removed comments in code and input files
- [x] Documented source code
- [x] Checked for redundant headers
- [x] Ready to go!
