### PR TITLE
Add CI root following in 2-step MCSCF

### DIFF
--- a/register_forte_options.py
+++ b/register_forte_options.py
@@ -919,6 +919,10 @@ def register_casscf_options(options):
     options.add_str("CASSCF_CI_SOLVER", "CAS",
                     "The active space solver to use in CASSCF")
 
+    options.add_bool("MCSCF_ROOT_FOLLOW", False,
+                     "Follow the initial CI roots along the orbital optimizations"
+                     " (only for CASSCF_CI_SOLVER = CAS)")
+
     options.add_int("CASSCF_CI_FREQ", 1,
                     "How often to solve CI?\n"
                     "< 1: do CI in the first macro iteration ONLY\n"

--- a/register_forte_options.py
+++ b/register_forte_options.py
@@ -923,6 +923,8 @@ def register_casscf_options(options):
                      "Follow the initial CI roots along the orbital optimizations"
                      " (only for CASSCF_CI_SOLVER = CAS)")
 
+    options.add_bool("MCSCF_LOCK_S_STATE", False, "Follow S state")
+
     options.add_int("CASSCF_CI_FREQ", 1,
                     "How often to solve CI?\n"
                     "< 1: do CI in the first macro iteration ONLY\n"

--- a/src/base_classes/active_space_method.cc
+++ b/src/base_classes/active_space_method.cc
@@ -56,6 +56,8 @@ void ActiveSpaceMethod::set_active_space_integrals(std::shared_ptr<ActiveSpaceIn
 
 psi::SharedVector ActiveSpaceMethod::evals() { return evals_; }
 
+psi::SharedMatrix ActiveSpaceMethod::evecs() { return evecs_; }
+
 const std::vector<double>& ActiveSpaceMethod::energies() const { return energies_; }
 
 void ActiveSpaceMethod::set_e_convergence(double value) { e_convergence_ = value; }

--- a/src/base_classes/active_space_method.cc
+++ b/src/base_classes/active_space_method.cc
@@ -58,6 +58,10 @@ psi::SharedVector ActiveSpaceMethod::evals() { return evals_; }
 
 psi::SharedMatrix ActiveSpaceMethod::evecs() { return evecs_; }
 
+std::vector<std::vector<double>> ActiveSpaceMethod::quadrupole_moments() {
+    return quadruple_moments_;
+}
+
 const std::vector<double>& ActiveSpaceMethod::energies() const { return energies_; }
 
 void ActiveSpaceMethod::set_e_convergence(double value) { e_convergence_ = value; }

--- a/src/base_classes/active_space_method.h
+++ b/src/base_classes/active_space_method.h
@@ -33,6 +33,7 @@
 #include <unordered_set>
 
 #include "base_classes/state_info.h"
+#include "psi4/libmints/matrix.h"
 #include "psi4/libmints/vector.h"
 
 namespace forte {
@@ -140,6 +141,9 @@ class ActiveSpaceMethod {
     /// Return the eigenvalues
     psi::SharedVector evals();
 
+    /// Return the eigen vectors
+    psi::SharedMatrix evecs();
+
     /// Return a vector with the energies of all the states
     const std::vector<double>& energies() const;
 
@@ -205,6 +209,9 @@ class ActiveSpaceMethod {
 
     /// Eigenvalues
     psi::SharedVector evals_;
+
+    /// Eigenvectors
+    psi::SharedMatrix evecs_;
 
     /// The energies (including nuclear repulsion) of all the states
     std::vector<double> energies_;

--- a/src/base_classes/active_space_method.h
+++ b/src/base_classes/active_space_method.h
@@ -144,6 +144,9 @@ class ActiveSpaceMethod {
     /// Return the eigen vectors
     psi::SharedMatrix evecs();
 
+    /// Return the quadrupole moments
+    std::vector<std::vector<double> > quadrupole_moments();
+
     /// Return a vector with the energies of all the states
     const std::vector<double>& energies() const;
 
@@ -212,6 +215,9 @@ class ActiveSpaceMethod {
 
     /// Eigenvectors
     psi::SharedMatrix evecs_;
+
+    /// Quadrupole moments
+    std::vector<std::vector<double>> quadruple_moments_;
 
     /// The energies (including nuclear repulsion) of all the states
     std::vector<double> energies_;

--- a/src/base_classes/active_space_solver.cc
+++ b/src/base_classes/active_space_solver.cc
@@ -84,8 +84,10 @@ const std::map<StateInfo, std::vector<double>>& ActiveSpaceSolver::compute_energ
         method->compute_energy();
         const auto& energies = method->energies();
         state_energies_map_[state] = energies;
-        if (keep_evecs_)
+        if (keep_evecs_) {
             state_evecs_map_[state] = method->evecs();
+            state_Qpole_map_[state] = method->quadrupole_moments();
+        }
 
         // save energies for ms < 0 states (same in energy as ms > 0) to ensure correct averaging
         if (twice_ms > 0 and ms_avg_) {

--- a/src/base_classes/active_space_solver.cc
+++ b/src/base_classes/active_space_solver.cc
@@ -84,6 +84,8 @@ const std::map<StateInfo, std::vector<double>>& ActiveSpaceSolver::compute_energ
         method->compute_energy();
         const auto& energies = method->energies();
         state_energies_map_[state] = energies;
+        if (keep_evecs_)
+            state_evecs_map_[state] = method->evecs();
 
         // save energies for ms < 0 states (same in energy as ms > 0) to ensure correct averaging
         if (twice_ms > 0 and ms_avg_) {

--- a/src/base_classes/active_space_solver.h
+++ b/src/base_classes/active_space_solver.h
@@ -29,8 +29,9 @@
 #ifndef _active_space_solver_h_
 #define _active_space_solver_h_
 
-#include <vector>
+#include <map>
 #include <string>
+#include <vector>
 
 #include "psi4/libmints/matrix.h"
 
@@ -111,6 +112,14 @@ class ActiveSpaceSolver {
         as_ints_ = as_ints;
     }
 
+    /// Set the boolean if the eigen vectors are stored or not
+    void set_keep_evecs(bool keep) { keep_evecs_ = keep; }
+
+    /// Return the map of StateInfo to the computed nroots of eigen vectors
+    const std::map<StateInfo, psi::SharedMatrix>& state_evecs_map() const {
+        return state_evecs_map_;
+    }
+
   protected:
     /// a string that specifies the method used (e.g. "FCI", "ACI", ...)
     std::string method_;
@@ -127,8 +136,7 @@ class ActiveSpaceSolver {
     std::shared_ptr<MOSpaceInfo> mo_space_info_;
 
     /// The molecular integrals for the active space
-    /// This object holds only the integrals for the orbital contained in the
-    /// active_mo_vector.
+    /// This object holds only the integrals for the orbital contained in the active_mo_vector.
     /// The one-electron integrals and scalar energy contains contributions from the
     /// doubly occupied orbitals specified by the core_mo_ vector.
     std::shared_ptr<ActiveSpaceIntegrals> as_ints_;
@@ -160,6 +168,11 @@ class ActiveSpaceSolver {
 
     /// A variable to control printing information
     int print_ = 1;
+
+    /// Whether to store the eigen vectors or not
+    bool keep_evecs_ = false;
+    /// A map of state symmetries to the eigen vectors under given state symmetry
+    std::map<StateInfo, psi::SharedMatrix> state_evecs_map_;
 
     /// Pairs of state info and the contracted CI eigen vectors
     std::map<StateInfo, std::shared_ptr<psi::Matrix>>

--- a/src/base_classes/active_space_solver.h
+++ b/src/base_classes/active_space_solver.h
@@ -116,8 +116,13 @@ class ActiveSpaceSolver {
     void set_keep_evecs(bool keep) { keep_evecs_ = keep; }
 
     /// Return the map of StateInfo to the computed nroots of eigen vectors
-    const std::map<StateInfo, psi::SharedMatrix>& state_evecs_map() const {
+    std::map<StateInfo, psi::SharedMatrix> state_evecs_map() const {
         return state_evecs_map_;
+    }
+
+    /// Return the map of StateInfo to the computed nroots of quadrupole moments
+    std::map<StateInfo, std::vector<std::vector<double>>> state_Qpole_map() const {
+        return state_Qpole_map_;
     }
 
   protected:
@@ -173,6 +178,8 @@ class ActiveSpaceSolver {
     bool keep_evecs_ = false;
     /// A map of state symmetries to the eigen vectors under given state symmetry
     std::map<StateInfo, psi::SharedMatrix> state_evecs_map_;
+    /// A map of state symmetries to state quadrupole moments
+    std::map<StateInfo, std::vector<std::vector<double>>> state_Qpole_map_;
 
     /// Pairs of state info and the contracted CI eigen vectors
     std::map<StateInfo, std::shared_ptr<psi::Matrix>>

--- a/src/casscf/mcscf_2step.cc
+++ b/src/casscf/mcscf_2step.cc
@@ -88,6 +88,7 @@ void MCSCF_2STEP::read_options() {
     orb_type_redundant_ = options_->get_str("CASSCF_FINAL_ORBITAL");
 
     ci_type_ = options_->get_str("CASSCF_CI_SOLVER");
+    ci_follow_ = options_->get_bool("MCSCF_ROOT_FOLLOW") and (ci_type_ == "CAS");
 
     max_rot_ = options_->get_double("CASSCF_MAX_ROTATION");
     internal_rot_ = options_->get_bool("CASSCF_INTERNAL_ROT");
@@ -118,7 +119,9 @@ void MCSCF_2STEP::print_options() {
         {"Final orbital type", orb_type_redundant_}};
 
     std::vector<std::pair<std::string, bool>> info_bool{
-        {"Include internal rotations", internal_rot_}, {"Debug printing", debug_print_}};
+        {"Include internal rotations", internal_rot_},
+        {"CI root following", ci_follow_},
+        {"Debug printing", debug_print_}};
 
     if (do_diis_) {
         info_int.push_back({"DIIS start", diis_start_});
@@ -343,7 +346,10 @@ MCSCF_2STEP::diagonalize_hamiltonian(std::shared_ptr<ActiveSpaceIntegrals> fci_i
     auto active_space_solver = make_active_space_solver(ci_type_, state_map, scf_info_,
                                                         mo_space_info_, fci_ints, options_);
     active_space_solver->set_print(print);
+    active_space_solver->set_keep_evecs(ci_follow_);
     const auto state_energies_map = active_space_solver->compute_energy();
+
+    // TODO: compute roots overlap and determine new state_weights_map
 
     // TODO: need to save CI vectors and dump to file and let solver read them
 

--- a/src/casscf/mcscf_2step.h
+++ b/src/casscf/mcscf_2step.h
@@ -131,6 +131,8 @@ class MCSCF_2STEP {
 
     /// The name of CI solver
     std::string ci_type_;
+    /// Do CI root following
+    bool ci_follow_;
 
     /// Final total energy
     double energy_;

--- a/src/casscf/mcscf_2step.h
+++ b/src/casscf/mcscf_2step.h
@@ -134,6 +134,11 @@ class MCSCF_2STEP {
     /// Do CI root following
     bool ci_follow_;
 
+    /// The state to eigen vector map
+    std::map<StateInfo, psi::SharedMatrix> state_evecs_map_;
+    /// CI root following procedure
+    void ci_root_following(const std::unique_ptr<ActiveSpaceSolver> &active_space_solver);
+
     /// Final total energy
     double energy_;
 

--- a/src/integrals/integrals.cc
+++ b/src/integrals/integrals.cc
@@ -292,6 +292,10 @@ std::vector<std::shared_ptr<psi::Matrix>> ForteIntegrals::ao_dipole_ints() const
     return dipole_ints_ao_;
 }
 
+std::vector<std::shared_ptr<psi::Matrix>> ForteIntegrals::ao_quadrupole_ints() const {
+    return quadrupole_ints_ao_;
+}
+
 // void ForteIntegrals::set_oei(double** ints, bool alpha) {
 //    std::vector<double>& p_oei = alpha ? one_electron_integrals_a_ : one_electron_integrals_b_;
 //    for (size_t p = 0; p < aptei_idx_; ++p) {
@@ -490,6 +494,8 @@ ForteIntegrals::dipole_ints_mo_helper(std::shared_ptr<psi::Matrix>, psi::SharedV
 
     return MOdipole_ints;
 }
+
+void ForteIntegrals::build_quadrupole_ints_ao() { _undefined_function("build_quadrupole_ints_ao"); }
 
 void ForteIntegrals::rotate_orbitals(std::shared_ptr<psi::Matrix> Ua,
                                      std::shared_ptr<psi::Matrix> Ub) {

--- a/src/integrals/integrals.h
+++ b/src/integrals/integrals.h
@@ -363,6 +363,10 @@ class ForteIntegrals {
     /// Each direction is a std::shared_ptr<psi::Matrix> of dimension nmo * nmo
     std::vector<std::shared_ptr<psi::Matrix>> ao_dipole_ints() const;
 
+    /// Obtain AO dipole integrals [XX, XY, XZ, YY, YZ, ZZ]
+    /// Each direction is a std::shared_ptr<psi::Matrix> of dimension nmo * nmo
+    std::vector<std::shared_ptr<psi::Matrix>> ao_quadrupole_ints() const;
+
     /**
      * Compute MO dipole integrals
      * @param alpha if true, compute MO dipole using Ca, else Cb
@@ -498,6 +502,11 @@ class ForteIntegrals {
     dipole_ints_mo_helper(std::shared_ptr<psi::Matrix> Cao, std::shared_ptr<psi::Vector> epsilon,
                           const bool& resort);
 
+    /// AO quadrupole integrals
+    std::vector<std::shared_ptr<psi::Matrix>> quadrupole_ints_ao_;
+    /// Compute AO quadrupole integrals
+    virtual void build_quadrupole_ints_ao();
+
     // ==> Class private functions <==
 
     /// Class initializer
@@ -582,6 +591,8 @@ class Psi4Integrals : public ForteIntegrals {
     std::vector<std::shared_ptr<psi::Matrix>>
     dipole_ints_mo_helper(std::shared_ptr<psi::Matrix> Cao, std::shared_ptr<psi::Vector> epsilon,
                           const bool& resort) override;
+
+    void build_quadrupole_ints_ao() override;
 
     /// Make a shared pointer to a Psi4 JK object
     void make_psi4_JK();

--- a/src/integrals/integrals_psi4_interface.cc
+++ b/src/integrals/integrals_psi4_interface.cc
@@ -71,6 +71,7 @@ Psi4Integrals::Psi4Integrals(std::shared_ptr<ForteOptions> options,
 void Psi4Integrals::base_initialize_psi4() {
     setup_psi4_ints();
     build_dipole_ints_ao();
+    build_quadrupole_ints_ao();
 
     if (not skip_build_) {
         transform_one_electron_integrals();
@@ -390,6 +391,20 @@ std::vector<std::shared_ptr<psi::Matrix>> Psi4Integrals::mo_dipole_ints(const bo
     } else {
         return dipole_ints_mo_helper(wfn_->Cb_subset("AO"), wfn_->epsilon_b(), resort);
     }
+}
+
+void Psi4Integrals::build_quadrupole_ints_ao() {
+    std::shared_ptr<psi::BasisSet> basisset = wfn_->basisset();
+    std::shared_ptr<IntegralFactory> ints_fac = std::make_shared<IntegralFactory>(basisset);
+    int nbf = basisset->nbf();
+
+    quadrupole_ints_ao_.clear();
+    for (const std::string& direction : {"XX", "XY", "XZ", "YY", "YZ", "ZZ"}) {
+        std::string name = "AO Quadrupole " + direction;
+        quadrupole_ints_ao_.push_back(std::make_shared<psi::Matrix>(name, nbf, nbf));
+    }
+    std::shared_ptr<OneBodyAOInt> aoqOBI(ints_fac->ao_quadrupole());
+    aoqOBI->compute(quadrupole_ints_ao_);
 }
 
 std::vector<std::shared_ptr<psi::Matrix>>

--- a/src/mrdsrg-spin-integrated/dwms_mrpt2.h
+++ b/src/mrdsrg-spin-integrated/dwms_mrpt2.h
@@ -150,7 +150,7 @@ class DWMS_DSRGPT2 {
     bool eri_df_;
 
     /// a shared_ptr of ActiveSpaceIntegrals (mostly used in CI_RDMS)
-    std::shared_ptr<ActiveSpaceIntegrals> fci_ints_;
+    std::shared_ptr<ActiveSpaceIntegrals> as_ints_;
 
     /// energy of original CASCI
     std::vector<std::vector<double>> Eref_0_;

--- a/src/sci/fci_mo.cc
+++ b/src/sci/fci_mo.cc
@@ -41,6 +41,7 @@
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/integral.h"
 #include "psi4/libmints/basisset.h"
+#include "psi4/libmints/mintshelper.h"
 #include "psi4/libpsio/psio.hpp"
 
 #include "base_classes/forte_options.h"
@@ -974,6 +975,43 @@ void FCI_MO::compute_permanent_dipole() {
         evecs->set_column(0, i, (eigen_[i]).first);
     }
 
+    // MintsHelper
+    MintsHelper mints(ints_->wfn());
+    auto so_angular_momentum = mints.so_angular_momentum();
+    std::vector<SharedMatrix> mo_angular_momentum;
+    std::vector<SharedMatrix> mo_L_squared;
+    for (int i = 0; i < 3; ++i) {
+        auto T = linalg::triplet(ints_->Ca(), so_angular_momentum[i], ints_->Ca(), true, false, false);
+        T->set_name("MO Angular Momentum " + std::to_string(i));
+        T->print();
+        mo_angular_momentum.push_back(T);
+        auto X = linalg::doublet(T, T, false, true);
+        X->set_name("MO L^2 " + std::to_string(i));
+        X->print();
+        mo_L_squared.push_back(X);
+    }
+
+    auto so_dipole = mints.so_dipole();
+    auto so_quadruple = mints.so_quadrupole();
+    auto T = linalg::triplet(so_dipole[0], ints_->wfn()->S(), so_dipole[0], false, false, false);
+    auto X = linalg::triplet(ints_->Ca(), T, ints_->Ca(), true, false, false);
+    X->print();
+    T = linalg::triplet(ints_->Ca(), so_quadruple[0], ints_->Ca(), true, false, false);
+    T->print();
+
+    // compute AO quadrupole integrals
+    std::shared_ptr<psi::BasisSet> basisset = ints_->wfn()->basisset();
+    std::shared_ptr<IntegralFactory> ints = std::shared_ptr<IntegralFactory>(
+        new IntegralFactory(basisset, basisset, basisset, basisset));
+
+    std::vector<psi::SharedMatrix> ao_Qpole;
+    for (const std::string& direction : {"XX", "XY", "XZ", "YY", "YZ", "ZZ"}) {
+        std::string name = "AO Quadrupole" + direction;
+        ao_Qpole.push_back(std::make_shared<psi::Matrix>(name, basisset->nbf(), basisset->nbf()));
+    }
+    std::shared_ptr<OneBodyAOInt> aoqOBI(ints->ao_quadrupole());
+    aoqOBI->compute(ao_Qpole);
+
     // loop over states
     for (size_t A = 0; A < nroot_; ++A) {
         std::string trans_name = std::to_string(A) + " -> " + std::to_string(A);
@@ -983,6 +1021,8 @@ void FCI_MO::compute_permanent_dipole() {
         ci_rdms.compute_1rdm(opdm_a, opdm_b);
 
         psi::SharedMatrix SOdens = reformat_1rdm("SO density " + trans_name, opdm_a, false);
+        auto SOdens_copy = SOdens->clone();
+        SOdens_copy->print();
         SOdens->back_transform(ints_->Ca());
 
         size_t nao = sotoao->coldim(0);
@@ -1001,6 +1041,17 @@ void FCI_MO::compute_permanent_dipole() {
             outfile->Printf("\n  Permanent dipole moments (a.u.) %s:  X: %7.4f  Y: "
                             "%7.4f  Z: %7.4f  Total: %7.4f",
                             trans_name.c_str(), de[0], de[1], de[2], de[3]);
+        }
+
+        outfile->Printf("\n  Root %d", A);
+        for (int i: {0, 3, 5}) {
+            auto temp = 2.0 * AOdens->vector_dot(ao_Qpole[i]);
+            outfile->Printf("\n  Qpole %d: %20.15f", i, temp);
+        }
+
+        for (int i = 0; i < 3; ++i) {
+            auto temp = 2.0 * SOdens_copy->vector_dot(mo_L_squared[i]);
+            outfile->Printf("\n  L^2 %d: %20.15f", i, temp);
         }
     }
     outfile->Printf("\n");

--- a/src/sci/fci_mo.h
+++ b/src/sci/fci_mo.h
@@ -90,19 +90,6 @@ class FCI_MO : public ActiveSpaceMethod {
         std::shared_ptr<SCFInfo> scf_info, std::shared_ptr<ForteOptions> options,
         std::shared_ptr<ForteIntegrals> ints, std::shared_ptr<MOSpaceInfo> mo_space_info);
 
-    /**
-     * @brief FCI_MO Constructor
-     * @param ref_wfn The reference wavefunction object
-     * @param options PSI4 and FORTE options
-     * @param ints ForteInegrals
-     * @param mo_space_info MOSpaceInfo
-     * @param fci_ints FCIInegrals
-     */
-    [[deprecated("Using a deprecated constructor that does not take state and nroot")]] FCI_MO(
-        std::shared_ptr<SCFInfo> scf_info, std::shared_ptr<ForteOptions> options,
-        std::shared_ptr<ForteIntegrals> ints, std::shared_ptr<MOSpaceInfo> mo_space_info,
-        std::shared_ptr<ActiveSpaceIntegrals> fci_ints);
-
     /// Destructor
     ~FCI_MO();
 
@@ -187,8 +174,8 @@ class FCI_MO : public ActiveSpaceMethod {
     /// Set if safe to read densities from files
     void set_safe_to_read_density_files(bool safe) { safe_to_read_density_files_ = safe; }
 
-    /// Set fci_int_ pointer
-    void set_fci_int(std::shared_ptr<ActiveSpaceIntegrals> fci_ints) { fci_ints_ = fci_ints; }
+    /// Set ActiveSpaceIntegral pointer
+    void set_as_int(std::shared_ptr<ActiveSpaceIntegrals> as_ints) { as_ints_ = as_ints; }
 
     /// Set multiplicity
     void set_multiplicity(int multiplicity) { multi_ = multiplicity; }
@@ -221,8 +208,8 @@ class FCI_MO : public ActiveSpaceMethod {
     /// Set state-averaged eigen values and vectors
     void set_eigens(const std::vector<std::vector<std::pair<psi::SharedVector, double>>>& eigens);
 
-    /// Return fci_int_ pointer
-    std::shared_ptr<ActiveSpaceIntegrals> fci_ints() { return fci_ints_; }
+    /// Return ActiveSpaceIntegral pointer
+    std::shared_ptr<ActiveSpaceIntegrals> as_ints() { return as_ints_; }
 
     /// Return the vector of determinants
     const vecdet& p_space() const { return determinant_; }
@@ -272,9 +259,9 @@ class FCI_MO : public ActiveSpaceMethod {
     void cleanup();
 
     /// Integrals
-    std::shared_ptr<ForteIntegrals> integral_;
+    std::shared_ptr<ActiveSpaceIntegrals> as_ints_;
+    std::shared_ptr<ForteIntegrals> ints_;
     std::string int_type_;
-    std::shared_ptr<ActiveSpaceIntegrals> fci_ints_;
 
     /// Reference Type
     std::string ref_type_;


### PR DESCRIPTION
## Description
Add CI root following in 2-step MCSCF.

The point of this PR is to lock down a particular state along the MCSCF iterations. For example, when computing the d10 singlet S state of Ni atom using the 3d + 4s active space, the singlet S state appears to be the lowest Ag state (in D2h) of CASCI with RHF orbitals. As the d9s1 configuration gains more contribution along the MCSCF iterations, the ground-state singlet Ag becomes the broken-symmetry singlet D state.

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added tests of new features
- [ ] Removed comments in code and input files
- [ ] Documented source code
- [ ] Checked for redundant headers
- [ ] Checked for consistency in the formatting of the output file
- [ ] Documented new features in the manual
- [ ] Ready to go!
