### PR TITLE
Reset forte options

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -31,24 +31,13 @@
 __version__ = '1.0'
 __author__ = 'Forte Developers'
 
-import sys
-
 # Load Python modules
 from .pymodule import *
-
-from .register_forte_options import *
 
 # Load C++ plugin
 from .forte import *
 
-# Create a ForteOptions object (stores all options)
-forte_options = forte.ForteOptions()
+from .options_helpers import reset_forte_options
 
-# Register options defined in Forte in the forte_options object
-register_forte_options(forte_options)
-
-# If we are running psi4, push the options defined in forte_options to psi
-if 'psi4' in sys.modules:
-    psi_options = psi4.core.get_options()
-    psi_options.set_current_module('FORTE')
-    forte_options.push_options_to_psi4(psi_options)
+# Create a fresh ForteOptions object (stores all options)
+forte_options = reset_forte_options()

--- a/options_helpers.py
+++ b/options_helpers.py
@@ -1,0 +1,19 @@
+import sys
+from .pymodule import *
+
+from .register_forte_options import *
+
+def reset_forte_options():
+    # Create a freash ForteOptions object
+    forte_options = forte.ForteOptions()
+
+    # Register options defined in Forte in the forte_options object
+    register_forte_options(forte_options)
+
+    # If we are running psi4, push the options defined in forte_options to psi
+    if 'psi4' in sys.modules:
+        psi_options = psi4.core.get_options()
+        psi_options.set_current_module('FORTE')  # clean up all Forte module options in Psi4
+        forte_options.push_options_to_psi4(psi_options)
+
+    return forte_options

--- a/options_helpers.py
+++ b/options_helpers.py
@@ -16,7 +16,11 @@ def reset_forte_options():
     # If we are running psi4, push the options defined in forte_options to psi
     if 'psi4' in sys.modules:
         psi_options = psi4.core.get_options()
-        psi_options.set_current_module('FORTE')  # clean up all Forte module options in Psi4
+        psi_options.set_current_module('FORTE')
+        # TODO: need Psi4 functionality to clean up all Forte module options
+        # something like psi_options.clean_options_module('FORTE')
+        # because the function below only calls `add` functions of Psi4 Options,
+        # which doesn't update option values if the option key is already in the map.
         forte_options.push_options_to_psi4(psi_options)
 
     return forte_options

--- a/options_helpers.py
+++ b/options_helpers.py
@@ -4,6 +4,9 @@ from .pymodule import *
 from .register_forte_options import *
 
 def reset_forte_options():
+    """
+    Create a new ForteOptions object, set default values, push to Psi4, and return.
+    """
     # Create a freash ForteOptions object
     forte_options = forte.ForteOptions()
 


### PR DESCRIPTION
## Description
Add a function to reset Forte options. Not sure where this file should live. I tried to put it to utils but that requires py3js installed, which is probably not ideal.

## User Notes
- [x] Reset Forte options in the Python side.

## Checklist
- [ ] Ready to go!
