### PR TITLE
Passes forte_options to make_forte_integrals() rather than options in…

### DIFF
--- a/tutorials/02-Forte_API/Tutorial_02_forte_api.ipynb
+++ b/tutorials/02-Forte_API/Tutorial_02_forte_api.ipynb
@@ -177,7 +177,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ints = forte.make_forte_integrals(wfn, options, mo_space_info)\n",
+    "ints = forte.make_forte_integrals(wfn, forte_options, mo_space_info)\n",
     "print(f'Number of molecular orbitals: {ints.nmo()}')\n",
     "print(f'Number of correlated molecular orbitals: {ints.ncmo()}')"
    ]
@@ -309,7 +309,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
… jn Tutorial-02.

## Description
Fixes an issue in the Tutorial-02 Forte API jupyter notebook. Previously integrals were passed 'options' (a psi4 object), rather than 'forte_options', causing an error when running the notebook.

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added tests of new features
- [ ] Removed comments in code and input files
- [ ] Documented source code
- [ ] Checked for redundant headers
- [ ] Checked for consistency in the formatting of the output file
- [ ] Documented new features in the manual
- [ ] Ready to go!
