### PR TITLE
Fix Problems of Running Relativistic Computations

### DIFF
--- a/tests/methods/tests.yaml
+++ b/tests/methods/tests.yaml
@@ -333,7 +333,7 @@ gasscf:
    - gasscf-2
    - gasscf-dsrg-mrpt2-1
    - sa-gasscf-3
-#x2c:
-#  medium:
-#   - x2c-1
+x2c:
+  short:
+   - x2c-1
 

--- a/tests/methods/x2c-1/output.ref
+++ b/tests/methods/x2c-1/output.ref
@@ -1,0 +1,568 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.4a2.dev941 
+
+                         Git: Rev {HEAD} ec769e8 
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Wednesday, 02 December 2020 02:40AM
+
+    Process ID: 93629
+    Host:       Yorks-Mac.local
+    PSIDATADIR: /Users/york/src/psi4new/psi4/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+import forte
+
+refscf = -76.07925670423528
+reffci = -76.09203532830179
+
+molecule h2o {
+  O 
+  H 1 0.96
+  H 1 0.96 2 104.5
+}
+
+set {
+  basis cc-pVDZ-DK
+  relativistic X2C
+  basis_relativistic cc-pVDZ-DK
+  scf_type pk
+  reference rhf
+  e_convergence 10
+  d_convergence 10
+  r_convergence 10
+}
+
+set forte {
+  active_space_solver fci
+  restricted_docc [2,0,0,0]
+  active          [2,0,1,3]
+}
+
+E, wfn = energy('scf', return_wfn=True)
+compare_values(refscf, variable("CURRENT ENERGY"),11, "SCF energy")
+
+E, wfn = energy('forte', ref_wfn=wfn, return_wfn=True)
+compare_values(reffci, variable("CURRENT ENERGY"),11, "FCI energy")
+
+--------------------------------------------------------------------------
+
+Scratch directory: /Users/york/scratch/psi4/
+
+*** tstart() called on Yorks-Mac.local
+*** at Wed Dec  2 02:40:25 2020
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ-DK
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   195 file /Users/york/src/psi4new/psi4/share/psi4/basis/cc-pvdz-dk.gbs 
+    atoms 2-3 entry H          line    25 file /Users/york/src/psi4new/psi4/share/psi4/basis/cc-pvdz-dk.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065775570547    15.994914619570
+         H            0.000000000000    -0.759061990794     0.521953018286     1.007825032230
+         H            0.000000000000     0.759061990794     0.521953018286     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =     27.26297  B =     14.51533  C =      9.47217 [cm^-1]
+  Rotational constants: A = 817323.21126  B = 435158.60141  C = 283968.37536 [MHz]
+  Nuclear repulsion =    9.168193296424349
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-10
+  Integral threshold = 0.00e+00
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ-DK
+    Blend: CC-PVDZ-DK
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ-DK
+    Role: DECON
+    Keyword: BASIS_RELATIVISTIC
+    atoms 1   entry O          line   195 file /Users/york/src/psi4new/psi4/share/psi4/basis/cc-pvdz-dk.gbs 
+    atoms 2-3 entry H          line    25 file /Users/york/src/psi4new/psi4/share/psi4/basis/cc-pvdz-dk.gbs 
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        25
+      Number of basis functions:        24
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 90300 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+ OEINTS: Using relativistic (X2C) overlap, kinetic, and potential integrals.
+         ------------------------------------------------------------
+         Spin-Free X2C Integrals at the One-Electron Level (SFX2C-1e)
+                 by Prakash Verma and Francesco A. Evangelista
+         ------------------------------------------------------------
+
+  ==> X2C Options <==
+
+    Computational Basis: CC-PVDZ-DK
+    X2C Basis: CC-PVDZ-DK
+    The X2C Hamiltonian will be computed in the X2C Basis
+
+    The 1-norm of |H_X2C - H_Dirac| is: 0.000000000204
+  Minimum eigenvalue in the overlap matrix is 3.2717529351E-02.
+  Reciprocal condition number of the overlap matrix is 1.0391948152E-02.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        11      11 
+     A2         2       2 
+     B1         4       4 
+     B2         7       7 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.55945551561828   -7.55595e+01   0.00000e+00 
+   @RHF iter   1:   -76.00581504091343   -4.46360e-01   3.04312e-02 DIIS
+   @RHF iter   2:   -76.05945659942705   -5.36416e-02   1.74597e-02 DIIS
+   @RHF iter   3:   -76.07884557339885   -1.93890e-02   1.58845e-03 DIIS
+   @RHF iter   4:   -76.07923602454049   -3.90451e-04   3.66164e-04 DIIS
+   @RHF iter   5:   -76.07925573558327   -1.97110e-05   6.73665e-05 DIIS
+   @RHF iter   6:   -76.07925667706522   -9.41482e-07   1.07371e-05 DIIS
+   @RHF iter   7:   -76.07925670364457   -2.65794e-08   1.52431e-06 DIIS
+   @RHF iter   8:   -76.07925670419982   -5.55247e-10   3.54881e-07 DIIS
+   @RHF iter   9:   -76.07925670423434   -3.45182e-11   5.97247e-08 DIIS
+   @RHF iter  10:   -76.07925670423522   -8.81073e-13   4.93843e-09 DIIS
+   @RHF iter  11:   -76.07925670423519    2.84217e-14   8.63285e-10 DIIS
+   @RHF iter  12:   -76.07925670423519    0.00000e+00   4.95301e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.565769     2A1    -1.336948     1B2    -0.697428  
+       3A1    -0.565955     1B1    -0.492659  
+
+    Virtual:                                                              
+
+       4A1     0.184956     2B2     0.255914     3B2     0.787407  
+       5A1     0.851616     6A1     1.163538     2B1     1.200177  
+       4B2     1.253418     7A1     1.444417     1A2     1.475670  
+       3B1     1.674121     8A1     1.865160     5B2     1.931920  
+       6B2     2.446203     9A1     2.482505     4B1     3.283310  
+       2A2     3.336157    10A1     3.506867    11A1     3.862556  
+       7B2     4.144055  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    1 ]
+
+  @RHF Final Energy:   -76.07925670423519
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1681932964243487
+    One-Electron Energy =                -123.1773831283792759
+    Two-Electron Energy =                  37.9299331277197354
+    Total Energy =                        -76.0792567042351919
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9783
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1701
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.8083     Total:     0.8083
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.0544     Total:     2.0544
+
+
+*** tstop() called on Yorks-Mac.local at Wed Dec  2 02:40:26 2020
+Module time:
+	user time   =       0.27 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       0.27 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+    SCF energy............................................................................PASSED
+
+Scratch directory: /Users/york/scratch/psi4/
+
+  Forte
+  ----------------------------------------------------------------------------
+  A suite of quantum chemistry methods for strongly correlated electrons
+
+    git branch: master - git commit: 392b5e9a
+
+  Developed by:
+    Francesco A. Evangelista, Chenyang Li, Kevin P. Hannon,
+    Jeffrey B. Schriber, Tianyuan Zhang, Chenxi Cai,
+    Nan He, Nicholas Stair, Shuhe Wang, Renke Huang
+  ----------------------------------------------------------------------------
+
+  Size of Determinant class: 256 bits
+  Preparing forte objects from a psi4 Wavefunction object
+  Read options for space RESTRICTED_DOCC
+  Read options for space ACTIVE
+  Read options for space RESTRICTED_DOCC
+
+  ==> MO Space Information <==
+
+  -------------------------------------------------
+                       A1    A2    B1    B2   Sum
+  -------------------------------------------------
+    FROZEN_DOCC         0     0     0     0     0
+    RESTRICTED_DOCC     2     0     0     0     2
+    GAS1                2     0     1     3     6
+    GAS2                0     0     0     0     0
+    GAS3                0     0     0     0     0
+    GAS4                0     0     0     0     0
+    GAS5                0     0     0     0     0
+    GAS6                0     0     0     0     0
+    RESTRICTED_UOCC     7     2     3     4    16
+    FROZEN_UOCC         0     0     0     0     0
+    Total              11     2     4     7    24
+  -------------------------------------------------
+
+  Forte Testing Orbital Orthonormality ...   => Loading Basis Set <=
+
+    Name: CC-PVDZ-DK
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   195 file /Users/york/src/psi4new/psi4/share/psi4/basis/cc-pvdz-dk.gbs 
+    atoms 2-3 entry H          line    25 file /Users/york/src/psi4new/psi4/share/psi4/basis/cc-pvdz-dk.gbs 
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ-DK
+    Role: DECON
+    Keyword: BASIS_RELATIVISTIC
+    atoms 1   entry O          line   195 file /Users/york/src/psi4new/psi4/share/psi4/basis/cc-pvdz-dk.gbs 
+    atoms 2-3 entry H          line    25 file /Users/york/src/psi4new/psi4/share/psi4/basis/cc-pvdz-dk.gbs 
+
+ OEINTS: Using relativistic (X2C) overlap, kinetic, and potential integrals.
+         ------------------------------------------------------------
+         Spin-Free X2C Integrals at the One-Electron Level (SFX2C-1e)
+                 by Prakash Verma and Francesco A. Evangelista
+         ------------------------------------------------------------
+
+  ==> X2C Options <==
+
+    Computational Basis: CC-PVDZ-DK
+    X2C Basis: CC-PVDZ-DK
+    The X2C Hamiltonian will be computed in the X2C Basis
+
+    The 1-norm of |H_X2C - H_Dirac| is: 0.000000000204
+
+  Done checking orbital orthonormality (OK).   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: MINAO_BASIS
+    atoms 1   entry O          line    81 file /Users/york/src/psi4new/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /Users/york/src/psi4new/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+  Forte will use psi4 integrals
+
+  ==> Primary Basis Set Summary <==
+
+  Basis Set: CC-PVDZ-DK
+    Blend: CC-PVDZ-DK
+    Number of shells: 12
+    Number of basis function: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+
+  JK created using conventional PK integrals
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             32
+      Number of atomic orbitals:        25
+      Number of basis functions:        24
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 90300 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              400
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+
+
+  ==> Integral Transformation <==
+
+  Number of molecular orbitals:                         24
+  Number of correlated molecular orbitals:              24
+  Number of frozen occupied orbitals:                    0
+  Number of frozen unoccupied orbitals:                  0
+  Two-electron integral type:                 Conventional
+
+
+  Computing Conventional Integrals	Presorting SO-basis two-electron integrals.
+	Sorting File: SO Ints (nn|nn) nbuckets = 1
+	Transforming the one-electron integrals and constructing Fock matrices
+	Starting first half-transformation.
+	Sorting half-transformed integrals.
+	First half integral transformation complete.
+	Starting second half-transformation.
+	Two-electron integral transformation complete.
+
+  Integral transformation done. 0.01220033 s
+  Reading the two-electron integrals from disk
+  Size of two-electron integrals:   0.007416 GB
+  Timing for conventional integral transformation:            0.034 s.
+  Timing for freezing core and virtual orbitals:              0.000 s.
+  Timing for computing conventional integrals:                0.035 s.
+
+  ==> Summary of Active Space Solver Input <==
+
+    Irrep.  Multi.(2ms)      N
+    --------------------------
+       A1      1  (  0)      1
+    --------------------------
+    N: number of roots
+    ms: spin z component
+    Total number of roots:   1
+    --------------------------
+
+
+  ==> String Lists <==
+
+  Number of alpha electrons     = 3
+  Number of beta electrons      = 3
+  Number of alpha strings       = 20
+  Number of beta strings        = 20
+  Number of alpha strings (N-3) = 1
+  Number of beta strings (N-3)  = 1
+  Timing for strings        =      0.000 s
+  Timing for NN strings     =      0.000 s
+  Timing for VO strings     =      0.000 s
+  Timing for OO strings     =      0.000 s
+  Timing for VVOO strings   =      0.000 s
+  Timing for VOVO strings   =      0.000 s
+  Timing for 1-hole strings =      0.000 s
+  Timing for 2-hole strings =      0.000 s
+  Timing for 3-hole strings =      0.000 s
+  Total timing              =      0.000 s
+
+  ==> FCI Solver <==
+
+    Number of determinants                         104
+    Symmetry                                         0
+    Multiplicity                                     1
+    Number of roots                                  1
+    Target root                                      0
+    Trial vectors per root                          10
+
+  Allocating memory for the Hamiltonian algorithm. Size: 2 x 6 x 6.   Memory: 0.000001 GB
+
+  ==> FCI Initial Guess <==
+
+  ---------------------------------------------
+    Root            Energy     <S^2>   Spin
+  ---------------------------------------------
+      0      -76.081280603816  0.000  singlet
+      1      -75.687068262458  2.000  triplet
+      2      -75.656323293810  0.000  singlet
+      3      -75.500592304492  2.000  triplet
+      4      -75.379315801177  0.000  singlet
+      5      -75.090775953172  2.000  triplet
+      6      -75.073931749258  0.000  singlet
+      7      -74.967970117497  6.000  quintet
+      8      -74.934019897761  0.000  singlet
+      9      -74.915514745501  0.000  singlet
+     10      -74.908646987210  0.000  singlet
+     11      -74.877440691929  2.000  triplet
+     12      -74.828180940928  2.000  triplet
+     13      -74.801183728971  0.000  singlet
+     14      -74.742565391077  2.000  triplet
+     15      -74.731903576292  0.000  singlet
+     16      -74.677960540602  0.000  singlet
+     17      -74.632491515793  0.000  singlet
+     18      -74.563494880478  2.000  triplet
+     19      -74.393773651315  0.000  singlet
+  ---------------------------------------------
+  Timing for initial guess  =      0.001 s
+
+  Projecting out root 1
+  Projecting out root 3
+  Projecting out root 5
+  Projecting out root 7
+  Projecting out root 11
+  Projecting out root 12
+  Projecting out root 14
+  Projecting out root 18
+
+  ==> Diagonalizing Hamiltonian <==
+
+  Energy   convergence: 1.00e-10
+  Residual convergence: 1.00e-10
+  -----------------------------------------------------
+    Iter.      Avg. Energy       Delta_E     Res. Norm
+  -----------------------------------------------------
+      1      -76.081280603816  -7.608e+01  +1.409e-01
+      2      -76.091905069870  -1.062e-02  +1.477e-02
+      3      -76.092033055164  -1.280e-04  +2.169e-03
+      4      -76.092035254851  -2.200e-06  +3.933e-04
+      5      -76.092035325433  -7.058e-08  +7.830e-05
+      6      -76.092035328106  -2.674e-09  +1.993e-05
+      7      -76.092035328295  -1.892e-10  +3.983e-06
+      8      -76.092035328301  -6.025e-12  +7.996e-07
+      9      -76.092035328302  -2.558e-13  +1.181e-07
+     10      -76.092035328302  -1.421e-14  +2.932e-08
+     11      -76.092035328302  +0.000e+00  +7.470e-09
+     12      -76.092035328302  +0.000e+00  +2.207e-09
+     13      -76.092035328302  +1.421e-14  +4.602e-10
+     14      -76.092035328302  +0.000e+00  +1.095e-10
+     15      -76.092035328302  +0.000e+00  +2.445e-11
+  -----------------------------------------------------
+  The Davidson-Liu algorithm converged in 16 iterations.
+
+  ==> Root No. 0 <==
+
+    20 2 200     -0.99599866
+
+    Total Energy:       -76.092035328301648
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy
+    ---------------------------------------------
+       1  (  0)    A1     0      -76.092035328302
+    ---------------------------------------------
+
+  Time to prepare integrals:        0.064 seconds
+  Time to run job          :        0.005 seconds
+  Total                    :        0.005 seconds    FCI energy............................................................................PASSED
+
+    Psi4 stopped on: Wednesday, 02 December 2020 02:40AM
+    Psi4 wall time for execution: 0:00:00.46
+
+*** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
Fix the problem introduced in PR #200 due to testing orbital orthonomality, which calls MintsHelper to build SO overlap integrals.

## User Notes
- [x] Enable test case x2c-1

## Checklist
- [x] Added tests of new features
- [x] Removed comments in code and input files
- [x] Ready to go!
