### PR TITLE
Fix bug in iterative solver

### DIFF
--- a/pymodule.py
+++ b/pymodule.py
@@ -380,6 +380,11 @@ def run_forte(name, **kwargs):
                                                options.get_str('MINAO_BASIS'))
         ref_wfn.set_basisset('MINAO_BASIS', minao_basis)
 
+    if (options.get_str('BASIS_RELATIVISTIC')):
+        relativistic_basis = psi4.core.BasisSet.build(ref_wfn.molecule(), 'BASIS_RELATIVISTIC',
+                                               options.get_str('BASIS_RELATIVISTIC'))
+        ref_wfn.set_basisset('BASIS_RELATIVISTIC', relativistic_basis)
+
     # Start Forte, initialize ambit
     my_proc_n_nodes = forte.startup()
     my_proc, n_nodes = my_proc_n_nodes

--- a/pymodule.py
+++ b/pymodule.py
@@ -380,11 +380,6 @@ def run_forte(name, **kwargs):
                                                options.get_str('MINAO_BASIS'))
         ref_wfn.set_basisset('MINAO_BASIS', minao_basis)
 
-    if (options.get_str('BASIS_RELATIVISTIC')):
-        relativistic_basis = psi4.core.BasisSet.build(ref_wfn.molecule(), 'BASIS_RELATIVISTIC',
-                                               options.get_str('BASIS_RELATIVISTIC'))
-        ref_wfn.set_basisset('BASIS_RELATIVISTIC', relativistic_basis)
-
     # Start Forte, initialize ambit
     my_proc_n_nodes = forte.startup()
     my_proc, n_nodes = my_proc_n_nodes

--- a/register_forte_options.py
+++ b/register_forte_options.py
@@ -443,7 +443,7 @@ def register_aci_options(options):
 
     options.add_bool("ACI_PRINT_REFS", False, "Print the P space?")
 
-    options.add_int("DL_GUESS_SIZE",26,
+    options.add_int("DL_GUESS_SIZE",50,
                           "Set the initial guess space size for DL solver")
 
     options.add_int("N_GUESS_VEC", 10,

--- a/register_forte_options.py
+++ b/register_forte_options.py
@@ -32,6 +32,8 @@ def register_driver_options(options):
 
     options.add_str('DERTYPE', 'NONE', ['NONE', 'FIRST'], 'Derivative order')
 
+    options.add_str('BASIS_RELATIVISTIC', '','Relativistic basis set')
+
     options.add_double("E_CONVERGENCE", 1.0e-9, "The energy convergence criterion")
     options.add_double("D_CONVERGENCE", 1.0e-6, "The density convergence criterion")
 

--- a/register_forte_options.py
+++ b/register_forte_options.py
@@ -32,11 +32,8 @@ def register_driver_options(options):
 
     options.add_str('DERTYPE', 'NONE', ['NONE', 'FIRST'], 'Derivative order')
 
-    options.add_str('BASIS_RELATIVISTIC', '','Relativistic basis set')
-
     options.add_double("E_CONVERGENCE", 1.0e-9, "The energy convergence criterion")
     options.add_double("D_CONVERGENCE", 1.0e-6, "The density convergence criterion")
-
 
     options.add_str(
         'ACTIVE_SPACE_SOLVER', '', ['FCI', 'ACI', 'CAS'],
@@ -393,18 +390,14 @@ def register_sci_options(options):
     options.add_bool("SCI_QUIET_MODE", False,
                            "Print during ACI procedure?")
 
-   # options.add_bool("ACI_STREAMLINE_Q", False,
-   #                        "Do streamlined algorithm?")
-
     options.add_int("SCI_PREITERATIONS", 0,
                           "Number of iterations to run SA-ACI before SS-ACI")
-
 
     options.add_bool("SCI_DIRECT_RDMS", False,
                            "Computes RDMs without coupling lists?")
 
     options.add_bool("SCI_SAVE_FINAL_WFN", False,
-                           "Print final wavefunction to file?")
+                           "Save final wavefunction to file?")
 
     options.add_bool("SCI_TEST_RDMS", False, "Run test for the RDMs?")
 
@@ -412,7 +405,6 @@ def register_sci_options(options):
 
     options.add_bool("SCI_CORE_EX", False,
                            "Use core excitation algorithm")
-
 
 
 def register_aci_options(options):
@@ -461,7 +453,7 @@ def register_aci_options(options):
     options.add_bool("ACI_PRINT_REFS", False, "Print the P space?")
 
     options.add_int("DL_GUESS_SIZE",50,
-                          "Set the initial guess space size for DL solver")
+                          "Set the number of determinants in the initial guess space for the DL solver")
 
     options.add_int("N_GUESS_VEC", 10,
                           "Number of guess vectors for Sparse CI solver")

--- a/register_forte_options.py
+++ b/register_forte_options.py
@@ -895,6 +895,7 @@ def register_old_options(options):
 
 def register_psi_options(options):
     options.add_str('BASIS','','The primary basis set')
+    options.add_str('BASIS_RELATIVISTIC','','The basis set used to run relativistic computations')
     options.add_double("INTS_TOLERANCE", 1.0E-12, 'Schwarz screening threshold')
     options.add_str("DF_INTS_IO", "NONE", ['NONE','SAVE','LOAD'],'IO caching for CP corrections')
     options.add_str('DF_BASIS_MP2','','Auxiliary basis set for density fitting computations')

--- a/register_forte_options.py
+++ b/register_forte_options.py
@@ -11,6 +11,7 @@ def register_forte_options(options):
     register_pt2_options(options)
     register_pci_options(options)
     register_fci_options(options)
+    register_sci_options(options)
     register_aci_options(options)
     register_asci_options(options)
     register_fci_mo_options(options)
@@ -367,6 +368,14 @@ def register_fci_options(options):
         'NTRIAL_PER_ROOT', 10,
         'The number of trial guess vectors to generate per root')
 
+def register_sci_options(options):
+    options.set_group("SCI")
+
+    options.add_bool("SCI_ENFORCE_SPIN_COMPLETE", True,
+                           "Enforce determinant spaces to be spin-complete?")
+
+    options.add_bool("SCI_ENFORCE_SPIN_COMPLETE_P", False,
+                           "Enforce determinant in the P space to be spin-complete?")
 
 def register_aci_options(options):
     options.set_group("ACI")
@@ -401,12 +410,6 @@ def register_aci_options(options):
      2 - Project only after converged PQ space
      3 - Do 1 and 2""")
 
-    options.add_bool("ACI_ENFORCE_SPIN_COMPLETE", True,
-                           "Enforce determinant spaces to be spin-complete?")
-
-    options.add_bool("ACI_ENFORCE_SPIN_COMPLETE_P", False,
-                           "Enforce determinant in the P space to be spin-complete?")
-
     options.add_bool(
         "SCI_PROJECT_OUT_SPIN_CONTAMINANTS", True,
         "Project out spin contaminants in Davidson-Liu's algorithm?")
@@ -421,13 +424,13 @@ def register_aci_options(options):
 
     options.add_int("SCI_MAX_CYCLE", 20, "Maximum number of cycles")
 
-    options.add_bool("ACI_QUIET_MODE", False,
+    options.add_bool("SCI_QUIET_MODE", False,
                            "Print during ACI procedure?")
 
    # options.add_bool("ACI_STREAMLINE_Q", False,
    #                        "Do streamlined algorithm?")
 
-    options.add_int("ACI_PREITERATIONS", 0,
+    options.add_int("SCI_PREITERATIONS", 0,
                           "Number of iterations to run SA-ACI before SS-ACI")
 
     options.add_int("ACI_N_AVERAGE", 1, "Number of roots to averag")
@@ -440,7 +443,7 @@ def register_aci_options(options):
 
     options.add_bool("ACI_PRINT_REFS", False, "Print the P space?")
 
-    options.add_int("DL_GUESS_SIZE", 100,
+    options.add_int("DL_GUESS_SIZE",26,
                           "Set the initial guess space size for DL solver")
 
     options.add_int("N_GUESS_VEC", 10,

--- a/register_forte_options.py
+++ b/register_forte_options.py
@@ -372,10 +372,46 @@ def register_sci_options(options):
     options.set_group("SCI")
 
     options.add_bool("SCI_ENFORCE_SPIN_COMPLETE", True,
-                           "Enforce determinant spaces to be spin-complete?")
+                           "Enforce determinant spaces (P and Q) to be spin-complete?")
 
     options.add_bool("SCI_ENFORCE_SPIN_COMPLETE_P", False,
-                           "Enforce determinant in the P space to be spin-complete?")
+                           "Enforce determinant space P to be spin-complete?")
+
+    options.add_bool(
+        "SCI_PROJECT_OUT_SPIN_CONTAMINANTS", True,
+        "Project out spin contaminants in Davidson-Liu's algorithm?")
+
+    options.add_str(
+        "SCI_EXCITED_ALGORITHM", "NONE",
+        ['AVERAGE', 'ROOT_ORTHOGONALIZE', 'ROOT_COMBINE', 'MULTISTATE'],
+        "The selected CI excited state algorithm")
+
+    options.add_int("SCI_MAX_CYCLE", 20, "Maximum number of cycles")
+
+    options.add_bool("SCI_QUIET_MODE", False,
+                           "Print during ACI procedure?")
+
+   # options.add_bool("ACI_STREAMLINE_Q", False,
+   #                        "Do streamlined algorithm?")
+
+    options.add_int("SCI_PREITERATIONS", 0,
+                          "Number of iterations to run SA-ACI before SS-ACI")
+
+
+    options.add_bool("SCI_DIRECT_RDMS", False,
+                           "Computes RDMs without coupling lists?")
+
+    options.add_bool("SCI_SAVE_FINAL_WFN", False,
+                           "Print final wavefunction to file?")
+
+    options.add_bool("SCI_TEST_RDMS", False, "Run test for the RDMs?")
+
+    options.add_bool("SCI_FIRST_ITER_ROOTS", False, "Compute all roots on first iteration?")
+
+    options.add_bool("SCI_CORE_EX", False,
+                           "Use core excitation algorithm")
+
+
 
 def register_aci_options(options):
     options.set_group("ACI")
@@ -398,10 +434,6 @@ def register_aci_options(options):
     options.add_str("ACI_PQ_FUNCTION", "AVERAGE", ['AVERAGE', 'MAX'],
                           "Function of q-space criteria, per root for SA-ACI")
 
-    options.add_str(
-        "SCI_EXCITED_ALGORITHM", "NONE",
-        ['AVERAGE', 'ROOT_ORTHOGONALIZE', 'ROOT_COMBINE', 'MULTISTATE'],
-        "The excited state algorithm")
 
     options.add_int(
         "ACI_SPIN_PROJECTION", 0, """Type of spin projection
@@ -411,10 +443,6 @@ def register_aci_options(options):
      3 - Do 1 and 2""")
 
     options.add_bool(
-        "SCI_PROJECT_OUT_SPIN_CONTAMINANTS", True,
-        "Project out spin contaminants in Davidson-Liu's algorithm?")
-
-    options.add_bool(
         "SPIN_PROJECT_FULL", False,
         "Project solution in full diagonalization algorithm?")
 
@@ -422,24 +450,11 @@ def register_aci_options(options):
         "ACI_ADD_AIMED_DEGENERATE", True,
         "Add degenerate determinants not included in the aimed selection")
 
-    options.add_int("SCI_MAX_CYCLE", 20, "Maximum number of cycles")
-
-    options.add_bool("SCI_QUIET_MODE", False,
-                           "Print during ACI procedure?")
-
-   # options.add_bool("ACI_STREAMLINE_Q", False,
-   #                        "Do streamlined algorithm?")
-
-    options.add_int("SCI_PREITERATIONS", 0,
-                          "Number of iterations to run SA-ACI before SS-ACI")
 
     options.add_int("ACI_N_AVERAGE", 1, "Number of roots to averag")
 
     options.add_int("ACI_AVERAGE_OFFSET", 0,
                           "Offset for state averaging")
-
-    options.add_bool("SCI_SAVE_FINAL_WFN", False,
-                           "Print final wavefunction to file?")
 
     options.add_bool("ACI_PRINT_REFS", False, "Print the P space?")
 
@@ -455,10 +470,6 @@ def register_aci_options(options):
     options.add_double("ACI_SPIN_TOL", 0.02, "Tolerance for S^2 value")
 
     options.add_bool("ACI_APPROXIMATE_RDM", False, "Approximate the RDMs?")
-
-    options.add_bool("SCI_TEST_RDMS", False, "Run test for the RDMs?")
-
-    options.add_bool("SCI_FIRST_ITER_ROOTS", False, "Compute all roots on first iteration?")
 
     options.add_bool("ACI_PRINT_WEIGHTS", False, "Print weights for active space prediction?")
 
@@ -477,9 +488,6 @@ def register_aci_options(options):
 
     options.add_bool("ACI_REF_RELAX", False,
                            "Do reference relaxation in ACI?")
-
-    options.add_bool("SCI_CORE_EX", False,
-                           "Use core excitation algorithm")
 
     options.add_int("ACI_NFROZEN_CORE", 0,
                           "Number of orbitals to freeze for core excitations")
@@ -526,9 +534,6 @@ def register_aci_options(options):
 
     options.add_double("ACI_SCALE_SIGMA", 0.5,
                              "Scales sigma in batched algorithm")
-
-    options.add_bool("SCI_DIRECT_RDMS", False,
-                           "Computes RDMs without coupling lists?")
 
     options.add_int("ACTIVE_GUESS_SIZE", 1000,
                           "Number of determinants for CI guess")

--- a/src/base_classes/active_space_method.cc
+++ b/src/base_classes/active_space_method.cc
@@ -92,7 +92,7 @@ std::unique_ptr<ActiveSpaceMethod> make_active_space_method(
     } else if (type == "PCI") {
         solver = std::make_unique<ExcitedStateSolver>(
             state, nroot, mo_space_info, as_ints,
-            std::make_unique<ProjectorCI>(state, nroot, scf_info, mo_space_info, as_ints));
+            std::make_unique<ProjectorCI>(state, nroot, scf_info, options, mo_space_info, as_ints));
     } else {
         throw psi::PSIEXCEPTION("make_active_space_method: type = " + type + " was not recognized");
     }

--- a/src/ci_ex_states/excited_state_solver.cc
+++ b/src/ci_ex_states/excited_state_solver.cc
@@ -424,7 +424,7 @@ void ExcitedStateSolver::print_wfn(DeterminantHashVec& space, std::shared_ptr<ps
 
         psi::outfile->Printf("\n\n  Most important contributions to root %3d:", n);
 
-        size_t max_dets = std::min(100, evecs->nrow());
+        size_t max_dets = std::min(10, evecs->nrow());
         tmp.subspace(space, evecs, tmp_evecs, max_dets, n);
 
         for (size_t I = 0; I < max_dets; ++I) {

--- a/src/ci_ex_states/excited_state_solver.cc
+++ b/src/ci_ex_states/excited_state_solver.cc
@@ -75,7 +75,7 @@ void ExcitedStateSolver::set_options(std::shared_ptr<ForteOptions> options) {
     }
 
     core_ex_ = options->get_bool("SCI_CORE_EX");
-    quiet_mode_ = options->get_bool("ACI_QUIET_MODE");
+    quiet_mode_ = options->get_bool("SCI_QUIET_MODE");
     direct_rdms_ = options->get_bool("SCI_DIRECT_RDMS");
     test_rdms_ = options->get_bool("SCI_TEST_RDMS");
     save_final_wfn_ = options->get_bool("SCI_SAVE_FINAL_WFN");
@@ -424,7 +424,7 @@ void ExcitedStateSolver::print_wfn(DeterminantHashVec& space, std::shared_ptr<ps
 
         psi::outfile->Printf("\n\n  Most important contributions to root %3d:", n);
 
-        size_t max_dets = std::min(10, evecs->nrow());
+        size_t max_dets = std::min(100, evecs->nrow());
         tmp.subspace(space, evecs, tmp_evecs, max_dets, n);
 
         for (size_t I = 0; I < max_dets; ++I) {

--- a/src/fci/fci_solver.cc
+++ b/src/fci/fci_solver.cc
@@ -256,7 +256,7 @@ double FCISolver::compute_energy() {
 
     if (converged == SolverStatus::NotConverged) {
         outfile->Printf("\n  FCI did not converge!");
-        throw psi::PSIEXCEPTION("FCI did not converge. Try increasing FCI_ITERATIONS.");
+        throw psi::PSIEXCEPTION("FCI did not converge. Try increasing FCI_MAXITER.");
     }
 
     // Compute final eigenvectors

--- a/src/fci/fci_solver.cc
+++ b/src/fci/fci_solver.cc
@@ -200,6 +200,8 @@ double FCISolver::compute_energy() {
 
     if (print_) {
         outfile->Printf("\n\n  ==> Diagonalizing Hamiltonian <==\n");
+        outfile->Printf("\n  Energy   convergence: %.2e", dls.get_e_convergence());
+        outfile->Printf("\n  Residual convergence: %.2e", dls.get_r_convergence());
         outfile->Printf("\n  -----------------------------------------------------");
         outfile->Printf("\n    Iter.      Avg. Energy       Delta_E     Res. Norm");
         outfile->Printf("\n  -----------------------------------------------------");

--- a/src/helpers/helpers.cc
+++ b/src/helpers/helpers.cc
@@ -211,4 +211,22 @@ std::pair<std::vector<size_t>, std::vector<size_t>> split_up_tasks(size_t size_o
     return my_lists;
 }
 
+namespace math {
+size_t combinations(size_t n, size_t k) {
+    if (k > n)
+        return 0;
+    if (k * 2 > n)
+        k = n - k;
+    if (k == 0)
+        return 1;
+
+    size_t result = n;
+    for (size_t i = 2; i <= k; ++i) {
+        result *= (n - i + 1);
+        result /= i;
+    }
+    return result;
+}
+} // namespace math
+
 } // namespace forte

--- a/src/helpers/helpers.h
+++ b/src/helpers/helpers.h
@@ -166,6 +166,11 @@ void apply_permutation_in_place(std::vector<T>& vec, const std::vector<std::size
     }
 }
 
+namespace math {
+/// Return the number of combinations of n identical objects
+size_t combinations(size_t n, size_t k);
+} // namespace math
+
 } // namespace forte
 
 #endif // _helpers_h_

--- a/src/helpers/iterative_solvers.cc
+++ b/src/helpers/iterative_solvers.cc
@@ -287,7 +287,6 @@ std::vector<double> DavidsonLiuSolver::normalize_vectors(psi::SharedMatrix v, si
         }
         norm = std::sqrt(norm);
         v_norm.push_back(norm);
-        outfile->Printf("\n  Norm of vector %zu = %e", k, norm);
         for (size_t I = 0; I < size_; I++) {
             v_p[k][I] /= norm;
         }

--- a/src/helpers/iterative_solvers.cc
+++ b/src/helpers/iterative_solvers.cc
@@ -332,8 +332,7 @@ bool DavidsonLiuSolver::subspace_collapse() {
             double norm_bnew_k = std::fabs(bnew->get_row(0, k)->norm());
             if (norm_bnew_k > schmidt_threshold_) {
                 if (schmidt_add(b_->pointer(), k, size_, bnew->pointer()[k])) {
-                    basis_size_++; // <- Increase L if we add one more basis
-                                   // vector
+                    basis_size_++; // <- Increase L if we add one more basis vector
                 }
             }
         }

--- a/src/helpers/iterative_solvers.cc
+++ b/src/helpers/iterative_solvers.cc
@@ -92,6 +92,10 @@ void DavidsonLiuSolver::set_e_convergence(double value) { e_convergence_ = value
 
 void DavidsonLiuSolver::set_r_convergence(double value) { r_convergence_ = value; }
 
+double DavidsonLiuSolver::get_e_convergence() const { return e_convergence_; }
+
+double DavidsonLiuSolver::get_r_convergence() const { return r_convergence_; }
+
 void DavidsonLiuSolver::set_collapse_per_root(int value) { collapse_per_root_ = value; }
 
 void DavidsonLiuSolver::set_subspace_per_root(int value) { subspace_per_root_ = value; }
@@ -195,7 +199,7 @@ SolverStatus DavidsonLiuSolver::update() {
     for (size_t k = 0; k < nroot_; k++) {
         if (basis_size_ < subspace_size_) {
             // check that the norm of the correction vector (before normalization) is "not small"
-            if (f_norm[k] > schmidt_threshold_) {
+            if (f_norm[k] > 0.1 * r_convergence_) {
                 // Schmidt-orthogonalize the correction vector
                 if (schmidt_add(b_->pointer(), basis_size_, size_, f->pointer()[k])) {
                     basis_size_++; // <- Increase L if we add one more basis vector

--- a/src/helpers/iterative_solvers.cc
+++ b/src/helpers/iterative_solvers.cc
@@ -35,15 +35,14 @@
 #include "helpers/iterative_solvers.h"
 
 #define PRINT_VARS(msg)                                                                            \
-    //    std::vector<std::pair<size_t,std::string>> v = \
-//        {{collapse_size_,"collapse_size_"}, \
-//        {subspace_size_,"subspace_size_"}, \
-//        {basis_size_,"basis_size_"}, \
-//        {sigma_size_,"sigma_size_"}, \
-//        {nroot_,"nroot_"}}; \
-//    outfile->Printf("\n\n => %s <=",msg); \
-//    for (auto vk : v){ \
-//        outfile->Printf("\n    %-30s  %zu",vk.second.c_str(),vk.first); \
+    //    std::vector<std::pair<size_t, std::string>> v = {{collapse_size_, "collapse_size_"},           \
+//                                                     {subspace_size_, "subspace_size_"},           \
+//                                                     {basis_size_, "basis_size_"},                 \
+//                                                     {sigma_size_, "sigma_size_"},                 \
+//                                                     {nroot_, "nroot_"}};                          \
+//    outfile->Printf("\n\n => %s <=", msg);                                                         \
+//    for (auto vk : v) {                                                                            \
+//        outfile->Printf("\n    %-30s  %zu", vk.second.c_str(), vk.first);                          \
 //    }
 
 using namespace psi;
@@ -164,8 +163,13 @@ SolverStatus DavidsonLiuSolver::update() {
     G->gemm(false, false, 1.0, b_, sigma_, 0.0);
     G->diagonalize(alpha, lambda);
 
+    bool is_energy_converged = false;
+    bool is_residual_converged = false;
     if (not last_update_collapsed_) {
-        if (check_convergence()) {
+        auto converged = check_convergence();
+        is_energy_converged = converged.first;
+        is_residual_converged = converged.second;
+        if (is_energy_converged and is_residual_converged) {
             get_results();
             return SolverStatus::Converged;
         }
@@ -196,16 +200,26 @@ SolverStatus DavidsonLiuSolver::update() {
 
     // schmidt orthogonalize the f[k] against the set of b[i] and add new
     // vectors
+    size_t num_added = 0;
     for (size_t k = 0; k < nroot_; k++) {
         if (basis_size_ < subspace_size_) {
             // check that the norm of the correction vector (before normalization) is "not small"
-            if (f_norm[k] > 0.1 * r_convergence_) {
+            if (f_norm[k] > 0.01 * r_convergence_) {
                 // Schmidt-orthogonalize the correction vector
                 if (schmidt_add(b_->pointer(), basis_size_, size_, f->pointer()[k])) {
                     basis_size_++; // <- Increase L if we add one more basis vector
+                    num_added += 1;
+                } else {
+                    outfile->Printf("\n  Rejected new correction vector %d with norm: %f", k,
+                                    f_norm[k]);
                 }
             }
         }
+    }
+
+    // if we do not add any new vector then we are in trouble and we better finish the computation
+    if ((num_added == 0) and is_energy_converged) {
+        return SolverStatus::Converged;
     }
 
     iter_++;
@@ -231,8 +245,9 @@ void DavidsonLiuSolver::form_correction_vectors() {
                 f_p[k][I] += alpha_p[i][k] * (sigma_p[I][i] - lambda_p[k] * b_p[i][I]);
             }
             residual_[k] += std::pow(f_p[k][I], 2.0);
+
             double denom = lambda_p[k] - Adiag_p[I];
-            if (std::fabs(denom) > 1e-6) {
+            if (std::fabs(denom) > 1.0e-6) {
                 f_p[k][I] /= denom;
             } else {
                 f_p[k][I] = 0.0;
@@ -371,33 +386,42 @@ void DavidsonLiuSolver::collapse_vectors() {
     }
 }
 
-bool DavidsonLiuSolver::check_convergence() {
+std::pair<bool, bool> DavidsonLiuSolver::check_convergence() {
     compute_residual_norm();
     // check convergence on all roots
-    bool has_converged = false;
+    int num_converged_energy = 0;
+    int num_converged_residual = 0;
     converged_ = 0;
     if (print_level_ > 1) {
         outfile->Printf("\n  Root      Eigenvalue        Delta   Converged?\n");
         outfile->Printf("  ---- -------------------- --------- ----------\n");
     }
     for (size_t k = 0; k < nroot_; k++) {
+        // check if the energy converged
         double diff = std::fabs(lambda->get(k) - lambda_old->get(k));
-        bool this_converged = false;
-        if ((diff < e_convergence_) and (residual_[k] < r_convergence_)) {
-            this_converged = true;
+        bool this_energy_converged = (diff < e_convergence_);
+        // check if the residual converged
+        bool this_residual_converged = (residual_[k] < r_convergence_);
+        // update counters
+        num_converged_energy += this_energy_converged;
+        num_converged_residual += this_residual_converged;
+
+        if (this_energy_converged and this_residual_converged) {
             converged_++;
         }
+        // update the old eigenvalue
         lambda_old->set(k, lambda->get(k));
+
         if (print_level_ > 1) {
+            bool this_converged = (this_energy_converged and this_residual_converged);
             outfile->Printf("  %3d  %20.14f %4.3e      %1s\n", k, lambda->get(k), diff,
                             this_converged ? "Y" : "N");
         }
     }
 
-    if (converged_ == nroot_) {
-        has_converged = true;
-    }
-    return has_converged;
+    bool is_energy_converged = (num_converged_energy == nroot_);
+    bool is_residual_converged = (num_converged_residual == nroot_);
+    return std::make_pair(is_energy_converged, is_residual_converged);
 }
 
 void DavidsonLiuSolver::get_results() {

--- a/src/helpers/iterative_solvers.h
+++ b/src/helpers/iterative_solvers.h
@@ -134,8 +134,9 @@ class DavidsonLiuSolver {
     void compute_residual_norm();
     /// Project out undesired roots
     void project_out_roots(psi::SharedMatrix v);
-    /// Normalize the correction vectors
-    void normalize_vectors(psi::SharedMatrix v, size_t n);
+    /// Normalize the correction vectors and return the norm of the vectors before they were
+    /// normalized
+    std::vector<double> normalize_vectors(psi::SharedMatrix v, size_t n);
     /// Perform subspace collapse
     bool subspace_collapse();
     /// Collapse the vectors
@@ -149,8 +150,8 @@ class DavidsonLiuSolver {
     double e_convergence_ = 1.0e-12;
     /// Residual convergence threshold
     double r_convergence_ = 1.0e-6;
-    /// The threshold used to discard vectors
-    double schmidt_threshold_ = 1.0e-3;
+    /// The threshold used to discard correction vectors
+    double schmidt_threshold_ = 1.0e-6;
     /// The dimension of the vectors
     size_t size_;
     /// The number of roots requested
@@ -172,7 +173,7 @@ class DavidsonLiuSolver {
     double timing_ = 0.0;
     bool last_update_collapsed_ = false;
 
-    /// Current set of guess vectors stored by row
+    /// Current set of basis vectors stored by row
     psi::SharedMatrix b_;
     /// Guess vectors formed from old vectors, stored by row
     psi::SharedMatrix bnew;

--- a/src/helpers/iterative_solvers.h
+++ b/src/helpers/iterative_solvers.h
@@ -131,7 +131,8 @@ class DavidsonLiuSolver {
     /// Check that the eigenvectors are orthogonal
     bool check_orthogonality();
     /// Check if the the iterative procedure has converged
-    bool check_convergence();
+    /// @return a pair of boolean (is_energy_converged,is_residual_converged)
+    std::pair<bool, bool> check_convergence();
     /// Build the correction vectors
     void form_correction_vectors();
     /// Compute the 2-norm of the residual

--- a/src/helpers/iterative_solvers.h
+++ b/src/helpers/iterative_solvers.h
@@ -85,6 +85,10 @@ class DavidsonLiuSolver {
     void set_e_convergence(double value);
     /// Set the residual convergence
     void set_r_convergence(double value);
+    /// Get the energy convergence
+    double get_e_convergence() const;
+    /// Get the residual convergence
+    double get_r_convergence() const;
     /// Set the number of collapse vectors for each root
     void set_collapse_per_root(int value);
     /// Set the maximum subspace size for each root
@@ -151,7 +155,7 @@ class DavidsonLiuSolver {
     /// Residual convergence threshold
     double r_convergence_ = 1.0e-6;
     /// The threshold used to discard correction vectors
-    double schmidt_threshold_ = 1.0e-6;
+    double schmidt_threshold_ = 1.0e-8;
     /// The dimension of the vectors
     size_t size_;
     /// The number of roots requested

--- a/src/integrals/integrals.cc
+++ b/src/integrals/integrals.cc
@@ -246,23 +246,9 @@ std::vector<std::shared_ptr<psi::Matrix>> ForteIntegrals::AOdipole_ints() const 
 }
 
 void ForteIntegrals::transform_one_electron_integrals() {
-    // Now we want the reference (SCF) wavefunction
-    std::shared_ptr<PSIO> psio_ = PSIO::shared_object();
-
-    std::shared_ptr<psi::Matrix> T =
-        std::shared_ptr<psi::Matrix>(wfn_->matrix_factory()->create_matrix(PSIF_SO_T));
-    std::shared_ptr<psi::Matrix> V =
-        std::shared_ptr<psi::Matrix>(wfn_->matrix_factory()->create_matrix(PSIF_SO_V));
-
-    MintsHelper mints(wfn_->basisset(), psi::Process::environment.options,
-                      0); // 0 here is to avoid printing of basis info
-    T = mints.so_kinetic();
-    V = mints.so_potential();
-
-    std::shared_ptr<psi::Matrix> Ha = T->clone();
-    std::shared_ptr<psi::Matrix> Hb = T->clone();
-    Ha->add(V);
-    Hb->add(V);
+    // Grab the one-electron integrals from psi4's wave function object
+    std::shared_ptr<psi::Matrix> Ha = wfn_->H()->clone();
+    std::shared_ptr<psi::Matrix> Hb = wfn_->H()->clone();
 
     OneIntsAO_ = Ha->clone();
 

--- a/src/pci/pci.cc
+++ b/src/pci/pci.cc
@@ -212,9 +212,10 @@ void ProjectorCI::sortHashVecByCoefficient(det_hashvec& dets_hashvec, std::vecto
 }
 
 ProjectorCI::ProjectorCI(StateInfo state, size_t nroot, std::shared_ptr<SCFInfo> scf_info,
+                         std::shared_ptr<ForteOptions> options,
                          std::shared_ptr<MOSpaceInfo> mo_space_info,
                          std::shared_ptr<ActiveSpaceIntegrals> as_ints)
-    : SelectedCIMethod(state, nroot, scf_info, mo_space_info, as_ints) {
+    : SelectedCIMethod(state, nroot, scf_info, options, mo_space_info, as_ints) {
     // Copy the wavefunction information
     startup();
 }

--- a/src/pci/pci.cc
+++ b/src/pci/pci.cc
@@ -860,7 +860,7 @@ void ProjectorCI::post_iter_process() {
         DeterminantHashVec det_map(std::move(dets_hashvec_));
 
         // set SparseCISolver options
-        sparse_solver_.set_spin_project(true);
+        sparse_solver_.set_spin_project(options_->get_bool("SCI_PROJECT_OUT_SPIN_CONTAMINANTS"));
         sparse_solver_.manual_guess(false);
         sparse_solver_.set_force_diag(false);
 

--- a/src/pci/pci.h
+++ b/src/pci/pci.h
@@ -69,7 +69,7 @@ class ProjectorCI : public SelectedCIMethod {
      * @param options The main options object
      * @param ints A pointer to an allocated integral object
      */
-    ProjectorCI(StateInfo state, size_t nroot, std::shared_ptr<forte::SCFInfo> scf_info,
+    ProjectorCI(StateInfo state, size_t nroot, std::shared_ptr<forte::SCFInfo> scf_info, std::shared_ptr<ForteOptions> options,
                   std::shared_ptr<MOSpaceInfo> mo_space_info,
                   std::shared_ptr<ActiveSpaceIntegrals> as_ints);
 

--- a/src/sci/aci.cc
+++ b/src/sci/aci.cc
@@ -574,6 +574,8 @@ void AdaptiveCI::pre_iter_preparation() {
     sparse_solver_->set_guess_dimension(options_->get_int("DL_GUESS_SIZE"));
     sparse_solver_->set_num_vecs(options_->get_int("N_GUESS_VEC"));
     sparse_solver_->set_spin_project_full(false);
+    sparse_solver_->set_ncollapse_per_root(options_->get_int("DL_COLLAPSE_PER_ROOT"));
+    sparse_solver_->set_nsubspace_per_root(options_->get_int("DL_SUBSPACE_PER_ROOT"));
 }
 
 void AdaptiveCI::diagonalize_P_space() {

--- a/src/sci/aci.h
+++ b/src/sci/aci.h
@@ -134,49 +134,11 @@ class AdaptiveCI : public SelectedCIMethod {
     DeterminantHashVec PQ_space_;
 
     // ==> Class data <==
-    /// Forte options
-    std::shared_ptr<ForteOptions> options_;
-    /// The wave function symmetry
-    int wavefunction_symmetry_;
-    /// The symmetry of each orbital in Pitzer ordering
-    std::vector<int> mo_symmetry_;
-    /// The number of correlated molecular orbitals
-    int ncmo_;
-    /// The multiplicity of the reference
-    int multiplicity_;
-    /// M_s of the reference
-    int twice_ms_;
-    /// The number of active electrons
-    int nactel_;
-    /// The number of correlated alpha electrons
-    int nalpha_;
-    /// The number of correlated beta electrons
-    int nbeta_;
-    /// The number of frozen core orbitals
-    int nfrzc_;
-    psi::Dimension frzcpi_;
-    /// The number of correlated molecular orbitals per irrep
-    psi::Dimension ncmopi_;
-    /// The number of restricted docc orbitals per irrep
-    psi::Dimension rdoccpi_;
-    /// The number of active orbitals per irrep
-    psi::Dimension nactpi_;
-    /// The number of restricted docc
-    size_t rdocc_;
-    /// The number of restricted virtual
-    size_t rvir_;
-    /// The number of frozen virtual
-    size_t fvir_;
-    /// The number of irreps
-    size_t nirrep_;
 
-    /// The nuclear repulsion energy
-    double nuclear_repulsion_energy_;
     /// The reference determinant
     std::vector<Determinant> initial_reference_;
     /// The PT2 energy correction
     std::vector<double> multistate_pt2_energy_correction_;
-    size_t pre_iter_;
     bool set_ints_ = false;
 
     // ==> ACI Options <==
@@ -186,15 +148,12 @@ class AdaptiveCI : public SelectedCIMethod {
     double gamma_;
     /// The prescreening threshold
     double screen_thresh_;
-    /// The number of roots computed
-    int nroot_;
     /// Use threshold from perturbation theory?
     bool perturb_select_;
 
     /// Add missing degenerate determinants excluded from the aimed selection?
     bool add_aimed_degenerate_;
-    /// Add missing degenerate determinants excluded from the aimed selection?
-    bool project_out_spin_contaminants_;
+
 
     /// The function of the q-space criteria per root
     std::string pq_function_;
@@ -220,18 +179,11 @@ class AdaptiveCI : public SelectedCIMethod {
     double spin_tol_;
     /// Compute 1-RDM?
     bool compute_rdms_;
-    /// Enforce spin completeness of the P and P + Q spaces?
-    bool spin_complete_;
-    /// Enforce spin completeness of the P space?
-    bool spin_complete_P_ = false;
     /// Print a determinant analysis?
     bool det_hist_;
     /// Save dets to file?
     bool det_save_;
-    /// Order of RDM to compute
-    //    int rdm_level_;
-    /// Control amount of printing
-    bool quiet_mode_;
+
     /// Control streamlining
     bool streamline_qspace_;
     /// The CI coeffiecients
@@ -273,27 +225,6 @@ class AdaptiveCI : public SelectedCIMethod {
     double build_space_;
     double screen_space_;
     double spin_trans_;
-
-    // The RDMS
-    //    std::vector<double> ordm_a_;
-    //    std::vector<double> ordm_b_;
-    //    std::vector<double> trdm_aa_;
-    //    std::vector<double> trdm_ab_;
-    //    std::vector<double> trdm_bb_;
-    //    std::vector<double> trdm_aaa_;
-    //    std::vector<double> trdm_aab_;
-    //    std::vector<double> trdm_abb_;
-    //    std::vector<double> trdm_bbb_;
-
-    ambit::Tensor ordm_a_;
-    ambit::Tensor ordm_b_;
-    ambit::Tensor trdm_aa_;
-    ambit::Tensor trdm_ab_;
-    ambit::Tensor trdm_bb_;
-    ambit::Tensor trdm_aaa_;
-    ambit::Tensor trdm_aab_;
-    ambit::Tensor trdm_abb_;
-    ambit::Tensor trdm_bbb_;
 
     // ==> Class functions <==
 

--- a/src/sci/asci.cc
+++ b/src/sci/asci.cc
@@ -61,12 +61,7 @@ bool pairCompDescend(const std::pair<double, Determinant> E1,
 ASCI::ASCI(StateInfo state, size_t nroot, std::shared_ptr<SCFInfo> scf_info,
            std::shared_ptr<ForteOptions> options, std::shared_ptr<MOSpaceInfo> mo_space_info,
            std::shared_ptr<ActiveSpaceIntegrals> as_ints)
-    : SelectedCIMethod(state, nroot, scf_info, mo_space_info, as_ints), scf_info_(scf_info),
-      options_(options) {
-    // select the sigma vector type
-    sigma_vector_type_ = string_to_sigma_vector_type(options_->get_str("DIAG_ALGORITHM"));
-    mo_symmetry_ = mo_space_info_->symmetry("ACTIVE");
-    nuclear_repulsion_energy_ = as_ints->ints()->nuclear_repulsion_energy();
+    : SelectedCIMethod(state, nroot, scf_info, options, mo_space_info, as_ints) {
     startup();
 }
 
@@ -102,24 +97,6 @@ void ASCI::pre_iter_preparation() {
 }
 
 void ASCI::startup() {
-
-    //    if (!set_ints_) {
-    //        set_asci_ints(ints_); // TODO: maybe a BUG?
-    //    }
-
-    wavefunction_symmetry_ = state_.irrep();
-    multiplicity_ = state_.multiplicity();
-
-    nact_ = mo_space_info_->size("ACTIVE");
-    nactpi_ = mo_space_info_->dimension("ACTIVE");
-
-    nirrep_ = mo_space_info_->nirrep();
-    // Include frozen_docc and restricted_docc
-    frzcpi_ = mo_space_info_->dimension("INACTIVE_DOCC");
-    nfrzc_ = mo_space_info_->size("INACTIVE_DOCC");
-
-    twice_ms_ = state_.twice_ms();
-
     // Build the reference determinant and compute its energy
     CI_Reference ref(scf_info_, options_, mo_space_info_, as_ints_, multiplicity_, twice_ms_,
                      wavefunction_symmetry_);
@@ -127,12 +104,6 @@ void ASCI::startup() {
 
     // Read options
     nroot_ = options_->get_int("NROOT");
-
-    max_cycle_ = options_->get_int("SCI_MAX_CYCLE");
-
-    pre_iter_ = options_->get_int("ACI_PREITERATIONS");
-
-    max_memory_ = options_->get_int("SIGMA_VECTOR_MAX_MEMORY");
 
     // Decide when to compute coupling lists
     build_lists_ = true;

--- a/src/sci/asci.h
+++ b/src/sci/asci.h
@@ -38,8 +38,8 @@ namespace forte {
 class RDMs;
 
 /**
- * @brief The AdaptiveCI class
- * This class implements an adaptive CI algorithm
+ * @brief The ASCI class
+ * This class implements the Adaptively Selected CI algorithm
  */
 class ASCI : public SelectedCIMethod {
   public:
@@ -115,8 +115,6 @@ class ASCI : public SelectedCIMethod {
     bool follow_;
     local_timer cycle_time_;
 
-    bool project_out_spin_contaminants_;
-
     // Temporarily added interface to ExcitedStateSolver
     psi::SharedMatrix PQ_evecs_;
     psi::SharedVector PQ_evals_;
@@ -126,35 +124,12 @@ class ASCI : public SelectedCIMethod {
     /// Storage of past roots
     std::vector<std::vector<std::pair<Determinant, double>>> old_roots_;
 
-    /// HF info
-    std::shared_ptr<SCFInfo> scf_info_;
-    /// Options
-    std::shared_ptr<ForteOptions> options_;
-    /// The wave function symmetry
-    int wavefunction_symmetry_;
-    /// The symmetry of each orbital in Pitzer ordering
-    std::vector<int> mo_symmetry_;
-    /// The multiplicity of the reference
-    int multiplicity_;
-    /// M_s of the reference
-    int twice_ms_;
-    /// Number of irreps
-    size_t nirrep_;
-    /// The number of frozen core orbitals
-    int nfrzc_;
-    /// The number of frozen core orbital per irrets
-    psi::Dimension frzcpi_;
-    /// The number of active orbitals per irrep
-    psi::Dimension nactpi_;
-    /// The nuclear repulsion energy
-    double nuclear_repulsion_energy_;
     /// The reference determinant
     std::vector<Determinant> initial_reference_;
     /// The PT2 energy correction
     std::vector<double> multistate_pt2_energy_correction_;
     /// The last iteration
     bool set_ints_ = false;
-    size_t pre_iter_;
 
     // ==> ASCI Options <==
     /// The threshold applied to the primary space
@@ -166,8 +141,6 @@ class ASCI : public SelectedCIMethod {
     bool compute_rdms_;
     /// The CI coeffiecients
     psi::SharedMatrix evecs_;
-
-    bool quiet_mode_ = false;
 
     bool build_lists_;
     bool print_weights_ = false;
@@ -183,17 +156,6 @@ class ASCI : public SelectedCIMethod {
     double build_space_;
     double screen_space_;
     double spin_trans_;
-
-    // The RDMS
-    ambit::Tensor ordm_a_;
-    ambit::Tensor ordm_b_;
-    ambit::Tensor trdm_aa_;
-    ambit::Tensor trdm_ab_;
-    ambit::Tensor trdm_bb_;
-    ambit::Tensor trdm_aaa_;
-    ambit::Tensor trdm_aab_;
-    ambit::Tensor trdm_abb_;
-    ambit::Tensor trdm_bbb_;
 
     // ==> Class functions <==
 

--- a/src/sci/fci_mo.cc
+++ b/src/sci/fci_mo.cc
@@ -901,7 +901,7 @@ void FCI_MO::Diagonalize_H(const vecdet& p_space, const int& multi, const int& n
     SparseCISolver sparse_solver;
     sparse_solver.set_e_convergence(econv_);
     sparse_solver.set_r_convergence(rconv_);
-    sparse_solver.set_spin_project(true);
+    sparse_solver.set_spin_project(options_->get_bool("SCI_PROJECT_OUT_SPIN_CONTAMINANTS"));
     sparse_solver.set_maxiter_davidson(options_->get_int("DL_MAXITER"));
     sparse_solver.set_guess_dimension(options_->get_int("DL_GUESS_SIZE"));
     if (projected_roots_.size() != 0) {

--- a/src/sci/sci.h
+++ b/src/sci/sci.h
@@ -51,6 +51,7 @@ class SparseCISolver;
 class SelectedCIMethod {
   public:
     SelectedCIMethod(StateInfo state, size_t nroot, std::shared_ptr<SCFInfo> scf_info,
+                     std::shared_ptr<ForteOptions> options,
                      std::shared_ptr<MOSpaceInfo> mo_space_info,
                      std::shared_ptr<ActiveSpaceIntegrals> as_ints);
 
@@ -98,8 +99,9 @@ class SelectedCIMethod {
     virtual std::vector<double> get_multistate_pt2_energy_correction() = 0;
     virtual size_t get_cycle();
 
+    void base_startup();
     void print_wfn(DeterminantHashVec& space, psi::SharedMatrix evecs, int nroot,
-                   size_t max_dets_to_print = 10);
+                   size_t max_dets_to_print = 20);
 
     SigmaVectorType sigma_vector_type() const;
     /// Return the maximum amount of memory allowed
@@ -111,6 +113,9 @@ class SelectedCIMethod {
 
     /// The number of roots (default = 1)
     size_t nroot_ = 1;
+
+    /// The nuclear repulsion energy
+    double nuclear_repulsion_energy_;
 
     /// The sigma vector type
     SigmaVectorType sigma_vector_type_ = SigmaVectorType::Dynamic;
@@ -124,8 +129,11 @@ class SelectedCIMethod {
     /// doubly occupied orbitals specified by the core_mo_ vector.
     std::shared_ptr<ActiveSpaceIntegrals> as_ints_;
 
-    /// Some HF info
+    /// HF info
     std::shared_ptr<SCFInfo> scf_info_;
+
+    /// Options
+    std::shared_ptr<ForteOptions> options_;
 
     /// The sparse CI solver (allocated at creation by the base class)
     std::shared_ptr<SparseCISolver> sparse_solver_;
@@ -133,14 +141,73 @@ class SelectedCIMethod {
     /// The current iteration
     size_t cycle_;
 
+    /// TODO needs documentation
+    size_t pre_iter_;
+
     /// Maximum number of SCI iterations
     size_t max_cycle_;
 
     /// Maximum memory size
     size_t max_memory_ = 0;
 
+    /// Control amount of printing
+    bool quiet_mode_;
+
+    /// Add missing degenerate determinants excluded from the aimed selection?
+    bool project_out_spin_contaminants_;
+
+    /// The wave function symmetry
+    int wavefunction_symmetry_;
+    /// The symmetry of each orbital in Pitzer ordering
+    std::vector<int> mo_symmetry_;
+    /// The number of correlated molecular orbitals
+    int ncmo_;
+    /// The multiplicity of the reference
+    int multiplicity_;
+    /// M_s of the reference
+    int twice_ms_;
+    /// The number of active electrons
+    int nactel_;
+    /// The number of correlated alpha electrons
+    int nalpha_;
+    /// The number of correlated beta electrons
+    int nbeta_;
+    /// The number of frozen core orbitals
+    int nfrzc_;
+    /// The number of irreps
+    size_t nirrep_;
+    psi::Dimension frzcpi_;
+    /// The number of correlated molecular orbitals per irrep
+    psi::Dimension ncmopi_;
+    /// The number of restricted docc orbitals per irrep
+    psi::Dimension rdoccpi_;
+    /// The number of active orbitals per irrep
+    psi::Dimension nactpi_;
+    /// The number of restricted docc
+    size_t rdocc_;
+    /// The number of restricted virtual
+    size_t rvir_;
+    /// The number of frozen virtual
+    size_t fvir_;
+
     /// The number of active orbitals
     size_t nact_;
+
+    /// Enforce spin completeness of the P and P + Q spaces?
+    bool spin_complete_;
+    /// Enforce spin completeness of the P space?
+    bool spin_complete_P_;
+
+    // The RDMS
+    ambit::Tensor ordm_a_;
+    ambit::Tensor ordm_b_;
+    ambit::Tensor trdm_aa_;
+    ambit::Tensor trdm_ab_;
+    ambit::Tensor trdm_bb_;
+    ambit::Tensor trdm_aaa_;
+    ambit::Tensor trdm_aab_;
+    ambit::Tensor trdm_abb_;
+    ambit::Tensor trdm_bbb_;
 };
 } // namespace forte
 

--- a/src/sparse_ci/determinant_functions.hpp
+++ b/src/sparse_ci/determinant_functions.hpp
@@ -33,6 +33,8 @@ Determinant union_occupation(const Determinant& lhs, const Determinant& rhs);
 
 void enforce_spin_completeness(std::vector<Determinant>& det_space, int nmo);
 
+std::vector<Determinant> find_minimum_spin_complete(std::vector<Determinant>& det_space, int nmo);
+
 } // namespace forte
 
 #endif // _determinant_functions_hpp_

--- a/src/sparse_ci/sigma_vector.h
+++ b/src/sparse_ci/sigma_vector.h
@@ -56,6 +56,9 @@ class SigmaVector {
         : space_(space), fci_ints_(fci_ints), size_(space.size()),
           sigma_vector_type_(sigma_vector_type), label_(label) {}
 
+    /// Virtual destructor to enable deletion of a Derived* through a Base*
+    virtual ~SigmaVector() = default;
+
     size_t size() { return size_; }
 
     std::shared_ptr<ActiveSpaceIntegrals> as_ints() { return fci_ints_; }

--- a/src/sparse_ci/sparse_ci_solver.cc
+++ b/src/sparse_ci/sparse_ci_solver.cc
@@ -339,48 +339,6 @@ SparseCISolver::initial_guess(const DeterminantHashVec& space,
             std::make_pair(d, space.get_idx(d))); // store a det and its position
     }
 
-    //    for (size_t n = 0; n < ndets; n++) {
-    //        outfile->Printf("\n %7d  %s", n, str(detmap[n], nmo).c_str());
-    //    }
-
-    // old code
-    //    std::vector<Determinant> guess_det;
-    //    for (size_t i = 0; i < nguess; i++) {
-    //        const Determinant& detI = smallest[i].second;
-    //        guess_dets_pos.push_back(
-    //            std::make_pair(detI, space.get_idx(detI))); // store a det and its position
-    //        guess_det.push_back(detI);
-    //        outfile->Printf("\n  %s", str(detI, nmo).c_str());
-    //    }
-
-    //    if (spin_project_) {
-    //        find_minimum_spin_complete(guess_det, nmo);
-
-    //        enforce_spin_completeness(guess_det, sigma_vector->as_ints()->nmo());
-    //        if (guess_det.size() > nguess) {
-    //            size_t nnew_dets = guess_det.size() - nguess;
-    //            if (print_details_)
-    //                outfile->Printf("\n  Initial guess space is incomplete!\n  "
-    //                                "Trying to add %d determinant(s).",
-    //                                nnew_dets);
-    //            int nfound = 0;
-    //            for (size_t i = 0; i < nnew_dets; ++i) {
-    //                for (size_t j = nguess; j < ndets; ++j) {
-    //                    const Determinant& detJ = smallest[j].second;
-    //                    if (detJ == guess_det[nguess + i]) {
-    //                        guess_dets_pos.push_back(std::make_pair(
-    //                            detJ, space.get_idx(detJ))); // store a det and its position
-    //                        nfound++;
-    //                        break;
-    //                    }
-    //                }
-    //            }
-    //            if (print_details_)
-    //                outfile->Printf("  %d determinant(s) added.", nfound);
-    //        }
-    //        nguess = guess_dets_pos.size();
-    //    }
-
     // Form the S^2 operator matrix and diagonalize it
     Matrix S2("S^2", nguess, nguess);
     for (size_t I = 0; I < nguess; I++) {
@@ -483,8 +441,6 @@ SparseCISolver::initial_guess(const DeterminantHashVec& space,
             }
             double E = HS2evals.get(r);
             guess.push_back(std::make_tuple(m, E, det_C));
-            //            outfile->Printf("\n  Guess state %4zu: E = %12.9f  2S+1 = %2d",
-            //            guess.size(), E, m);
         }
     }
     outfile->Printf("\n  ========================");

--- a/src/sparse_ci/sparse_ci_solver.cc
+++ b/src/sparse_ci/sparse_ci_solver.cc
@@ -103,6 +103,7 @@ SparseCISolver::diagonalize_hamiltonian(const DeterminantHashVec& space,
 
     if ((!force_diag_ and (space.size() <= 200)) or
         sigma_vector->sigma_vector_type() == SigmaVectorType::Full) {
+        outfile->Printf("\n\n  Performing diagonalization of the H matrix");
         const std::vector<Determinant> dets = space.determinants();
         return diagonalize_hamiltonian_full(dets, sigma_vector->as_ints(), nroot, multiplicity);
     }

--- a/src/sparse_ci/sparse_ci_solver.cc
+++ b/src/sparse_ci/sparse_ci_solver.cc
@@ -62,6 +62,10 @@ void SparseCISolver::set_r_convergence(double value) { r_convergence_ = value; }
 
 void SparseCISolver::set_maxiter_davidson(int value) { maxiter_davidson_ = value; }
 
+void SparseCISolver::set_ncollapse_per_root(int value) { ncollapse_per_root_ = value; }
+
+void SparseCISolver::set_nsubspace_per_root(int value) { nsubspace_per_root_ = value; }
+
 void SparseCISolver::set_spin_project_full(bool value) { spin_project_full_ = value; }
 
 void SparseCISolver::set_force_diag(bool value) { force_diag_ = value; }

--- a/src/sparse_ci/sparse_ci_solver.cc
+++ b/src/sparse_ci/sparse_ci_solver.cc
@@ -507,6 +507,8 @@ bool SparseCISolver::davidson_liu_solver(const DeterminantHashVec& space,
 
     if (print_details_) {
         outfile->Printf("\n\n  ==> Diagonalizing Hamiltonian <==\n");
+        outfile->Printf("\n  Energy   convergence: %.2e", dls.get_e_convergence());
+        outfile->Printf("\n  Residual convergence: %.2e", dls.get_r_convergence());
         outfile->Printf("\n  -----------------------------------------------------");
         outfile->Printf("\n    Iter.      Avg. Energy       Delta_E     Res. Norm");
         outfile->Printf("\n  -----------------------------------------------------");

--- a/src/sparse_ci/sparse_ci_solver.cc
+++ b/src/sparse_ci/sparse_ci_solver.cc
@@ -574,7 +574,6 @@ bool SparseCISolver::davidson_liu_solver(const DeterminantHashVec& space,
 
                 bad_roots.push_back(std::get<2>(g));
                 rejected += 1;
-                //            }
             }
             count += 1;
         }

--- a/src/sparse_ci/sparse_ci_solver.cc
+++ b/src/sparse_ci/sparse_ci_solver.cc
@@ -311,13 +311,10 @@ SparseCISolver::initial_guess(const DeterminantHashVec& space,
     }
     std::sort(smallest.begin(), smallest.end());
 
-    //    outfile->Printf("\n  Guess determinants:");
-
     std::vector<Determinant> guess_det;
     for (size_t i = 0; i < nguess; i++) {
         const Determinant& detI = smallest[i].second;
         guess_det.push_back(detI);
-        //        outfile->Printf("\n  %s", str(detI, nmo).c_str());
     }
 
     outfile->Printf("\n  Initial guess determinants:         %zu", guess_det.size());
@@ -357,7 +354,6 @@ SparseCISolver::initial_guess(const DeterminantHashVec& space,
 
     // Form the Hamiltonian
     Matrix H("H", nguess, nguess);
-    Matrix H2("H", nguess, nguess);
     for (size_t I = 0; I < nguess; I++) {
         for (size_t J = I; J < nguess; J++) {
             const Determinant& detI = guess_dets_pos[I].first;
@@ -365,11 +361,9 @@ SparseCISolver::initial_guess(const DeterminantHashVec& space,
             double HIJ = as_ints->slater_rules(detI, detJ);
             H.set(I, J, HIJ);
             H.set(J, I, HIJ);
-            H2.set(I, J, HIJ);
-            H2.set(J, I, HIJ);
         }
     }
-    // H.print();
+
     // Project H onto the spin-adapted subspace
     H.transform(S2evecs);
 
@@ -380,10 +374,6 @@ SparseCISolver::initial_guess(const DeterminantHashVec& space,
         double mult = std::sqrt(1.0 + 4.0 * S2evals.get(i)); // 2S + 1 = Sqrt(1 + 4 S (S + 1))
         int mult_int = std::round(mult);
         double error = mult - static_cast<double>(mult_int);
-
-        //        outfile->Printf("\n  Guess %3d -> S(S+1) : %12.9f,  mult = %f, mult_int = %d", i,
-        //                        S2evals.get(i), mult, mult_int);
-
         if (std::fabs(error) < Stollerance) {
             mult_list[mult_int].push_back(i);
         } else if (print_details_) {

--- a/src/sparse_ci/sparse_ci_solver.h
+++ b/src/sparse_ci/sparse_ci_solver.h
@@ -108,6 +108,9 @@ class SparseCISolver {
     /// The maximum number of iterations for the Davidson algorithm
     void set_maxiter_davidson(int value);
 
+    void set_ncollapse_per_root(int value);
+    void set_nsubspace_per_root(int value);
+
     /// Build the full Hamiltonian matrix
     std::shared_ptr<psi::Matrix>
     build_full_hamiltonian(const std::vector<Determinant>& space,

--- a/src/sparse_ci/sparse_ci_solver.h
+++ b/src/sparse_ci/sparse_ci_solver.h
@@ -163,7 +163,7 @@ class SparseCISolver {
     /// Maximum number of iterations in the Davidson-Liu algorithm
     int maxiter_davidson_ = 100;
     /// Initial guess size per root
-    size_t dl_guess_ = 200;
+    size_t dl_guess_ = 50;
     /// Options for forcing diagonalization method
     bool force_diag_ = false;
     /// Additional roots to project out

--- a/src/sparse_ci/sparse_ci_solver.h
+++ b/src/sparse_ci/sparse_ci_solver.h
@@ -165,7 +165,7 @@ class SparseCISolver {
     int nsubspace_per_root_ = 4;
     /// Maximum number of iterations in the Davidson-Liu algorithm
     int maxiter_davidson_ = 100;
-    /// Initial guess size per root
+    /// Number of determinants used to form guess vector per root
     size_t dl_guess_ = 50;
     /// Options for forcing diagonalization method
     bool force_diag_ = false;

--- a/src/sparse_ci/sparse_ci_solver.h
+++ b/src/sparse_ci/sparse_ci_solver.h
@@ -128,7 +128,7 @@ class SparseCISolver {
     void set_num_vecs(size_t value);
 
   private:
-    std::vector<std::pair<double, std::vector<std::pair<size_t, double>>>>
+    std::vector<std::tuple<int, double, std::vector<std::pair<size_t, double>>>>
     initial_guess(const DeterminantHashVec& space, std::shared_ptr<SigmaVector> sigma_vector,
                   int nroot, int multiplicity);
 

--- a/tests/large_det/aci-1/input.dat
+++ b/tests/large_det/aci-1/input.dat
@@ -34,7 +34,7 @@ set forte {
   gamma 0.0015
   nroot 1
   charge 0
-  aci_enforce_spin_complete true
+  sci_enforce_spin_complete true
 }
 
 E, wfn = energy('scf', return_wfn=True)

--- a/tests/large_det/aci-2/input.dat
+++ b/tests/large_det/aci-2/input.dat
@@ -34,7 +34,7 @@ set forte {
   gamma 0.0015
   nroot 1
   charge 0
-  aci_enforce_spin_complete true
+  sci_enforce_spin_complete true
 }
 
 E, wfn = energy('scf', return_wfn=True)

--- a/tests/methods/aci-1/input.dat
+++ b/tests/methods/aci-1/input.dat
@@ -4,8 +4,8 @@
 import forte
 
 refscf = -14.839846512738 #TEST
-refaci = -14.889051449776 #TEST
-refacipt2 = -14.890048359302 #TEST
+refaci = -14.889166993726 #TEST
+refacipt2 = -14.890166618934 #TEST
 
 molecule li2{
 0 1
@@ -35,13 +35,13 @@ set forte {
   root_sym 0
   charge 0
   sci_enforce_spin_complete false
-#  r_convergence 0.1
+  sci_project_out_spin_contaminants false
   active_ref_type hf 
 }
 
 energy('scf')
 
-#compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
 compare_values(refaci, variable("ACI ENERGY"),9, "ACI energy") #TEST

--- a/tests/methods/aci-1/input.dat
+++ b/tests/methods/aci-1/input.dat
@@ -16,8 +16,7 @@ molecule li2{
 set {
   basis DZ
   e_convergence 10
-  d_convergence 10
-  r_convergence 10
+  d_convergence  8
   guess gwh
 }
 
@@ -35,8 +34,8 @@ set forte {
   nroot 1
   root_sym 0
   charge 0
-  aci_enforce_spin_complete false
-  r_convergence 0.1
+  sci_enforce_spin_complete false
+#  r_convergence 0.1
   active_ref_type hf 
 }
 

--- a/tests/methods/aci-10/input.dat
+++ b/tests/methods/aci-10/input.dat
@@ -44,7 +44,7 @@ set forte {
   nroot                  1
   active_space_solver    aci
   sigma	                  0.001
-  aci_enforce_spin_complete  true
+  sci_enforce_spin_complete  true
   aci_add_aimed_degenerate false
   sci_project_out_spin_contaminants false
   diag_algorithm full

--- a/tests/methods/aci-11/input.dat
+++ b/tests/methods/aci-11/input.dat
@@ -38,7 +38,7 @@ set forte {
   sigma 0.02
   nroot 1
   charge 0
-  aci_enforce_spin_complete true
+  sci_enforce_spin_complete true
   active_ref_type hf
 }
 

--- a/tests/methods/aci-12/input.dat
+++ b/tests/methods/aci-12/input.dat
@@ -35,7 +35,7 @@ set forte {
   sigma 0.05
   nroot 3
   charge 0
-  aci_enforce_spin_complete true
+  sci_enforce_spin_complete true
   aci_n_average 3
   aci_average_offset 0
   diag_algorithm sparse

--- a/tests/methods/aci-13/input.dat
+++ b/tests/methods/aci-13/input.dat
@@ -38,7 +38,7 @@ set forte {
   sigma 0.02
   nroot 1
   charge 0
-  aci_enforce_spin_complete true
+  sci_enforce_spin_complete true
   diag_algorithm sparse
   active_ref_type hf
 }

--- a/tests/methods/aci-14/input.dat
+++ b/tests/methods/aci-14/input.dat
@@ -32,7 +32,7 @@ set forte {
   aci_n_average 2
   charge 0
   root_sym 0
-  aci_preiterations 2
+  sci_preiterations 2
   dl_maxiter 100
 }
 

--- a/tests/methods/aci-15/input.dat
+++ b/tests/methods/aci-15/input.dat
@@ -38,7 +38,7 @@ set forte {
   sigma 0.02
   nroot 1
   charge 0
-  aci_enforce_spin_complete true
+  sci_enforce_spin_complete true
   diag_algorithm sparse
   active_ref_type hf
 }

--- a/tests/methods/aci-17/input.dat
+++ b/tests/methods/aci-17/input.dat
@@ -34,7 +34,7 @@ set forte {
   active_space_solver aci
   frozen_docc = [0,0,0,0,0,0,0,0]
   sigma 0.001
-  aci_enforce_spin_complete false
+  sci_enforce_spin_complete false
   nroot 1
   charge 0
   diag_algorithm  full

--- a/tests/methods/aci-18/input.dat
+++ b/tests/methods/aci-18/input.dat
@@ -29,7 +29,7 @@ set forte {
   nroot 2
   aci_nfrozen_core 1
   aci_roots_per_core 1
-  aci_preiterations 2
+  sci_preiterations 2
   charge 0                               
   aci_add_aimed_degenerate false
   aci_screen_alg core

--- a/tests/methods/aci-2/input.dat
+++ b/tests/methods/aci-2/input.dat
@@ -31,7 +31,7 @@ set forte {
   active_space_solver aci
   frozen_docc = [0,0,0,0,0,0,0,0]
   sigma 0.001
-  aci_enforce_spin_complete false
+  sci_enforce_spin_complete false
   nroot 1
   charge 0
   diag_algorithm full 

--- a/tests/methods/aci-3/input.dat
+++ b/tests/methods/aci-3/input.dat
@@ -19,9 +19,8 @@ H -0.1  0.5 1.0
 
 set {
   basis cc-pVDZ
-  e_convergence 10
-  d_convergence 10
-  r_convergence 10
+  e_convergence 12
+  d_convergence  6
   scf_type pk
   guess gwh
 }
@@ -30,6 +29,8 @@ set forte {
   multiplicity 1
   ms 0.0
   active_space_solver aci
+  e_convergence 11
+  r_convergence  7
   sigma 0.001000
   nroot 1
   charge 0

--- a/tests/methods/aci-4/input.dat
+++ b/tests/methods/aci-4/input.dat
@@ -38,7 +38,7 @@ set forte {
   root 1 
   charge 0
  # aci_initial_space cis
-  aci_enforce_spin_complete true
+  sci_enforce_spin_complete true
 }
 
 energy('scf')

--- a/tests/methods/aci-5/input.dat
+++ b/tests/methods/aci-5/input.dat
@@ -35,7 +35,7 @@ set forte {
   sigma 0.005
   nroot 2
   charge 0
-  aci_enforce_spin_complete false
+  sci_enforce_spin_complete false
   active_guess_size 56
 }
 

--- a/tests/methods/aci-6/input.dat
+++ b/tests/methods/aci-6/input.dat
@@ -34,7 +34,7 @@ set forte {
   sigma 0.07
   nroot 1
   charge 0
-  aci_enforce_spin_complete true
+  sci_enforce_spin_complete true
   aci_add_aimed_degenerate true
   sci_project_out_spin_contaminants true
 }

--- a/tests/methods/aci-8/input.dat
+++ b/tests/methods/aci-8/input.dat
@@ -29,7 +29,7 @@ set {
 
 set forte {
   active_space_solver aci
-  aci_enforce_spin_complete false
+  sci_enforce_spin_complete false
   sigma 0.001
   nroot 1
   charge 0
@@ -37,7 +37,7 @@ set forte {
   spin_analysis true
   spin_basis NO
   spin_test true
-  r_convergence 1
+  r_convergence 6
   e_convergence 12
 }
 

--- a/tests/methods/aci-8b/input.dat
+++ b/tests/methods/aci-8b/input.dat
@@ -1,12 +1,12 @@
-#! This tests the Adaptive-CI procedure using energy selection
+#! This tests a similar to aci-8 but it enforces a spin-complete determinant space
 #! Generated using commit GITCOMMIT
 #
 import forte 
 
 refscf = -2.0310813811962447 #TEST
-refaci = -2.115357375325 #TEST 
-refacipt2 = -2.116357232307 #TEST
-spin_val = 0.028996090 #TEST
+refaci = -2.115455548697 #TEST 
+refacipt2 = -2.116454728791 #TEST
+spin_val = 0.029056451 #TEST
 
 molecule li2{
 0 1
@@ -27,7 +27,7 @@ set {
 
 set forte {
   active_space_solver aci
-  sci_enforce_spin_complete false
+  sci_enforce_spin_complete true
   sigma 0.001
   nroot 1
   charge 0
@@ -35,7 +35,6 @@ set forte {
   spin_analysis true
   spin_basis NO
   spin_test true
-  sci_project_out_spin_contaminants false
   r_convergence 6
   e_convergence 12
 }

--- a/tests/methods/aci-9/input.dat
+++ b/tests/methods/aci-9/input.dat
@@ -26,7 +26,7 @@ set {
 set forte {
   active_space_solver aci
   aci_add_aimed_degenerate false
-  aci_enforce_spin_complete false
+  sci_enforce_spin_complete false
   frozen_docc [1,0,0,0,0,1,0,0]
   restricted_docc [1,0,0,0,0,0,1,0]
   active [1,0,1,1,0,2,0,1]

--- a/tests/methods/aci-dsrg-mrpt2-5/input.dat
+++ b/tests/methods/aci-dsrg-mrpt2-5/input.dat
@@ -2,9 +2,9 @@ import forte
 
 memory 2 gb
 
-escf = -304.9057795504940600
-efix = -305.39002965567 #-305.390029668114494 
-eaci = -305.39810141321 # -305.398101397722598 
+escf = -304.905779550494
+efix = -305.390029652734
+eaci = -305.3981015635
 
 molecule ene2{
 0 1
@@ -63,7 +63,6 @@ set forte {
   charge 0
   print_no true
   relax_ref once
-  r_convergence 0.1
   e_convergence 13
 }
 set_num_threads(8)

--- a/tests/methods/aci_scf-3/input.dat
+++ b/tests/methods/aci_scf-3/input.dat
@@ -47,7 +47,7 @@ set forte {
   root_sym               0
   nroot                  1
   sigma	                 0.001
-  aci_enforce_spin_complete   true
+  sci_enforce_spin_complete   true
   casscf_reference       true
   casscf_ci_solver        ACI
   job_type                casscf

--- a/tests/methods/asci-1/input.dat
+++ b/tests/methods/asci-1/input.dat
@@ -3,20 +3,21 @@ import forte
 # This test reproduces the ASCI energy of C2 reported in the Table 2 of the following paper:
 #   Tubman, N. M., Lee, J., Takeshita, T. Y., Head-Gordon, M., & Whaley, K. B. (2016). 
 #   J. Chem. Phys., 145 (4), 044112. http://doi.org/doi: 10.1063/1.4955109
+#   Note that the paper reports the value: E = -75.718444237487
+#   This test yields a slightly lower energy because we do not project out
+#   spin contaminants. The original value can be reproduced by projection.
 
 refscf = -75.38645665583094 
-refasci = -75.7184255710 
+refasci = -75.718444237487
                                          
 molecule CH2{                            
 0 1
 C
 C 1 1.27273
-
 }                                        
                                          
 set {                                    
   scf_type pk                            
-  #multiplicity 1                         
   basis cc-pvdz                      
   reference rohf
   e_convergence 10
@@ -36,6 +37,7 @@ set forte {
   asci_tdet 10000
   sci_max_cycle 6   
   asci_e_convergence 1e-6
+  sci_project_out_spin_contaminants false
   diag_algorithm dynamic
 }                                        
                                          

--- a/tests/methods/asci-1/input.dat
+++ b/tests/methods/asci-1/input.dat
@@ -35,8 +35,7 @@ set forte {
   asci_cdet 4000
   asci_tdet 10000
   sci_max_cycle 6   
-  asci_e_convergence 1e-5
-  r_convergence 1e-1
+  asci_e_convergence 1e-6
   diag_algorithm dynamic
 }                                        
                                          

--- a/tests/methods/asci-2/input.dat
+++ b/tests/methods/asci-2/input.dat
@@ -1,11 +1,13 @@
 import forte                              
 
-# This test reproduces the ASCI energy of C2 reported in the Table 2 of the following paper:
+# This test is similar to the ASCI energy of C2 reported in the Table 2 of the following paper:
 #   Tubman, N. M., Lee, J., Takeshita, T. Y., Head-Gordon, M., & Whaley, K. B. (2016). 
 #   J. Chem. Phys., 145 (4), 044112. http://doi.org/doi: 10.1063/1.4955109
+#
+#   In this test we use a smaller basis (6-31G)
 
 refscf = -75.34896498316222 
-refasci = -75.625005495823 
+refasci = -75.625013576139
                                          
 molecule CH2{                            
 0 1
@@ -15,9 +17,7 @@ C 1 1.27273
                                          
 set {                                    
   scf_type pk                            
-  #multiplicity 1                         
   basis 6-31g                      
-  reference rohf
   e_convergence 10
 }                                        
                                          
@@ -35,7 +35,7 @@ set forte {
   asci_tdet 1000
   sci_max_cycle 8   
   asci_e_convergence 1e-5
-  sci_project_out_spin_contaminants true
+  sci_project_out_spin_contaminants false
   spin_project_full false
 }                                        
                                          

--- a/tests/methods/asci-2/input.dat
+++ b/tests/methods/asci-2/input.dat
@@ -11,7 +11,6 @@ molecule CH2{
 0 1
 C
 C 1 1.27273
-
 }                                        
                                          
 set {                                    
@@ -38,7 +37,6 @@ set forte {
   asci_e_convergence 1e-5
   sci_project_out_spin_contaminants true
   spin_project_full false
-  R_CONVERGENCE 1.0
 }                                        
                                          
 Escf, scf_wfn = energy('scf', return_wfn=True)

--- a/tests/methods/asci-3/input.dat
+++ b/tests/methods/asci-3/input.dat
@@ -1,11 +1,13 @@
 import forte                              
 
-# This test reproduces the ASCI energy of C2 reported in the Table 2 of the following paper:
+# This test is similar to the ASCI energy of C2 reported in the Table 2 of the following paper:
 #   Tubman, N. M., Lee, J., Takeshita, T. Y., Head-Gordon, M., & Whaley, K. B. (2016). 
 #   J. Chem. Phys., 145 (4), 044112. http://doi.org/doi: 10.1063/1.4955109
+#
+#   In this test we use a smaller basis (6-31G) and compute two states using an average algorithm
 
 refscf = -75.34896498316222 
-refasci = -75.550651284593 
+refasci = -75.550740036607
                                          
 molecule CH2{                            
 0 1
@@ -16,9 +18,7 @@ C 1 1.27273
                                          
 set {                                    
   scf_type pk                            
-  #multiplicity 1                         
   basis 6-31g                      
-  reference rohf
   e_convergence 10
 }                                        
                                          
@@ -38,10 +38,9 @@ set forte {
   asci_cdet 50
   asci_tdet 334
   sci_max_cycle 8   
-  sci_project_out_spin_contaminants true
+  sci_project_out_spin_contaminants false
   spin_project_full false
   e_convergence 12
-  r_convergence 0.1
 }                                        
                                          
 Escf, scf_wfn = energy('scf', return_wfn=True)

--- a/tests/methods/fci-8/input.dat
+++ b/tests/methods/fci-8/input.dat
@@ -27,7 +27,7 @@ set forte {
   active              [2,0,0,0]
   multiplicity        3
   e_convergence       10
-  r_convergence       10
+  r_convergence        6
 }
 
 energy('forte')

--- a/tests/methods/fci-8/input.dat
+++ b/tests/methods/fci-8/input.dat
@@ -1,0 +1,34 @@
+#! Generated using commit GITCOMMIT
+
+import forte
+
+refscf = -14.54873910108353
+reffci = -99.232257164276
+
+molecule HF {
+0 3
+H
+F 1 1.3001
+}
+
+set {
+  basis 3-21g
+  reference rohf
+  scf_type pk
+  e_convergence 12
+  d_convergence  6
+  docc [2,0,1,1]
+  socc [2,0,0,0]
+}
+
+set forte {
+  active_space_solver fci 
+  restricted_docc     [2,0,1,1]
+  active              [2,0,0,0]
+  multiplicity        3
+  e_convergence       10
+  r_convergence       10
+}
+
+energy('forte')
+compare_values(reffci, variable("CURRENT ENERGY"),11, "FCI energy") #TEST

--- a/tests/methods/mrdsrg-spin-adapted-pt2-3/input.dat
+++ b/tests/methods/mrdsrg-spin-adapted-pt2-3/input.dat
@@ -71,8 +71,7 @@ set forte{
   e_convergence          12
   r_convergence          8
   int_type               diskdf
-#  sci_enforce_spin_complete false
- # sci_project_out_spin_contaminants false
+  sci_project_out_spin_contaminants false
 }
 energy('forte', ref_wfn=wfn)
 Eupt2 = variable("UNRELAXED ENERGY")

--- a/tests/methods/mrdsrg-spin-adapted-pt2-3/input.dat
+++ b/tests/methods/mrdsrg-spin-adapted-pt2-3/input.dat
@@ -5,8 +5,8 @@ import forte
 memory 500 mb
 Ecas_psi4_jk  = -229.495450424144593
 Ecas_forte_jk = -229.495450424145076
-Ept2_ur       = -230.143771796409
-Ept2_pr       = -230.150516563759
+Ept2_ur       = -230.143771791121878
+Ept2_pr       = -230.150516562986667
 
 molecule pbenzyne{
   0 1
@@ -50,10 +50,11 @@ set forte{
   restricted_docc        [5,3,0,0,0,0,4,4]
   active                 [1,0,1,2,1,2,1,0]
   e_convergence          12
-  r_convergence          8
+  r_convergence          9
   casscf_g_convergence   1e-8
   casscf_e_convergence   1e-12
   int_type               df
+  fci_maxiter            50
 }
 Ecas, wfn = energy('forte', ref_wfn=wfn, return_wfn=True)
 compare_values(Ecas_forte_jk, Ecas, 9, "CASSCF(8,8)/cc-pVDZ-JKFIT (FORTE) energy")
@@ -69,9 +70,9 @@ set forte{
   dsrg_s                 0.5
   relax_ref              once
   e_convergence          12
-  r_convergence          8
+  r_convergence          9
   int_type               diskdf
-  sci_project_out_spin_contaminants false
+  fci_maxiter            50
 }
 energy('forte', ref_wfn=wfn)
 Eupt2 = variable("UNRELAXED ENERGY")

--- a/tests/methods/mrdsrg-spin-adapted-pt2-3/input.dat
+++ b/tests/methods/mrdsrg-spin-adapted-pt2-3/input.dat
@@ -5,8 +5,8 @@ import forte
 memory 500 mb
 Ecas_psi4_jk  = -229.495450424144593
 Ecas_forte_jk = -229.495450424145076
-Ept2_ur       = -230.143771791121878
-Ept2_pr       = -230.150516562986667
+Ept2_ur       = -230.143771796409
+Ept2_pr       = -230.150516563759
 
 molecule pbenzyne{
   0 1
@@ -71,6 +71,8 @@ set forte{
   e_convergence          12
   r_convergence          8
   int_type               diskdf
+#  sci_enforce_spin_complete false
+ # sci_project_out_spin_contaminants false
 }
 energy('forte', ref_wfn=wfn)
 Eupt2 = variable("UNRELAXED ENERGY")

--- a/tests/methods/pci-1/input.dat
+++ b/tests/methods/pci-1/input.dat
@@ -23,8 +23,9 @@ set forte {
   PCI_GENERATOR WALL-CHEBYSHEV
   pci_spawning_threshold 0.0001
   pci_post_diagonalize true
-  DIAG_ALGORITHM DLSOLVER
+  SCI_PROJECT_OUT_SPIN_CONTAMINANTS false
   pci_e_convergence 12
+  pci_r_convergence  6
   PCI_STOP_HIGHER_NEW_LOW true
 }
 energy('scf')

--- a/tests/methods/tests.yaml
+++ b/tests/methods/tests.yaml
@@ -276,3 +276,7 @@ pci:
 #   - pci-7
    - pci-8
 #   - pci-9
+x2c:
+  short:
+   - x2c-1
+

--- a/tests/methods/tests.yaml
+++ b/tests/methods/tests.yaml
@@ -276,7 +276,7 @@ pci:
 #   - pci-7
    - pci-8
 #   - pci-9
-x2c:
-  short:
-   - x2c-1
+#x2c:
+#  short:
+#   - x2c-1
 

--- a/tests/methods/tests.yaml
+++ b/tests/methods/tests.yaml
@@ -185,6 +185,7 @@ fci:
    - fci-4
    - fci-5
    - fci-7
+   - fci-8
    - fci-ecp-1
    - fci-ecp-2
    - fci-ex-1

--- a/tests/methods/x2c-1/input.dat
+++ b/tests/methods/x2c-1/input.dat
@@ -21,6 +21,7 @@ set {
 }
 
 set forte {
+  basis_relativistic cc-pVDZ-DK
   active_space_solver fci
   restricted_docc [2,0,0,0]
   active          [2,0,1,3]

--- a/tests/methods/x2c-1/input.dat
+++ b/tests/methods/x2c-1/input.dat
@@ -6,8 +6,9 @@ molecule h2o {
 }
 
 set {
-  basis sto-3g
+  basis cc-pVDZ-DK
   relativistic X2C
+  BASIS_RELATIVISTIC cc-pVDZ-DK
   scf_type pk
   reference rhf
   e_convergence 10

--- a/tests/methods/x2c-1/input.dat
+++ b/tests/methods/x2c-1/input.dat
@@ -21,7 +21,6 @@ set {
 }
 
 set forte {
-  basis_relativistic cc-pVDZ-DK
   active_space_solver fci
   restricted_docc [2,0,0,0]
   active          [2,0,1,3]

--- a/tests/methods/x2c-1/input.dat
+++ b/tests/methods/x2c-1/input.dat
@@ -1,4 +1,8 @@
 import forte
+
+refscf = -76.07925670423528
+reffci = -76.09203532830179
+
 molecule h2o {
   O 
   H 1 0.96
@@ -8,16 +12,23 @@ molecule h2o {
 set {
   basis cc-pVDZ-DK
   relativistic X2C
-  BASIS_RELATIVISTIC cc-pVDZ-DK
+  basis_relativistic cc-pVDZ-DK
   scf_type pk
   reference rhf
   e_convergence 10
   d_convergence 10
   r_convergence 10
 }
+
 set forte {
-  job_type fci
+  active_space_solver fci
+  restricted_docc [2,0,0,0]
+  active          [2,0,1,3]
 }
 
 E, wfn = energy('scf', return_wfn=True)
+compare_values(refscf, variable("CURRENT ENERGY"),11, "SCF energy")
+
 E, wfn = energy('forte', ref_wfn=wfn, return_wfn=True)
+compare_values(reffci, variable("CURRENT ENERGY"),11, "FCI energy")
+

--- a/tests/performance/aci-1/input.dat
+++ b/tests/performance/aci-1/input.dat
@@ -33,7 +33,7 @@ set forte {
   gamma 0.0015
   nroot 1
   charge 0
-  aci_enforce_spin_complete true
+  sci_enforce_spin_complete true
 }
 
 energy('scf')


### PR DESCRIPTION
## Description
This PR fixes a bug in the Davidson-Liu solver. The added test case make sure that the solver correctly converges to a triplet state found above a singlet. As usual, this started like a PR that was supposed to solve one problem and it ended up addressing a bunch of little extra things.

## Features
- [X] Fix issue with parsing of relativistic basis
- [X] Move some common variables from ACI to SCI class
- [X] Read one-electron integrals from wavefunction
- [X] Improvements to the DL solver
- [X] Expose some options

## Checklist
- [X] Added tests of new features
- [X] Removed comments in code and input files
- [X] Documented source code
- [x] Ready to go!
