### PR TITLE
Shorten GAS code in CI_Reference

### DIFF
--- a/src/helpers/helpers.h
+++ b/src/helpers/helpers.h
@@ -163,6 +163,26 @@ void apply_permutation_in_place(std::vector<T>& vec, const std::vector<std::size
 namespace math {
 /// Return the number of combinations of n identical objects
 size_t combinations(size_t n, size_t k);
+
+/// Return the Cartesian product of the input vector<vector<T>>
+/// https://stackoverflow.com/a/17050528/4101036
+template <typename T>
+std::vector<std::vector<T>> cartesian_product(const std::vector<std::vector<T>>& input) {
+    std::vector<std::vector<T>> product{{}};
+
+    for (const auto& vec : input) {
+        std::vector<std::vector<T>> tmp;
+        for (const auto& x : product) {
+            for (const auto& y : vec) {
+                tmp.push_back(x);
+                tmp.back().push_back(y);
+            }
+        }
+        product = std::move(tmp);
+    }
+
+    return product;
+}
 } // namespace math
 
 } // namespace forte

--- a/src/sci/aci.cc
+++ b/src/sci/aci.cc
@@ -951,18 +951,16 @@ void AdaptiveCI::zero_multistate_pt2_energy_correction() {
 }
 
 void AdaptiveCI::print_gas_wfn(DeterminantHashVec& space, psi::SharedMatrix evecs) {
-    std::vector<std::string> gas_electron_name = {"GAS1_A", "GASI_B", "GAS2_A", "GAS2_B",
+    std::vector<std::string> gas_electron_name = {"GAS1_A", "GAS1_B", "GAS2_A", "GAS2_B",
                                                   "GAS3_A", "GAS3_B", "GAS4_A", "GAS4_B",
                                                   "GAS5_A", "GAS5_B", "GAS6_A", "GAS6_B"};
-
-    psi::outfile->Printf("\n  ");
-    psi::outfile->Printf("\n  GAS Contribution Analysis  ");
+    print_h2("GAS Contribution Analysis");
 
     for (int n = 0; n < nroot_; ++n) {
         DeterminantHashVec tmp;
         std::vector<double> tmp_evecs;
 
-        psi::outfile->Printf("\n  GAS contributions root %d: \n", n);
+        psi::outfile->Printf("\n  Root %d:", n);
 
         size_t max_dets = static_cast<size_t>(evecs->nrow());
         tmp.subspace(space, evecs, tmp_evecs, max_dets, n);
@@ -1020,15 +1018,26 @@ void AdaptiveCI::print_gas_wfn(DeterminantHashVec& space, psi::SharedMatrix evec
                 exit(1);
             }
         }
+
+        outfile->Printf("\n    Config.");
+        int ndash = 7;
         for (size_t j = 0; j < 2 * gas_num_; j++) {
-            outfile->Printf("  %s  ", gas_electron_name[j].c_str());
+            std::string name = gas_electron_name[j].substr(3, 3);
+            outfile->Printf("  %s", name.c_str());
+            ndash += 5;
         }
-        outfile->Printf("      Cont  \n");
+        outfile->Printf("  Contribution");
+        ndash += 14;
+        std::string dash(ndash, '-');
+        outfile->Printf("\n    %s", dash.c_str());
+
         std::map<std::vector<size_t>, double> gas_total_amp;
         for (size_t i = 0; i < gas_config_num; i++) {
+            outfile->Printf("\n    %6d ", i + 1);
             for (size_t j = 0; j < 2 * gas_num_; j++) {
-                outfile->Printf("     %d    ", gas_electrons_[i][j]);
+                outfile->Printf(" %4d", gas_electrons_[i][j]);
             }
+
             std::vector<size_t> sum_gas;
             for (size_t j = 0; j < 2 * gas_num_; j += 2) {
                 sum_gas.push_back(gas_electrons_[i][j] + gas_electrons_[i][j + 1]);
@@ -1039,15 +1048,27 @@ void AdaptiveCI::print_gas_wfn(DeterminantHashVec& space, psi::SharedMatrix evec
             } else {
                 gas_total_amp[sum_gas] += gas_amp[i];
             }
-            psi::outfile->Printf("    %.9f  \n", gas_amp[i]);
+
+            outfile->Printf(" %12.8f%%", gas_amp[i] * 100.0);
         }
-        outfile->Printf("\n");
+        outfile->Printf("\n    %s", dash.c_str());
+
+        outfile->Printf("\n    %7c", ' ');
+        for (size_t j = 0; j < gas_num_; j++) {
+            std::string name = "GAS" + std::to_string(j + 1);
+            outfile->Printf("  %6s  ", name.c_str());
+        }
+        outfile->Printf("  Contribution");
+        outfile->Printf("\n    %s", dash.c_str());
+
         for (auto element : gas_total_amp) {
+            outfile->Printf("\n    %7c", ' ');
             for (size_t j = 0; j < gas_num_; j++) {
-                outfile->Printf("           %d       ", element.first[j]);
+                outfile->Printf("  %6d  ", element.first[j]);
             }
-            outfile->Printf("     %.9f  \n", element.second);
+            outfile->Printf(" %12.8f%%", element.second * 100);
         }
+        outfile->Printf("\n    %s", dash.c_str());
     }
 }
 

--- a/src/sparse_ci/ci_reference.cc
+++ b/src/sparse_ci/ci_reference.cc
@@ -694,7 +694,7 @@ void CI_Reference::build_gas_single(std::vector<Determinant>& ref_space) {
                     const auto& occ = gas_occ[gas];
                     for (int p = 0, psize = occ.size(); p < psize; ++p) {
                         if (occ[p]) {
-                            big_string[p] = true;
+                            big_string[rel_gas_mos[gas][p]] = true;
                             e += rel_gas_eps[2 * gas_nonzero_to_full[gas] + shift][p];
                         }
                     }

--- a/src/sparse_ci/ci_reference.cc
+++ b/src/sparse_ci/ci_reference.cc
@@ -32,10 +32,12 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libmints/vector.h"
 
+#include "forte-def.h"
 #include "ci_reference.h"
 #include "base_classes/forte_options.h"
 #include "helpers/helpers.h"
 #include "helpers/printing.h"
+#include "helpers/timer.h"
 
 #include <algorithm>
 
@@ -108,16 +110,39 @@ void CI_Reference::build_reference(std::vector<Determinant>& ref_space) {
         build_cas_reference(ref_space);
     } else if (ref_type_ == "GAS") {
         // Complete GAS
+        print_gas_scf_epsilon();
         get_gas_occupation();
         build_gas_reference(ref_space);
     } else if (ref_type_ == "GAS_SINGLE") {
         // Low(est) energy one in GAS
+        print_gas_scf_epsilon();
         get_gas_occupation();
         build_gas_single(ref_space);
     } else {
         build_ci_reference(ref_space);
         outfile->Printf("\n  Building_reference.", subspace_size_);
     }
+}
+
+void CI_Reference::print_gas_scf_epsilon() {
+    print_h2("GAS Orbital Energies from SCF");
+    outfile->Printf("\n    GAS        Energy  Index");
+    outfile->Printf("\n    ------------------------");
+
+    auto epsilon_a = scf_info_->epsilon_a();
+    for (int gas = 0; gas < 6; ++gas) {
+        std::string space_name = "GAS" + std::to_string(gas + 1);
+        auto abs_mos = mo_space_info_->absolute_mo(space_name);
+        if (abs_mos.size() == 0)
+            continue;
+
+        auto rel_mos = mo_space_info_->pos_in_space(space_name, "ACTIVE");
+        for (size_t i = 0, size = abs_mos.size(); i < size; ++i) {
+            outfile->Printf("\n    %2d %14.8f  %5zu", gas + 1, epsilon_a->get(abs_mos[i]),
+                            rel_mos[i]);
+        }
+    }
+    outfile->Printf("\n    ------------------------");
 }
 
 std::pair<std::map<std::vector<int>, std::vector<std::pair<size_t, size_t>>>,
@@ -525,33 +550,27 @@ CI_Reference::build_gas_occ_string(const std::vector<std::vector<std::vector<boo
         throw psi::PSIEXCEPTION("Inconsistent numbers of gas spaces");
 
     // compute the cartesian product of strings
+    /* For example (see Python itertools product):
+     * input:  [[gas1_occ1, gas1_occ2, gas1_occ3, ...], [gas2_occ1, gas2_occ2, ...], ...]
+     * output: [[gas1_occ1, gas2_occ1, ...], [gas1_occ1, gas2_occ2, ...],
+     *          [gas1_occ2, gas2_occ1, ...], [gas1_occ2, gas2_occ2, ...],
+     *          [gas1_occ3, gas2_occ1, ...], [gas1_occ3, gas2_occ2, ...], ...]
+     */
     auto product = math::cartesian_product(gas_strings);
-    outfile->Printf("\nGAS strings");
-    for (const auto& x : gas_strings) {
-        for (const auto& y : x) {
-            outfile->Printf("\n");
-            for (bool i:y) {
-                outfile->Printf("%d", i);
-            }
-        }
-    }
-    outfile->Printf("\nGAS string product");
-    for (const auto& x : product) {
-        for (const auto& y : x) {
-            outfile->Printf("\n");
-            for (bool i:y) {
-                outfile->Printf("%d", i);
-            }
-        }
-    }
 
     auto n_strings = product.size();
     std::vector<std::vector<bool>> out(n_strings);
-    outfile->Printf("\n  nproduct = %zu", n_strings);
+    if (n_strings == 0)
+        return out;
 
-    // combine gas strings to a string of size nactv_orbs
-#pragma omp parallel for
+    size_t n_threads = omp_get_num_threads();
+    if (n_threads > n_strings)
+        n_threads = n_strings;
+
+        // combine gas strings to a string of size nactv_orbs
+#pragma omp parallel for num_threads(n_threads)
     for (size_t n = 0; n < n_strings; ++n) {
+
         const auto& strings = product[n];
         std::vector<bool> s(nact_, false);
 
@@ -560,17 +579,11 @@ CI_Reference::build_gas_occ_string(const std::vector<std::vector<std::vector<boo
             const auto& string = strings[g];
             for (int p = 0, psize = string.size(); p < psize; ++p) {
                 if (string[p]) {
-                    outfile->Printf("\n  g = %d, p = %d, rel[p] = %zu", g, p, rel[p]);
                     s[rel[p]] = true;
                 }
             }
         }
-
         out[n] = s;
-        outfile->Printf("\n");
-        for (bool i : s) {
-            outfile->Printf("%d", i);
-        }
     }
 
     return out;
@@ -910,33 +923,24 @@ void CI_Reference::build_gas_single(std::vector<Determinant>& ref_space) {
 }
 
 void CI_Reference::build_gas_reference(std::vector<Determinant>& ref_space) {
+    ref_space.clear();
+
     // relative indices within the active orbitals
     std::vector<std::vector<size_t>> rel_gas_mos;
 
-    // print GAS orbital energies
-    print_h2("GAS Orbital Energies from SCF");
-    outfile->Printf("\n    GAS        Energy  Index");
-    outfile->Printf("\n    ------------------------");
-
-    auto epsilon_a = scf_info_->epsilon_a();
     for (int gas = 0; gas < 6; ++gas) {
         std::string space_name = "GAS" + std::to_string(gas + 1);
         auto abs_mos = mo_space_info_->absolute_mo(space_name);
         if (abs_mos.size() == 0)
             continue;
-
-        auto rel_mos = mo_space_info_->pos_in_space(space_name, "ACTIVE");
-        for (size_t i = 0, size = abs_mos.size(); i < size; ++i) {
-            outfile->Printf("\n    %2d %14.8f  %5zu", gas, epsilon_a->get(abs_mos[i]), rel_mos[i]);
-        }
-
-        rel_gas_mos.push_back(rel_mos);
+        rel_gas_mos.push_back(mo_space_info_->pos_in_space(space_name, "ACTIVE"));
     }
-    outfile->Printf("\n    ------------------------");
 
-    int ngas = rel_gas_mos.size(); // number of nonzero size GAS
+    int ngas = rel_gas_mos.size(); // number of nonzero-sized GAS
 
     // figure out symmetry product
+    // e.g., [[gas1_h1, gas1_h2], [gas2_h1, gas2_h2]] ->
+    // [[gas1_h1, gas2_h1], [gas1_h1, gas2_h2], [gas1_h2, gas2_h1], [gas1_h2, gas2_h2]]
     std::vector<std::vector<int>> irrep_pools(ngas);
     for (int i = 0; i < ngas; ++i) {
         std::vector<int> irrep(nirrep_);
@@ -946,7 +950,8 @@ void CI_Reference::build_gas_reference(std::vector<Determinant>& ref_space) {
     auto sym_product = math::cartesian_product(irrep_pools);
 
     // loop over all GAS configurations
-    size_t ndets = 0;
+    timer timer_gas("Build GAS determinants");
+    print_h2("Building GAS Determinants");
     for (size_t config = 0, size = gas_electrons_.size(); config < size; ++config) {
 
         // build alpha or beta strings (ngas of nirrep of vector of occupation)
@@ -962,25 +967,6 @@ void CI_Reference::build_gas_reference(std::vector<Determinant>& ref_space) {
 
             a_tmp.emplace_back(build_occ_string(norb, gas_electrons_[config][2 * gas], sym));
             b_tmp.emplace_back(build_occ_string(norb, gas_electrons_[config][2 * gas + 1], sym));
-            outfile->Printf("\n  GAS %d, na = %d, nb = %d", gas + 1, gas_electrons_[config][2 * gas], gas_electrons_[config][2 * gas + 1]);
-        }
-
-        for (int g = 0; g < ngas; ++ g) {
-            outfile->Printf("\n  GAS %d", g + 1);
-            for (int h = 0; h < nirrep_; ++h) {
-                outfile->Printf("\n  Alpha h = %d", h);
-                for (const auto& occ: a_tmp[g][h]) {
-                    outfile->Printf("\n  ");
-                    for (bool i : occ)
-                        outfile->Printf("%d", i);
-                }
-                outfile->Printf("\n  Beta h = %d", h);
-                for (const auto& occ: b_tmp[g][h]) {
-                    outfile->Printf("\n  ");
-                    for (bool i : occ)
-                        outfile->Printf("%d", i);
-                }
-            }
         }
 
         // alpha and beta strings (nirrep of vector of occupations)
@@ -1000,344 +986,32 @@ void CI_Reference::build_gas_reference(std::vector<Determinant>& ref_space) {
 
             // alpha
             auto strings_irrep = build_gas_occ_string(a, rel_gas_mos);
-            std::move(strings_irrep.begin(), strings_irrep.end(), std::back_inserter(a_strings[irrep]));
+            std::move(strings_irrep.begin(), strings_irrep.end(),
+                      std::back_inserter(a_strings[irrep]));
 
             // beta
             strings_irrep = build_gas_occ_string(b, rel_gas_mos);
-            std::move(strings_irrep.begin(), strings_irrep.end(), std::back_inserter(b_strings[irrep]));
-        }
-
-        outfile->Printf("\n  Alpha strings");
-        for (int h = 0; h < nirrep_; ++h) {
-            outfile->Printf("\n  Irrep = %d", h);
-            for (const auto& occ: a_strings[h]) {
-                outfile->Printf("\n  ");
-                for (bool i: occ) {
-                    outfile->Printf("%d", i);
-                }
-            }
+            std::move(strings_irrep.begin(), strings_irrep.end(),
+                      std::back_inserter(b_strings[irrep]));
         }
 
         // combine alpha and beta strings to form determinant
-        size_t n = 0;
         for (int ha = 0; ha < nirrep_; ++ha) {
             int hb = root_sym_ ^ ha;
             for (const auto& a : a_strings[ha]) {
-                for (const auto& b: b_strings[hb]) {
-                    Determinant det(a, b);
-                    outfile->Printf("\n  %s", str(det, nact_).c_str());
-                    n++;
-                }
-            }
-        }
-        ndets += n;
-        outfile->Printf("\n  Size of space: %zu", n);
-    }
-    outfile->Printf("\n  Size of final space: %zu", ndets);
-
-    // Build the entire GAS space
-
-    // The relative_mo of each GAS, without sorting the energy
-
-    //    std::shared_ptr<Vector> epsilon_a = scf_info_->epsilon_a();
-    outfile->Printf("\n");
-    outfile->Printf("\n  GAS Orbital Energies");
-    outfile->Printf("\n  GAS   Energies    Orb ");
-
-    std::vector<std::vector<size_t>> relative_gas_mo;
-    std::vector<size_t> act_mo = mo_space_info_->absolute_mo("ACTIVE");
-    std::map<int, int> re_ab_mo;
-    for (size_t i = 0; i < act_mo.size(); i++) {
-        re_ab_mo[act_mo[i]] = i;
-    }
-    for (size_t gas_count = 0; gas_count < 6; gas_count++) {
-        std::string space = "GAS" + std::to_string(gas_count + 1);
-        std::vector<size_t> relative_mo;
-        auto vec_mo_info = mo_space_info_->absolute_mo(space);
-        for (size_t i = 0, maxi = vec_mo_info.size(); i < maxi; ++i) {
-            size_t orb = vec_mo_info[i];
-            relative_mo.push_back(re_ab_mo[orb]);
-            outfile->Printf("\n  %d  %12.9f  %d ", gas_count + 1, epsilon_a->get(orb),
-                            re_ab_mo[orb]);
-        }
-        relative_gas_mo.push_back(relative_mo);
-    }
-
-    // iterate over all possible gas occupations
-    for (size_t i_config = 0; i_config < gas_electrons_.size(); ++i_config) {
-        size_t gas1_na = gas_electrons_[i_config][0];
-        size_t gas1_nb = gas_electrons_[i_config][1];
-        size_t gas2_na = gas_electrons_[i_config][2];
-        size_t gas2_nb = gas_electrons_[i_config][3];
-        size_t gas3_na = gas_electrons_[i_config][4];
-        size_t gas3_nb = gas_electrons_[i_config][5];
-        size_t gas4_na = gas_electrons_[i_config][6];
-        size_t gas4_nb = gas_electrons_[i_config][7];
-        size_t gas5_na = gas_electrons_[i_config][8];
-        size_t gas5_nb = gas_electrons_[i_config][9];
-        size_t gas6_na = gas_electrons_[i_config][10];
-        size_t gas6_nb = gas_electrons_[i_config][11];
-        size_t gas1_size = relative_gas_mo[0].size();
-        size_t gas2_size = relative_gas_mo[1].size();
-        size_t gas3_size = relative_gas_mo[2].size();
-        size_t gas4_size = relative_gas_mo[3].size();
-        size_t gas5_size = relative_gas_mo[4].size();
-        size_t gas6_size = relative_gas_mo[5].size();
-
-        // create the occupation of orbitals
-        std::vector<bool> tmp_det_gas1_a(gas1_size, false);
-        std::vector<bool> tmp_det_gas1_b(gas1_size, false);
-        std::vector<bool> tmp_det_gas2_a(gas2_size, false);
-        std::vector<bool> tmp_det_gas2_b(gas2_size, false);
-        std::vector<bool> tmp_det_gas3_a(gas3_size, false);
-        std::vector<bool> tmp_det_gas3_b(gas3_size, false);
-        std::vector<bool> tmp_det_gas4_a(gas4_size, false);
-        std::vector<bool> tmp_det_gas4_b(gas4_size, false);
-        std::vector<bool> tmp_det_gas5_a(gas5_size, false);
-        std::vector<bool> tmp_det_gas5_b(gas5_size, false);
-        std::vector<bool> tmp_det_gas6_a(gas6_size, false);
-        std::vector<bool> tmp_det_gas6_b(gas6_size, false);
-
-        if (gas1_size > 0) {
-            for (size_t i = 0; i < gas1_na; ++i) {
-                tmp_det_gas1_a[i] = true;
-            }
-            for (size_t i = 0; i < gas1_nb; ++i) {
-                tmp_det_gas1_b[i] = true;
-            }
-        }
-        if (gas2_size > 0) {
-            for (size_t i = 0; i < gas2_na; ++i) {
-                tmp_det_gas2_a[i] = true;
-            }
-            for (size_t i = 0; i < gas2_nb; ++i) {
-                tmp_det_gas2_b[i] = true;
-            }
-        }
-        if (gas3_size > 0) {
-            for (size_t i = 0; i < gas3_na; ++i) {
-                tmp_det_gas3_a[i] = true;
-            }
-            for (size_t i = 0; i < gas3_nb; ++i) {
-                tmp_det_gas3_b[i] = true;
-            }
-        }
-        if (gas4_size > 0) {
-            for (size_t i = 0; i < gas4_na; ++i) {
-                tmp_det_gas4_a[i] = true;
-            }
-            for (size_t i = 0; i < gas4_nb; ++i) {
-                tmp_det_gas4_b[i] = true;
-            }
-        }
-        if (gas5_size > 0) {
-            for (size_t i = 0; i < gas5_na; ++i) {
-                tmp_det_gas5_a[i] = true;
-            }
-            for (size_t i = 0; i < gas5_nb; ++i) {
-                tmp_det_gas5_b[i] = true;
-            }
-        }
-        if (gas6_size > 0) {
-            for (size_t i = 0; i < gas6_na; ++i) {
-                tmp_det_gas6_a[i] = true;
-            }
-            for (size_t i = 0; i < gas6_nb; ++i) {
-                tmp_det_gas6_b[i] = true;
-            }
-        }
-
-        // Sort
-        std::sort(begin(tmp_det_gas1_a), end(tmp_det_gas1_a));
-        std::sort(begin(tmp_det_gas1_b), end(tmp_det_gas1_b));
-        std::sort(begin(tmp_det_gas2_a), end(tmp_det_gas2_a));
-        std::sort(begin(tmp_det_gas2_b), end(tmp_det_gas2_b));
-        std::sort(begin(tmp_det_gas3_a), end(tmp_det_gas3_a));
-        std::sort(begin(tmp_det_gas3_b), end(tmp_det_gas3_b));
-        std::sort(begin(tmp_det_gas4_a), end(tmp_det_gas4_a));
-        std::sort(begin(tmp_det_gas4_b), end(tmp_det_gas4_b));
-        std::sort(begin(tmp_det_gas5_a), end(tmp_det_gas5_a));
-        std::sort(begin(tmp_det_gas5_b), end(tmp_det_gas5_b));
-        std::sort(begin(tmp_det_gas6_a), end(tmp_det_gas6_a));
-        std::sort(begin(tmp_det_gas6_b), end(tmp_det_gas6_b));
-
-        // Save all permutations
-        std::vector<std::vector<bool>> alldet_gas1_a;
-        std::vector<std::vector<bool>> alldet_gas1_b;
-        std::vector<std::vector<bool>> alldet_gas2_a;
-        std::vector<std::vector<bool>> alldet_gas2_b;
-        std::vector<std::vector<bool>> alldet_gas3_a;
-        std::vector<std::vector<bool>> alldet_gas3_b;
-        std::vector<std::vector<bool>> alldet_gas4_a;
-        std::vector<std::vector<bool>> alldet_gas4_b;
-        std::vector<std::vector<bool>> alldet_gas5_a;
-        std::vector<std::vector<bool>> alldet_gas5_b;
-        std::vector<std::vector<bool>> alldet_gas6_a;
-        std::vector<std::vector<bool>> alldet_gas6_b;
-
-        do {
-            alldet_gas1_a.push_back(tmp_det_gas1_a);
-        } while (std::next_permutation(tmp_det_gas1_a.begin(), tmp_det_gas1_a.begin() + gas1_size));
-        do {
-            alldet_gas1_b.push_back(tmp_det_gas1_b);
-        } while (std::next_permutation(tmp_det_gas1_b.begin(), tmp_det_gas1_b.begin() + gas1_size));
-        do {
-            alldet_gas2_a.push_back(tmp_det_gas2_a);
-        } while (std::next_permutation(tmp_det_gas2_a.begin(), tmp_det_gas2_a.begin() + gas2_size));
-        do {
-            alldet_gas2_b.push_back(tmp_det_gas2_b);
-        } while (std::next_permutation(tmp_det_gas2_b.begin(), tmp_det_gas2_b.begin() + gas2_size));
-        do {
-            alldet_gas3_a.push_back(tmp_det_gas3_a);
-        } while (std::next_permutation(tmp_det_gas3_a.begin(), tmp_det_gas3_a.begin() + gas3_size));
-        do {
-            alldet_gas3_b.push_back(tmp_det_gas3_b);
-        } while (std::next_permutation(tmp_det_gas3_b.begin(), tmp_det_gas3_b.begin() + gas3_size));
-        do {
-            alldet_gas4_a.push_back(tmp_det_gas4_a);
-        } while (std::next_permutation(tmp_det_gas4_a.begin(), tmp_det_gas4_a.begin() + gas4_size));
-        do {
-            alldet_gas4_b.push_back(tmp_det_gas4_b);
-        } while (std::next_permutation(tmp_det_gas4_b.begin(), tmp_det_gas4_b.begin() + gas4_size));
-        do {
-            alldet_gas5_a.push_back(tmp_det_gas5_a);
-        } while (std::next_permutation(tmp_det_gas5_a.begin(), tmp_det_gas5_a.begin() + gas5_size));
-        do {
-            alldet_gas5_b.push_back(tmp_det_gas5_b);
-        } while (std::next_permutation(tmp_det_gas5_b.begin(), tmp_det_gas5_b.begin() + gas5_size));
-        do {
-            alldet_gas6_a.push_back(tmp_det_gas6_a);
-        } while (std::next_permutation(tmp_det_gas6_a.begin(), tmp_det_gas6_a.begin() + gas6_size));
-        do {
-            alldet_gas6_b.push_back(tmp_det_gas6_b);
-        } while (std::next_permutation(tmp_det_gas6_b.begin(), tmp_det_gas6_b.begin() + gas6_size));
-
-        // Permutation of all the orbitals
-        for (const auto& det_gas1_a : alldet_gas1_a) {
-            for (const auto& det_gas1_b : alldet_gas1_b) {
-                for (const auto& det_gas2_a : alldet_gas2_a) {
-                    for (const auto& det_gas2_b : alldet_gas2_b) {
-                        for (const auto& det_gas3_a : alldet_gas3_a) {
-                            for (const auto& det_gas3_b : alldet_gas3_b) {
-                                for (const auto& det_gas4_a : alldet_gas4_a) {
-                                    for (const auto& det_gas4_b : alldet_gas4_b) {
-                                        for (const auto& det_gas5_a : alldet_gas5_a) {
-                                            for (const auto& det_gas5_b : alldet_gas5_b) {
-                                                for (const auto& det_gas6_a : alldet_gas6_a) {
-                                                    for (const auto& det_gas6_b : alldet_gas6_b) {
-                                                        // Build determinant
-                                                        // outfile->Printf(
-                                                        //   "\n Possible
-                                                        //   Configurations");
-                                                        Determinant det;
-                                                        int sym = 0;
-                                                        for (size_t p = 0; p < gas1_size; ++p) {
-                                                            det.set_alfa_bit(relative_gas_mo[0][p],
-                                                                             det_gas1_a[p]);
-                                                            det.set_beta_bit(relative_gas_mo[0][p],
-                                                                             det_gas1_b[p]);
-                                                            if (det_gas1_a[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[0][p]];
-                                                            }
-                                                            if (det_gas1_b[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[0][p]];
-                                                            }
-                                                        }
-                                                        for (size_t p = 0; p < gas2_size; ++p) {
-                                                            det.set_alfa_bit(relative_gas_mo[1][p],
-                                                                             det_gas2_a[p]);
-                                                            det.set_beta_bit(relative_gas_mo[1][p],
-                                                                             det_gas2_b[p]);
-                                                            if (det_gas2_a[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[1][p]];
-                                                            }
-                                                            if (det_gas2_b[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[1][p]];
-                                                            }
-                                                        }
-                                                        for (size_t p = 0; p < gas3_size; ++p) {
-                                                            det.set_alfa_bit(relative_gas_mo[2][p],
-                                                                             det_gas3_a[p]);
-                                                            det.set_beta_bit(relative_gas_mo[2][p],
-                                                                             det_gas3_b[p]);
-                                                            if (det_gas3_a[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[2][p]];
-                                                            }
-                                                            if (det_gas3_b[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[2][p]];
-                                                            }
-                                                        }
-                                                        for (size_t p = 0; p < gas4_size; ++p) {
-                                                            det.set_alfa_bit(relative_gas_mo[3][p],
-                                                                             det_gas4_a[p]);
-                                                            det.set_beta_bit(relative_gas_mo[3][p],
-                                                                             det_gas4_b[p]);
-                                                            if (det_gas4_a[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[3][p]];
-                                                            }
-                                                            if (det_gas4_b[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[3][p]];
-                                                            }
-                                                        }
-                                                        for (size_t p = 0; p < gas5_size; ++p) {
-                                                            det.set_alfa_bit(relative_gas_mo[4][p],
-                                                                             det_gas5_a[p]);
-                                                            det.set_beta_bit(relative_gas_mo[4][p],
-                                                                             det_gas5_b[p]);
-                                                            if (det_gas5_a[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[4][p]];
-                                                            }
-                                                            if (det_gas5_b[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[4][p]];
-                                                            }
-                                                        }
-                                                        for (size_t p = 0; p < gas6_size; ++p) {
-                                                            det.set_alfa_bit(relative_gas_mo[5][p],
-                                                                             det_gas6_a[p]);
-                                                            det.set_beta_bit(relative_gas_mo[5][p],
-                                                                             det_gas6_b[p]);
-                                                            if (det_gas6_a[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[5][p]];
-                                                            }
-                                                            if (det_gas6_b[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[5][p]];
-                                                            }
-                                                        }
-                                                        int nunpair =
-                                                            nalpha_ + nbeta_ - 2 * det.npair();
-                                                        // Check symmetry and multiplicity
-                                                        if (sym == root_sym_) {
-                                                            //                                                            outfile->Printf(
-                                                            //                                                                "\n  Ref: %s",
-                                                            //                                                                str(det, nact_).c_str());
-                                                            ref_space.push_back(det);
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                for (const auto& b : b_strings[hb]) {
+                    ref_space.emplace_back(a, b);
                 }
             }
         }
     }
-    //  outfile->Printf("\n ref size: %zu", ref_space.size());
+    timer_gas.stop();
+
+    outfile->Printf("\n  Size of GAS reference: %zu", ref_space.size());
+    print_h2("GAS Determinants");
+    for (const auto& det : ref_space) {
+        outfile->Printf("\n    %s", str(det, nact_).c_str());
+    }
 }
 
 std::vector<std::tuple<double, int, int>> CI_Reference::sym_labeled_orbitals(std::string type) {

--- a/src/sparse_ci/ci_reference.cc
+++ b/src/sparse_ci/ci_reference.cc
@@ -591,337 +591,558 @@ CI_Reference::build_gas_occ_string(const std::vector<std::vector<std::vector<boo
 }
 
 void CI_Reference::build_gas_single(std::vector<Determinant>& ref_space) {
+    // build the determinant from aufbau principle
+    ref_space.clear();
 
-    // build one single low energy determinant in the gas space
+    //    // sort symmetry of active orbitals according to orbital energies
+    //    auto symmetry = mo_space_info_->symmetry("ACTIVE");
 
-    std::shared_ptr<Vector> epsilon_a = scf_info_->epsilon_a();
+    //    // build aufbau determinant on-the-fly and test if it belongs to GAS
+    //    std::vector<bool> a_occ_tmp(nact_, false);
+    //    std::vector<bool> b_occ_tmp(nact_, false);
+    //    for (int i = nact_ - nalpha_; i < nact_; ++i)
+    //        a_occ_tmp[i] = true;
+    //    for (int i = nact_ - nbeta_; i < nact_; ++i)
+    //        b_occ_tmp[i] = true;
 
-    // relative_mo of each GAS
-    // Sort the aboslute_mo in the increasing order of energy for each GAS
-    std::vector<std::vector<size_t>> relative_gas_mo;
-    size_t total_act = 0;
-    outfile->Printf("\n");
-    outfile->Printf("\n  GAS Orbital Energies");
-    outfile->Printf("\n  GAS   Energies    Orb ");
-    std::vector<size_t> act_mo = mo_space_info_->absolute_mo("ACTIVE");
-    std::map<int, int> re_ab_mo;
-    for (size_t i = 0; i < act_mo.size(); i++) {
-        re_ab_mo[act_mo[i]] = i;
+    //    bool found = false;
+
+    //    do {
+    //        int a_sym = 0;
+    //        for (int p = 0; p < nact_; ++p) {
+    //            if (a_occ_tmp[p])
+    //                a_sym ^= symmetry[p]; // wrong
+    //        }
+
+    //        // tell me gas n and nele for alpha
+
+    //        do {
+    //            int b_sym = 0;
+    //            for (int p = 0; p < nact_; ++p) {
+    //                if (b_occ_tmp[p])
+    //                    b_sym ^= symmetry[p]; // wrong
+    //            }
+
+    //            if (b_sym != (root_sym_ ^ a_sym))
+    //                continue;
+
+    //            // tell me gas n and nele for beta
+
+    //            // test if this lies in gas configurations
+    //            // if so, stop: found = true;
+    //            // if not: go to the next one.
+    //        } while (std::next_permutation(b_occ_tmp.begin(), b_occ_tmp.begin() + nact_));
+    //    } while (std::next_permutation(a_occ_tmp.begin(), a_occ_tmp.begin() + nact_));
+
+    std::vector<std::vector<size_t>> rel_gas_mos;     // relative indices within active
+    std::vector<std::vector<double>> rel_gas_eps(12); // ngas of SCF orbital energies
+    std::map<int, int> gas_nonzero_to_full;
+    auto epsilon_a = scf_info_->epsilon_a();
+    auto epsilon_b = scf_info_->epsilon_b();
+
+    for (int gas = 0, gas_i = 0; gas < 6; ++gas) {
+        std::string space_name = "GAS" + std::to_string(gas + 1);
+        auto abs_mos = mo_space_info_->absolute_mo(space_name);
+
+        auto norbs = abs_mos.size();
+
+        std::vector<double> a_eps(norbs), b_eps(norbs);
+        for (size_t i = 0; i < norbs; ++i) {
+            a_eps[i] = epsilon_a->get(abs_mos[i]);
+            b_eps[i] = epsilon_b->get(abs_mos[i]);
+        }
+        rel_gas_eps[2 * gas] = a_eps;
+        rel_gas_eps[2 * gas + 1] = b_eps;
+
+        if (norbs == 0)
+            continue;
+
+        rel_gas_mos.push_back(mo_space_info_->pos_in_space(space_name, "ACTIVE"));
+
+        gas_nonzero_to_full[gas_i] = gas;
+        gas_i += 1;
     }
-    for (size_t gas_count = 0; gas_count < 6; gas_count++) {
-        const std::string space = "GAS" + std::to_string(gas_count + 1);
-        ;
-        std::vector<size_t> relative_mo_sorted;
-        auto vec_mo_info = mo_space_info_->absolute_mo(space);
-        std::vector<std::pair<double, int>> gas_orb_e;
-        for (size_t i = 0; i < vec_mo_info.size(); ++i) {
-            auto orb = vec_mo_info[i];
-            gas_orb_e.push_back(std::make_pair(epsilon_a->get(orb), re_ab_mo[orb]));
-        }
-        total_act += gas_orb_e.size();
-        std::sort(gas_orb_e.begin(), gas_orb_e.end());
 
-        for (size_t i = 0; i < gas_orb_e.size(); i++) {
-            auto act_orb = gas_orb_e[i].second;
-            relative_mo_sorted.push_back(act_orb);
-            outfile->Printf("\n   %d  %12.9f  %d ", gas_count + 1, gas_orb_e[i].first, act_orb);
-        }
-        relative_gas_mo.push_back(relative_mo_sorted);
+    int ngas = rel_gas_mos.size(); // number of nonzero-sized GAS
+
+    // figure out symmetry product
+    // e.g., [[gas1_h1, gas1_h2], [gas2_h1, gas2_h2]] ->
+    // [[gas1_h1, gas2_h1], [gas1_h1, gas2_h2], [gas1_h2, gas2_h1], [gas1_h2, gas2_h2]]
+    std::vector<std::vector<int>> irrep_pools(ngas);
+    for (int i = 0; i < ngas; ++i) {
+        std::vector<int> irrep(nirrep_);
+        std::iota(irrep.begin(), irrep.end(), 0);
+        irrep_pools[i] = irrep;
     }
+    auto sym_product = math::cartesian_product(irrep_pools);
 
-    // iterate over all possible gas occupations
-    timer timer_gas1("Build GAS aufbau determinant");
-    for (size_t i_config = 0; i_config < gas_electrons_.size(); ++i_config) {
+    // figure out aufbau occupation
+    // in: nirrep of vector of occupation
+    // out: nirrep of aufbau occupation
+    auto aufbau_occ = [&](std::vector<std::vector<std::vector<bool>>>& occ_strings,
+                          const std::vector<double>& eps) {
+        std::vector<std::vector<bool>> out(nirrep_);
+        int norbs = eps.size();
 
-        size_t gas1_na = gas_electrons_[i_config][0];
-        size_t gas1_nb = gas_electrons_[i_config][1];
-        size_t gas2_na = gas_electrons_[i_config][2];
-        size_t gas2_nb = gas_electrons_[i_config][3];
-        size_t gas3_na = gas_electrons_[i_config][4];
-        size_t gas3_nb = gas_electrons_[i_config][5];
-        size_t gas4_na = gas_electrons_[i_config][6];
-        size_t gas4_nb = gas_electrons_[i_config][7];
-        size_t gas5_na = gas_electrons_[i_config][8];
-        size_t gas5_nb = gas_electrons_[i_config][9];
-        size_t gas6_na = gas_electrons_[i_config][10];
-        size_t gas6_nb = gas_electrons_[i_config][11];
-        size_t gas1_size = relative_gas_mo[0].size();
-        size_t gas2_size = relative_gas_mo[1].size();
-        size_t gas3_size = relative_gas_mo[2].size();
-        size_t gas4_size = relative_gas_mo[3].size();
-        size_t gas5_size = relative_gas_mo[4].size();
-        size_t gas6_size = relative_gas_mo[5].size();
-
-        // create the occupation of orbitals
-        std::vector<bool> tmp_det_gas1_a(gas1_size, false);
-        std::vector<bool> tmp_det_gas1_b(gas1_size, false);
-        std::vector<bool> tmp_det_gas2_a(gas2_size, false);
-        std::vector<bool> tmp_det_gas2_b(gas2_size, false);
-        std::vector<bool> tmp_det_gas3_a(gas3_size, false);
-        std::vector<bool> tmp_det_gas3_b(gas3_size, false);
-        std::vector<bool> tmp_det_gas4_a(gas4_size, false);
-        std::vector<bool> tmp_det_gas4_b(gas4_size, false);
-        std::vector<bool> tmp_det_gas5_a(gas5_size, false);
-        std::vector<bool> tmp_det_gas5_b(gas5_size, false);
-        std::vector<bool> tmp_det_gas6_a(gas6_size, false);
-        std::vector<bool> tmp_det_gas6_b(gas6_size, false);
-
-        if (gas1_size > 0) {
-            for (size_t i = 0; i < gas1_na; ++i) {
-                tmp_det_gas1_a[i] = true;
-            }
-            for (size_t i = 0; i < gas1_nb; ++i) {
-                tmp_det_gas1_b[i] = true;
-            }
-        }
-        if (gas2_size > 0) {
-            for (size_t i = 0; i < gas2_na; ++i) {
-                tmp_det_gas2_a[i] = true;
-            }
-            for (size_t i = 0; i < gas2_nb; ++i) {
-                tmp_det_gas2_b[i] = true;
-            }
-        }
-        if (gas3_size > 0) {
-            for (size_t i = 0; i < gas3_na; ++i) {
-                tmp_det_gas3_a[i] = true;
-            }
-            for (size_t i = 0; i < gas3_nb; ++i) {
-                tmp_det_gas3_b[i] = true;
-            }
-        }
-        if (gas4_size > 0) {
-            for (size_t i = 0; i < gas4_na; ++i) {
-                tmp_det_gas4_a[i] = true;
-            }
-            for (size_t i = 0; i < gas4_nb; ++i) {
-                tmp_det_gas4_b[i] = true;
-            }
-        }
-        if (gas5_size > 0) {
-            for (size_t i = 0; i < gas5_na; ++i) {
-                tmp_det_gas5_a[i] = true;
-            }
-            for (size_t i = 0; i < gas5_nb; ++i) {
-                tmp_det_gas5_b[i] = true;
-            }
-        }
-        if (gas6_size > 0) {
-            for (size_t i = 0; i < gas6_na; ++i) {
-                tmp_det_gas6_a[i] = true;
-            }
-            for (size_t i = 0; i < gas6_nb; ++i) {
-                tmp_det_gas6_b[i] = true;
+        for (int h = 0; h < nirrep_; ++h) {
+            const auto& occs = occ_strings[h];
+            auto min_occ_h =
+                std::min_element(occs.begin(), occs.end(),
+                                 [&](const std::vector<bool>& lhs, const std::vector<bool>& rhs) {
+                                     double e_lhs = 0.0, e_rhs = 0.0;
+                                     for (int p = 0; p < norbs; ++p) {
+                                         if (lhs[p])
+                                             e_lhs += eps[p];
+                                         if (rhs[p])
+                                             e_rhs += eps[p];
+                                     }
+                                     return e_lhs < e_rhs;
+                                 });
+            if (min_occ_h != occs.end()) {
+                out[h] = *min_occ_h;
             }
         }
 
-        // Sort
-        std::sort(begin(tmp_det_gas1_a), end(tmp_det_gas1_a));
-        std::sort(begin(tmp_det_gas1_b), end(tmp_det_gas1_b));
-        std::sort(begin(tmp_det_gas2_a), end(tmp_det_gas2_a));
-        std::sort(begin(tmp_det_gas2_b), end(tmp_det_gas2_b));
-        std::sort(begin(tmp_det_gas3_a), end(tmp_det_gas3_a));
-        std::sort(begin(tmp_det_gas3_b), end(tmp_det_gas3_b));
-        std::sort(begin(tmp_det_gas4_a), end(tmp_det_gas4_a));
-        std::sort(begin(tmp_det_gas4_b), end(tmp_det_gas4_b));
-        std::sort(begin(tmp_det_gas5_a), end(tmp_det_gas5_a));
-        std::sort(begin(tmp_det_gas5_b), end(tmp_det_gas5_b));
-        std::sort(begin(tmp_det_gas6_a), end(tmp_det_gas6_a));
-        std::sort(begin(tmp_det_gas6_b), end(tmp_det_gas6_b));
+        return out;
+    };
 
-        // Save all permutations
-        std::vector<std::vector<bool>> alldet_gas1_a;
-        std::vector<std::vector<bool>> alldet_gas1_b;
-        std::vector<std::vector<bool>> alldet_gas2_a;
-        std::vector<std::vector<bool>> alldet_gas2_b;
-        std::vector<std::vector<bool>> alldet_gas3_a;
-        std::vector<std::vector<bool>> alldet_gas3_b;
-        std::vector<std::vector<bool>> alldet_gas4_a;
-        std::vector<std::vector<bool>> alldet_gas4_b;
-        std::vector<std::vector<bool>> alldet_gas5_a;
-        std::vector<std::vector<bool>> alldet_gas5_b;
-        std::vector<std::vector<bool>> alldet_gas6_a;
-        std::vector<std::vector<bool>> alldet_gas6_b;
+    // loop over all GAS configurations
+    timer timer_gas("Build GAS determinants");
+    print_h2("Building GAS Determinants");
+    for (size_t config = 0, size = gas_electrons_.size(); config < size; ++config) {
 
-        do {
-            alldet_gas1_a.push_back(tmp_det_gas1_a);
-        } while (std::next_permutation(tmp_det_gas1_a.begin(), tmp_det_gas1_a.begin() + gas1_size));
-        do {
-            alldet_gas1_b.push_back(tmp_det_gas1_b);
-        } while (std::next_permutation(tmp_det_gas1_b.begin(), tmp_det_gas1_b.begin() + gas1_size));
-        do {
-            alldet_gas2_a.push_back(tmp_det_gas2_a);
-        } while (std::next_permutation(tmp_det_gas2_a.begin(), tmp_det_gas2_a.begin() + gas2_size));
-        do {
-            alldet_gas2_b.push_back(tmp_det_gas2_b);
-        } while (std::next_permutation(tmp_det_gas2_b.begin(), tmp_det_gas2_b.begin() + gas2_size));
-        do {
-            alldet_gas3_a.push_back(tmp_det_gas3_a);
-        } while (std::next_permutation(tmp_det_gas3_a.begin(), tmp_det_gas3_a.begin() + gas3_size));
-        do {
-            alldet_gas3_b.push_back(tmp_det_gas3_b);
-        } while (std::next_permutation(tmp_det_gas3_b.begin(), tmp_det_gas3_b.begin() + gas3_size));
-        do {
-            alldet_gas4_a.push_back(tmp_det_gas4_a);
-        } while (std::next_permutation(tmp_det_gas4_a.begin(), tmp_det_gas4_a.begin() + gas4_size));
-        do {
-            alldet_gas4_b.push_back(tmp_det_gas4_b);
-        } while (std::next_permutation(tmp_det_gas4_b.begin(), tmp_det_gas4_b.begin() + gas4_size));
-        do {
-            alldet_gas5_a.push_back(tmp_det_gas5_a);
-        } while (std::next_permutation(tmp_det_gas5_a.begin(), tmp_det_gas5_a.begin() + gas5_size));
-        do {
-            alldet_gas5_b.push_back(tmp_det_gas5_b);
-        } while (std::next_permutation(tmp_det_gas5_b.begin(), tmp_det_gas5_b.begin() + gas5_size));
-        do {
-            alldet_gas6_a.push_back(tmp_det_gas6_a);
-        } while (std::next_permutation(tmp_det_gas6_a.begin(), tmp_det_gas6_a.begin() + gas6_size));
-        do {
-            alldet_gas6_b.push_back(tmp_det_gas6_b);
-        } while (std::next_permutation(tmp_det_gas6_b.begin(), tmp_det_gas6_b.begin() + gas6_size));
+        // build alpha or beta strings (ngas of nirrep of aufbau occupation)
+        std::vector<std::vector<std::vector<bool>>> a_tmp, b_tmp;
 
-        // Reverse for the low energy
-        std::reverse(begin(alldet_gas1_a), end(alldet_gas1_a));
-        std::reverse(begin(alldet_gas1_b), end(alldet_gas1_b));
-        std::reverse(begin(alldet_gas2_a), end(alldet_gas2_a));
-        std::reverse(begin(alldet_gas2_b), end(alldet_gas2_b));
-        std::reverse(begin(alldet_gas3_a), end(alldet_gas3_a));
-        std::reverse(begin(alldet_gas3_b), end(alldet_gas3_b));
-        std::reverse(begin(alldet_gas4_a), end(alldet_gas4_a));
-        std::reverse(begin(alldet_gas4_b), end(alldet_gas4_b));
-        std::reverse(begin(alldet_gas5_a), end(alldet_gas5_a));
-        std::reverse(begin(alldet_gas5_b), end(alldet_gas5_b));
-        std::reverse(begin(alldet_gas6_a), end(alldet_gas6_a));
-        std::reverse(begin(alldet_gas6_b), end(alldet_gas6_b));
+        for (int gas = 0; gas < 6; ++gas) {
+            auto space_name = "GAS" + std::to_string(gas + 1);
+            auto norb = mo_space_info_->size(space_name);
+            if (norb == 0)
+                continue;
 
-        // Permutation of all the orbitals
-        for (const auto& det_gas1_a : alldet_gas1_a) {
-            for (const auto& det_gas1_b : alldet_gas1_b) {
-                for (const auto& det_gas2_a : alldet_gas2_a) {
-                    for (const auto& det_gas2_b : alldet_gas2_b) {
-                        for (const auto& det_gas3_a : alldet_gas3_a) {
-                            for (const auto& det_gas3_b : alldet_gas3_b) {
-                                for (const auto& det_gas4_a : alldet_gas4_a) {
-                                    for (const auto& det_gas4_b : alldet_gas4_b) {
-                                        for (const auto& det_gas5_a : alldet_gas5_a) {
-                                            for (const auto& det_gas5_b : alldet_gas5_b) {
-                                                for (const auto& det_gas6_a : alldet_gas6_a) {
-                                                    for (const auto& det_gas6_b : alldet_gas6_b) {
-                                                        // Build determinant
-                                                        // outfile->Printf(
-                                                        //   "\n Possible
-                                                        //   Configurations");
-                                                        Determinant det;
-                                                        int sym = 0;
-                                                        for (size_t p = 0; p < gas1_size; ++p) {
-                                                            det.set_alfa_bit(relative_gas_mo[0][p],
-                                                                             det_gas1_a[p]);
-                                                            det.set_beta_bit(relative_gas_mo[0][p],
-                                                                             det_gas1_b[p]);
-                                                            if (det_gas1_a[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[0][p]];
-                                                            }
-                                                            if (det_gas1_b[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[0][p]];
-                                                            }
-                                                        }
-                                                        for (size_t p = 0; p < gas2_size; ++p) {
-                                                            det.set_alfa_bit(relative_gas_mo[1][p],
-                                                                             det_gas2_a[p]);
-                                                            det.set_beta_bit(relative_gas_mo[1][p],
-                                                                             det_gas2_b[p]);
-                                                            if (det_gas2_a[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[1][p]];
-                                                            }
-                                                            if (det_gas2_b[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[1][p]];
-                                                            }
-                                                        }
-                                                        for (size_t p = 0; p < gas3_size; ++p) {
-                                                            det.set_alfa_bit(relative_gas_mo[2][p],
-                                                                             det_gas3_a[p]);
-                                                            det.set_beta_bit(relative_gas_mo[2][p],
-                                                                             det_gas3_b[p]);
-                                                            if (det_gas3_a[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[2][p]];
-                                                            }
-                                                            if (det_gas3_b[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[2][p]];
-                                                            }
-                                                        }
-                                                        for (size_t p = 0; p < gas4_size; ++p) {
-                                                            det.set_alfa_bit(relative_gas_mo[3][p],
-                                                                             det_gas4_a[p]);
-                                                            det.set_beta_bit(relative_gas_mo[3][p],
-                                                                             det_gas4_b[p]);
-                                                            if (det_gas4_a[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[3][p]];
-                                                            }
-                                                            if (det_gas4_b[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[3][p]];
-                                                            }
-                                                        }
-                                                        for (size_t p = 0; p < gas5_size; ++p) {
-                                                            det.set_alfa_bit(relative_gas_mo[4][p],
-                                                                             det_gas5_a[p]);
-                                                            det.set_beta_bit(relative_gas_mo[4][p],
-                                                                             det_gas5_b[p]);
-                                                            if (det_gas5_a[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[4][p]];
-                                                            }
-                                                            if (det_gas5_b[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[4][p]];
-                                                            }
-                                                        }
-                                                        for (size_t p = 0; p < gas6_size; ++p) {
-                                                            det.set_alfa_bit(relative_gas_mo[5][p],
-                                                                             det_gas6_a[p]);
-                                                            det.set_beta_bit(relative_gas_mo[5][p],
-                                                                             det_gas6_b[p]);
-                                                            if (det_gas6_a[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[5][p]];
-                                                            }
-                                                            if (det_gas6_b[p]) {
-                                                                sym ^= mo_symmetry_
-                                                                    [relative_gas_mo[5][p]];
-                                                            }
-                                                        }
-                                                        int nunpair =
-                                                            nalpha_ + nbeta_ - 2 * det.npair();
-                                                        // Check symmetry and multiplicity
-                                                        if (sym == root_sym_ &&
-                                                            nunpair + 1 >= multiplicity_) {
-                                                            ref_space.push_back(det);
-                                                            //                                                            outfile->Printf("\n");
-                                                            //                                                            outfile->Printf(
-                                                            //                                                                "\n  Ref: %s",
-                                                            //                                                                str(det, nact_).c_str());
-                                                            return;
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
+            auto sym = mo_space_info_->symmetry(space_name);
+
+            // alpha aufbau string of each irrep
+            auto strings = build_occ_string(norb, gas_electrons_[config][2 * gas], sym);
+            a_tmp.push_back(aufbau_occ(strings, rel_gas_eps[2 * gas]));
+
+            // beta aufbau string of each irrep
+            strings = build_occ_string(norb, gas_electrons_[config][2 * gas + 1], sym);
+            b_tmp.push_back(aufbau_occ(strings, rel_gas_eps[2 * gas + 1]));
+        }
+
+        // combine to a string of size nactv
+        std::vector<std::tuple<double, std::vector<bool>>> a_strings(nirrep_), b_strings(nirrep_);
+
+        auto a_product = math::cartesian_product(a_tmp);
+        auto b_product = math::cartesian_product(b_tmp);
+
+        for (size_t i = 0, isize = sym_product.size(); i < isize; ++i) {
+            const auto& sym = sym_product[i];
+
+            // alpha
+            const auto& a_gas_occ = a_product[i];
+            if (std::all_of(a_gas_occ.begin(), a_gas_occ.end(),
+                            [](const std::vector<bool>& x) { return x.size(); })) {
+                // symmetry of this product
+                int h = 0;
+
+                // combine to a big string
+                std::vector<bool> big_string(nact_, false);
+                double e = 0.0;
+
+                for (int gas = 0; gas < ngas; ++gas) {
+                    h ^= sym[gas];
+                    const auto& occ = a_gas_occ[gas];
+                    for (int p = 0, psize = occ.size(); p < psize; ++p) {
+                        if (occ[p]) {
+                            big_string[p] = true;
+                            e += rel_gas_eps[2 * gas_nonzero_to_full[gas]][p];
                         }
                     }
                 }
+
+                a_strings[h] = {e, big_string};
+            }
+
+            // beta
+            const auto& b_gas_occ = b_product[i];
+
+            if (std::all_of(b_gas_occ.begin(), b_gas_occ.end(),
+                            [](const std::vector<bool>& x) { return x.size(); })) {
+                // symmetry of this product
+                int h = 0;
+
+                // combine to a big string
+                std::vector<bool> big_string(nact_, false);
+                double e = 0.0;
+
+                for (int gas = 0; gas < ngas; ++gas) {
+                    h ^= sym[gas];
+                    const auto& occ = b_gas_occ[gas];
+                    for (int p = 0, psize = occ.size(); p < psize; ++p) {
+                        if (occ[p]) {
+                            big_string[p] = true;
+                            e += rel_gas_eps[2 * gas_nonzero_to_full[gas] + 1][p];
+                        }
+                    }
+                }
+
+                b_strings[h] = {e, big_string};
             }
         }
+
+        // combine to determinant
+        double e_min = 0.0;
+        Determinant det_min;
+        for (int h = 0; h < nirrep_; ++h) {
+            const auto& a = a_strings[h];
+            const auto& b = b_strings[h ^ root_sym_];
+
+            double e = std::get<0>(a) + std::get<0>(b);
+            Determinant det(std::get<1>(a), std::get<1>(b));
+
+            if (e < e_min and (nalpha_ + nbeta_ - 2 * det.npair() + 1) >= multiplicity_) {
+                det_min = det;
+                e_min = e;
+            }
+        }
+        if (e_min != 0.0) {
+            ref_space.push_back(det_min);
+            outfile->Printf("\n  Reference determinant: %s", str(det_min, nact_).c_str());
+            break;
+        }
     }
+
+//    // build one single low energy determinant in the gas space
+
+//    //    std::shared_ptr<Vector> epsilon_a = scf_info_->epsilon_a();
+
+//    // relative_mo of each GAS
+//    // Sort the aboslute_mo in the increasing order of energy for each GAS
+//    std::vector<std::vector<size_t>> relative_gas_mo;
+//    size_t total_act = 0;
+//    outfile->Printf("\n");
+//    outfile->Printf("\n  GAS Orbital Energies");
+//    outfile->Printf("\n  GAS   Energies    Orb ");
+//    std::vector<size_t> act_mo = mo_space_info_->absolute_mo("ACTIVE");
+//    std::map<int, int> re_ab_mo;
+//    for (size_t i = 0; i < act_mo.size(); i++) {
+//        re_ab_mo[act_mo[i]] = i;
+//    }
+//    for (size_t gas_count = 0; gas_count < 6; gas_count++) {
+//        const std::string space = "GAS" + std::to_string(gas_count + 1);
+//        ;
+//        std::vector<size_t> relative_mo_sorted;
+//        auto vec_mo_info = mo_space_info_->absolute_mo(space);
+//        std::vector<std::pair<double, int>> gas_orb_e;
+//        for (size_t i = 0; i < vec_mo_info.size(); ++i) {
+//            auto orb = vec_mo_info[i];
+//            gas_orb_e.push_back(std::make_pair(epsilon_a->get(orb), re_ab_mo[orb]));
+//        }
+//        total_act += gas_orb_e.size();
+//        std::sort(gas_orb_e.begin(), gas_orb_e.end());
+
+//        for (size_t i = 0; i < gas_orb_e.size(); i++) {
+//            auto act_orb = gas_orb_e[i].second;
+//            relative_mo_sorted.push_back(act_orb);
+//            outfile->Printf("\n   %d  %12.9f  %d ", gas_count + 1, gas_orb_e[i].first, act_orb);
+//        }
+//        relative_gas_mo.push_back(relative_mo_sorted);
+//    }
+
+//    // iterate over all possible gas occupations
+//    timer timer_gas1("Build GAS aufbau determinant");
+//    for (size_t i_config = 0; i_config < gas_electrons_.size(); ++i_config) {
+
+//        size_t gas1_na = gas_electrons_[i_config][0];
+//        size_t gas1_nb = gas_electrons_[i_config][1];
+//        size_t gas2_na = gas_electrons_[i_config][2];
+//        size_t gas2_nb = gas_electrons_[i_config][3];
+//        size_t gas3_na = gas_electrons_[i_config][4];
+//        size_t gas3_nb = gas_electrons_[i_config][5];
+//        size_t gas4_na = gas_electrons_[i_config][6];
+//        size_t gas4_nb = gas_electrons_[i_config][7];
+//        size_t gas5_na = gas_electrons_[i_config][8];
+//        size_t gas5_nb = gas_electrons_[i_config][9];
+//        size_t gas6_na = gas_electrons_[i_config][10];
+//        size_t gas6_nb = gas_electrons_[i_config][11];
+//        size_t gas1_size = relative_gas_mo[0].size();
+//        size_t gas2_size = relative_gas_mo[1].size();
+//        size_t gas3_size = relative_gas_mo[2].size();
+//        size_t gas4_size = relative_gas_mo[3].size();
+//        size_t gas5_size = relative_gas_mo[4].size();
+//        size_t gas6_size = relative_gas_mo[5].size();
+
+//        // create the occupation of orbitals
+//        std::vector<bool> tmp_det_gas1_a(gas1_size, false);
+//        std::vector<bool> tmp_det_gas1_b(gas1_size, false);
+//        std::vector<bool> tmp_det_gas2_a(gas2_size, false);
+//        std::vector<bool> tmp_det_gas2_b(gas2_size, false);
+//        std::vector<bool> tmp_det_gas3_a(gas3_size, false);
+//        std::vector<bool> tmp_det_gas3_b(gas3_size, false);
+//        std::vector<bool> tmp_det_gas4_a(gas4_size, false);
+//        std::vector<bool> tmp_det_gas4_b(gas4_size, false);
+//        std::vector<bool> tmp_det_gas5_a(gas5_size, false);
+//        std::vector<bool> tmp_det_gas5_b(gas5_size, false);
+//        std::vector<bool> tmp_det_gas6_a(gas6_size, false);
+//        std::vector<bool> tmp_det_gas6_b(gas6_size, false);
+
+//        if (gas1_size > 0) {
+//            for (size_t i = 0; i < gas1_na; ++i) {
+//                tmp_det_gas1_a[i] = true;
+//            }
+//            for (size_t i = 0; i < gas1_nb; ++i) {
+//                tmp_det_gas1_b[i] = true;
+//            }
+//        }
+//        if (gas2_size > 0) {
+//            for (size_t i = 0; i < gas2_na; ++i) {
+//                tmp_det_gas2_a[i] = true;
+//            }
+//            for (size_t i = 0; i < gas2_nb; ++i) {
+//                tmp_det_gas2_b[i] = true;
+//            }
+//        }
+//        if (gas3_size > 0) {
+//            for (size_t i = 0; i < gas3_na; ++i) {
+//                tmp_det_gas3_a[i] = true;
+//            }
+//            for (size_t i = 0; i < gas3_nb; ++i) {
+//                tmp_det_gas3_b[i] = true;
+//            }
+//        }
+//        if (gas4_size > 0) {
+//            for (size_t i = 0; i < gas4_na; ++i) {
+//                tmp_det_gas4_a[i] = true;
+//            }
+//            for (size_t i = 0; i < gas4_nb; ++i) {
+//                tmp_det_gas4_b[i] = true;
+//            }
+//        }
+//        if (gas5_size > 0) {
+//            for (size_t i = 0; i < gas5_na; ++i) {
+//                tmp_det_gas5_a[i] = true;
+//            }
+//            for (size_t i = 0; i < gas5_nb; ++i) {
+//                tmp_det_gas5_b[i] = true;
+//            }
+//        }
+//        if (gas6_size > 0) {
+//            for (size_t i = 0; i < gas6_na; ++i) {
+//                tmp_det_gas6_a[i] = true;
+//            }
+//            for (size_t i = 0; i < gas6_nb; ++i) {
+//                tmp_det_gas6_b[i] = true;
+//            }
+//        }
+
+//        // Sort
+//        std::sort(begin(tmp_det_gas1_a), end(tmp_det_gas1_a));
+//        std::sort(begin(tmp_det_gas1_b), end(tmp_det_gas1_b));
+//        std::sort(begin(tmp_det_gas2_a), end(tmp_det_gas2_a));
+//        std::sort(begin(tmp_det_gas2_b), end(tmp_det_gas2_b));
+//        std::sort(begin(tmp_det_gas3_a), end(tmp_det_gas3_a));
+//        std::sort(begin(tmp_det_gas3_b), end(tmp_det_gas3_b));
+//        std::sort(begin(tmp_det_gas4_a), end(tmp_det_gas4_a));
+//        std::sort(begin(tmp_det_gas4_b), end(tmp_det_gas4_b));
+//        std::sort(begin(tmp_det_gas5_a), end(tmp_det_gas5_a));
+//        std::sort(begin(tmp_det_gas5_b), end(tmp_det_gas5_b));
+//        std::sort(begin(tmp_det_gas6_a), end(tmp_det_gas6_a));
+//        std::sort(begin(tmp_det_gas6_b), end(tmp_det_gas6_b));
+
+//        // Save all permutations
+//        std::vector<std::vector<bool>> alldet_gas1_a;
+//        std::vector<std::vector<bool>> alldet_gas1_b;
+//        std::vector<std::vector<bool>> alldet_gas2_a;
+//        std::vector<std::vector<bool>> alldet_gas2_b;
+//        std::vector<std::vector<bool>> alldet_gas3_a;
+//        std::vector<std::vector<bool>> alldet_gas3_b;
+//        std::vector<std::vector<bool>> alldet_gas4_a;
+//        std::vector<std::vector<bool>> alldet_gas4_b;
+//        std::vector<std::vector<bool>> alldet_gas5_a;
+//        std::vector<std::vector<bool>> alldet_gas5_b;
+//        std::vector<std::vector<bool>> alldet_gas6_a;
+//        std::vector<std::vector<bool>> alldet_gas6_b;
+
+//        do {
+//            alldet_gas1_a.push_back(tmp_det_gas1_a);
+//        } while (std::next_permutation(tmp_det_gas1_a.begin(), tmp_det_gas1_a.begin() + gas1_size));
+//        do {
+//            alldet_gas1_b.push_back(tmp_det_gas1_b);
+//        } while (std::next_permutation(tmp_det_gas1_b.begin(), tmp_det_gas1_b.begin() + gas1_size));
+//        do {
+//            alldet_gas2_a.push_back(tmp_det_gas2_a);
+//        } while (std::next_permutation(tmp_det_gas2_a.begin(), tmp_det_gas2_a.begin() + gas2_size));
+//        do {
+//            alldet_gas2_b.push_back(tmp_det_gas2_b);
+//        } while (std::next_permutation(tmp_det_gas2_b.begin(), tmp_det_gas2_b.begin() + gas2_size));
+//        do {
+//            alldet_gas3_a.push_back(tmp_det_gas3_a);
+//        } while (std::next_permutation(tmp_det_gas3_a.begin(), tmp_det_gas3_a.begin() + gas3_size));
+//        do {
+//            alldet_gas3_b.push_back(tmp_det_gas3_b);
+//        } while (std::next_permutation(tmp_det_gas3_b.begin(), tmp_det_gas3_b.begin() + gas3_size));
+//        do {
+//            alldet_gas4_a.push_back(tmp_det_gas4_a);
+//        } while (std::next_permutation(tmp_det_gas4_a.begin(), tmp_det_gas4_a.begin() + gas4_size));
+//        do {
+//            alldet_gas4_b.push_back(tmp_det_gas4_b);
+//        } while (std::next_permutation(tmp_det_gas4_b.begin(), tmp_det_gas4_b.begin() + gas4_size));
+//        do {
+//            alldet_gas5_a.push_back(tmp_det_gas5_a);
+//        } while (std::next_permutation(tmp_det_gas5_a.begin(), tmp_det_gas5_a.begin() + gas5_size));
+//        do {
+//            alldet_gas5_b.push_back(tmp_det_gas5_b);
+//        } while (std::next_permutation(tmp_det_gas5_b.begin(), tmp_det_gas5_b.begin() + gas5_size));
+//        do {
+//            alldet_gas6_a.push_back(tmp_det_gas6_a);
+//        } while (std::next_permutation(tmp_det_gas6_a.begin(), tmp_det_gas6_a.begin() + gas6_size));
+//        do {
+//            alldet_gas6_b.push_back(tmp_det_gas6_b);
+//        } while (std::next_permutation(tmp_det_gas6_b.begin(), tmp_det_gas6_b.begin() + gas6_size));
+
+//        // Reverse for the low energy
+//        std::reverse(begin(alldet_gas1_a), end(alldet_gas1_a));
+//        std::reverse(begin(alldet_gas1_b), end(alldet_gas1_b));
+//        std::reverse(begin(alldet_gas2_a), end(alldet_gas2_a));
+//        std::reverse(begin(alldet_gas2_b), end(alldet_gas2_b));
+//        std::reverse(begin(alldet_gas3_a), end(alldet_gas3_a));
+//        std::reverse(begin(alldet_gas3_b), end(alldet_gas3_b));
+//        std::reverse(begin(alldet_gas4_a), end(alldet_gas4_a));
+//        std::reverse(begin(alldet_gas4_b), end(alldet_gas4_b));
+//        std::reverse(begin(alldet_gas5_a), end(alldet_gas5_a));
+//        std::reverse(begin(alldet_gas5_b), end(alldet_gas5_b));
+//        std::reverse(begin(alldet_gas6_a), end(alldet_gas6_a));
+//        std::reverse(begin(alldet_gas6_b), end(alldet_gas6_b));
+
+//        // Permutation of all the orbitals
+//        for (const auto& det_gas1_a : alldet_gas1_a) {
+//            for (const auto& det_gas1_b : alldet_gas1_b) {
+//                for (const auto& det_gas2_a : alldet_gas2_a) {
+//                    for (const auto& det_gas2_b : alldet_gas2_b) {
+//                        for (const auto& det_gas3_a : alldet_gas3_a) {
+//                            for (const auto& det_gas3_b : alldet_gas3_b) {
+//                                for (const auto& det_gas4_a : alldet_gas4_a) {
+//                                    for (const auto& det_gas4_b : alldet_gas4_b) {
+//                                        for (const auto& det_gas5_a : alldet_gas5_a) {
+//                                            for (const auto& det_gas5_b : alldet_gas5_b) {
+//                                                for (const auto& det_gas6_a : alldet_gas6_a) {
+//                                                    for (const auto& det_gas6_b : alldet_gas6_b) {
+//                                                        // Build determinant
+//                                                        outfile->Printf(
+//                                                            "\n Possible Configurations");
+//                                                        Determinant det;
+//                                                        int sym = 0;
+//                                                        for (size_t p = 0; p < gas1_size; ++p) {
+//                                                            det.set_alfa_bit(relative_gas_mo[0][p],
+//                                                                             det_gas1_a[p]);
+//                                                            det.set_beta_bit(relative_gas_mo[0][p],
+//                                                                             det_gas1_b[p]);
+//                                                            if (det_gas1_a[p]) {
+//                                                                sym ^= mo_symmetry_
+//                                                                    [relative_gas_mo[0][p]];
+//                                                            }
+//                                                            if (det_gas1_b[p]) {
+//                                                                sym ^= mo_symmetry_
+//                                                                    [relative_gas_mo[0][p]];
+//                                                            }
+//                                                        }
+//                                                        for (size_t p = 0; p < gas2_size; ++p) {
+//                                                            det.set_alfa_bit(relative_gas_mo[1][p],
+//                                                                             det_gas2_a[p]);
+//                                                            det.set_beta_bit(relative_gas_mo[1][p],
+//                                                                             det_gas2_b[p]);
+//                                                            if (det_gas2_a[p]) {
+//                                                                sym ^= mo_symmetry_
+//                                                                    [relative_gas_mo[1][p]];
+//                                                            }
+//                                                            if (det_gas2_b[p]) {
+//                                                                sym ^= mo_symmetry_
+//                                                                    [relative_gas_mo[1][p]];
+//                                                            }
+//                                                        }
+//                                                        for (size_t p = 0; p < gas3_size; ++p) {
+//                                                            det.set_alfa_bit(relative_gas_mo[2][p],
+//                                                                             det_gas3_a[p]);
+//                                                            det.set_beta_bit(relative_gas_mo[2][p],
+//                                                                             det_gas3_b[p]);
+//                                                            if (det_gas3_a[p]) {
+//                                                                sym ^= mo_symmetry_
+//                                                                    [relative_gas_mo[2][p]];
+//                                                            }
+//                                                            if (det_gas3_b[p]) {
+//                                                                sym ^= mo_symmetry_
+//                                                                    [relative_gas_mo[2][p]];
+//                                                            }
+//                                                        }
+//                                                        for (size_t p = 0; p < gas4_size; ++p) {
+//                                                            det.set_alfa_bit(relative_gas_mo[3][p],
+//                                                                             det_gas4_a[p]);
+//                                                            det.set_beta_bit(relative_gas_mo[3][p],
+//                                                                             det_gas4_b[p]);
+//                                                            if (det_gas4_a[p]) {
+//                                                                sym ^= mo_symmetry_
+//                                                                    [relative_gas_mo[3][p]];
+//                                                            }
+//                                                            if (det_gas4_b[p]) {
+//                                                                sym ^= mo_symmetry_
+//                                                                    [relative_gas_mo[3][p]];
+//                                                            }
+//                                                        }
+//                                                        for (size_t p = 0; p < gas5_size; ++p) {
+//                                                            det.set_alfa_bit(relative_gas_mo[4][p],
+//                                                                             det_gas5_a[p]);
+//                                                            det.set_beta_bit(relative_gas_mo[4][p],
+//                                                                             det_gas5_b[p]);
+//                                                            if (det_gas5_a[p]) {
+//                                                                sym ^= mo_symmetry_
+//                                                                    [relative_gas_mo[4][p]];
+//                                                            }
+//                                                            if (det_gas5_b[p]) {
+//                                                                sym ^= mo_symmetry_
+//                                                                    [relative_gas_mo[4][p]];
+//                                                            }
+//                                                        }
+//                                                        for (size_t p = 0; p < gas6_size; ++p) {
+//                                                            det.set_alfa_bit(relative_gas_mo[5][p],
+//                                                                             det_gas6_a[p]);
+//                                                            det.set_beta_bit(relative_gas_mo[5][p],
+//                                                                             det_gas6_b[p]);
+//                                                            if (det_gas6_a[p]) {
+//                                                                sym ^= mo_symmetry_
+//                                                                    [relative_gas_mo[5][p]];
+//                                                            }
+//                                                            if (det_gas6_b[p]) {
+//                                                                sym ^= mo_symmetry_
+//                                                                    [relative_gas_mo[5][p]];
+//                                                            }
+//                                                        }
+//                                                        int nunpair =
+//                                                            nalpha_ + nbeta_ - 2 * det.npair();
+//                                                        // Check symmetry and multiplicity
+//                                                        if (sym == root_sym_ &&
+//                                                            nunpair + 1 >= multiplicity_) {
+//                                                            ref_space.push_back(det);
+//                                                            outfile->Printf("\n");
+//                                                            outfile->Printf(
+//                                                                "\n  Ref: %s",
+//                                                                str(det, nact_).c_str());
+//                                                            return;
+//                                                        }
+//                                                    }
+//                                                }
+//                                            }
+//                                        }
+//                                    }
+//                                }
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//    }
 }
 
 void CI_Reference::build_gas_reference(std::vector<Determinant>& ref_space) {

--- a/src/sparse_ci/ci_reference.h
+++ b/src/sparse_ci/ci_reference.h
@@ -106,6 +106,9 @@ class CI_Reference {
     /// GAS1_A, GAS1_B, GAS2_A, .... GAS6_B (12 elements)
     std::vector<std::vector<int>> gas_electrons_;
 
+    /// Print SCF orbital energies for GAS
+    void print_gas_scf_epsilon();
+
     /// Compute the occupation string for a given number of electrons and orbitals
     /// @return nirrep of vector of occupation
     std::vector<std::vector<std::vector<bool>>> build_occ_string(size_t norb, size_t nele,

--- a/src/sparse_ci/ci_reference.h
+++ b/src/sparse_ci/ci_reference.h
@@ -106,6 +106,18 @@ class CI_Reference {
     /// GAS1_A, GAS1_B, GAS2_A, .... GAS6_B (12 elements)
     std::vector<std::vector<int>> gas_electrons_;
 
+    /// Compute the occupation string for a given number of electrons and orbitals
+    /// @return nirrep of vector of occupation
+    std::vector<std::vector<std::vector<bool>>> build_occ_string(size_t norb, size_t nele,
+                                                          const std::vector<int>& symmetry);
+
+    /// Compute the cartesian product of occupation strings
+    /// @arg vector of vector of occupation
+    /// @return nirrep of vector of occupation
+    std::vector<std::vector<bool>>
+    build_gas_occ_string(const std::vector<std::vector<std::vector<bool>>>& gas_strings,
+                         const std::vector<std::vector<size_t>>& rel_mos);
+
   public:
     /// Default constructor
     CI_Reference(std::shared_ptr<SCFInfo> scf_info, std::shared_ptr<ForteOptions> options,

--- a/tests/methods/gasaci-1/output.ref
+++ b/tests/methods/gasaci-1/output.ref
@@ -3,31 +3,38 @@
           Psi4: An Open-Source Ab Initio Electronic Structure Package
                                Psi4 undefined 
 
-                         Git: Rev {master} 45315cb dirty
+                         Git: Rev {x2c-norm} b906495 
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
 
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
 
-                         Additional Contributions by
-    P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, R. A. Shaw,
-    A. Alenaizan, R. Galvelis, Z. L. Glick, S. Lehtola, and J. P. Misiewicz
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Sunday, 09 August 2020 05:50PM
+    Psi4 started on: Saturday, 30 January 2021 03:41AM
 
-    Process ID: 14786
-    Host:       DESKTOP-SQPD2D3
-    PSIDATADIR: /home/mhuang/psi4_install/share/psi4
+    Process ID: 63882
+    Host:       Yorks-Mac.local
+    PSIDATADIR: /Users/york/src/psi4new/psi4/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -35,7 +42,8 @@
 
 --------------------------------------------------------------------------
 #! Generated using commit GITCOMMIT 
-# GAS ACI calculation with energy threshold selection
+# GAS ACI calculation 
+# Failed gas-aci will lead to correct aci energy but incorrect acipt2 energy
 
 import forte
 
@@ -59,13 +67,11 @@ set {
 
 set scf {
   scf_type pk
-  reference rohf
-#  docc = [2,0,0,0,0,1,0,0]
+  reference rhf
 }
 
 set forte {
   active_space_solver aci
-  gas_iteration true
   multiplicity 1
   ms 0.0
   sigma 0.001
@@ -77,37 +83,39 @@ set forte {
   active_ref_type gas_single
   GAS1 [6,0,2,2,0,6,0,0]
   GAS2 [0,0,0,0,0,0,2,2]
-  GAS2MAX 2
-  GAS2MIN 0 
-  GAS1MIN 4
-  GAS1MAX 6
+  GAS2MAX [2]
+  GAS2MIN [0]
+  GAS1MIN [4]
+  GAS1MAX [6]
 }
 
 energy('scf')
 
-#compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
+compare_values(refscf, variable("CURRENT ENERGY"),9, "SCF energy") #TEST
 
 energy('forte')
 compare_values(refaci, variable("ACI ENERGY"),9, "ACI energy") #TEST
 compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
 --------------------------------------------------------------------------
 
-*** tstart() called on DESKTOP-SQPD2D3
-*** at Sun Aug  9 17:50:12 2020
+Scratch directory: /Users/york/scratch/psi4/
+
+*** tstart() called on Yorks-Mac.local
+*** at Sat Jan 30 03:41:38 2021
 
    => Loading Basis Set <=
 
     Name: DZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry LI         line    20 file /home/mhuang/psi4_install/share/psi4/basis/dz.gbs 
+    atoms 1-2 entry LI         line    20 file /Users/york/src/psi4new/psi4/share/psi4/basis/dz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
-                             ROHF Reference
+                              RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
@@ -144,7 +152,7 @@ compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
   Guess Type is GWH.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -161,24 +169,7 @@ compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
     Name: (DZ AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1-2 entry LI         line    59 file /home/mhuang/psi4_install/share/psi4/basis/def2-qzvpp-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag         6       6       0       0       0       0
-     B1g        0       0       0       0       0       0
-     B2g        2       2       0       0       0       0
-     B3g        2       2       0       0       0       0
-     Au         0       0       0       0       0       0
-     B1u        6       6       0       0       0       0
-     B2u        2       2       0       0       0       0
-     B3u        2       2       0       0       0       0
-   -------------------------------------------------------
-    Total      20      20       3       3       3       0
-   -------------------------------------------------------
+    atoms 1-2 entry LI         line    54 file /Users/york/src/psi4new/psi4/share/psi4/basis/def2-universal-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -208,10 +199,28 @@ compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
 
     OpenMP threads:              1
 
-  Minimum eigenvalue in the overlap matrix is 1.9077688868E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 6.5960170734E-03.
+  Reciprocal condition number of the overlap matrix is 1.7658990716E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Generalized Wolfsberg-Helmholtz.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         6       6       1       1       1       0
+     B1g        0       0       0       0       0       0
+     B2g        2       2       0       0       0       0
+     B3g        2       2       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        6       6       2       2       2       0
+     B2u        2       2       0       0       0       0
+     B3u        2       2       0       0       0       0
+   -------------------------------------------------------
+    Total      20      20       3       3       3       0
+   -------------------------------------------------------
 
   ==> Iterations <==
 
@@ -220,18 +229,17 @@ compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
     Occupation by irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     2,    0,    0,    0,    0,    1,    0,    0 ]
-    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
 
-   @DF-ROHF iter   1:   -13.86328592226872   -1.38633e+01   9.38367e-02 DIIS
-   @DF-ROHF iter   2:   -14.83151256644319   -9.68227e-01   5.72002e-03 DIIS
-   @DF-ROHF iter   3:   -14.83897650580172   -7.46394e-03   1.05869e-03 DIIS
-   @DF-ROHF iter   4:   -14.83973801876335   -7.61513e-04   3.60085e-04 DIIS
-   @DF-ROHF iter   5:   -14.83984352118057   -1.05502e-04   5.52298e-05 DIIS
-   @DF-ROHF iter   6:   -14.83984643708391   -2.91590e-06   9.06964e-06 DIIS
-   @DF-ROHF iter   7:   -14.83984651201011   -7.49262e-08   4.58804e-08 DIIS
-   @DF-ROHF iter   8:   -14.83984651201065   -5.40012e-13   5.89178e-09 DIIS
-   @DF-ROHF iter   9:   -14.83984651201067   -2.13163e-14   1.60078e-09 DIIS
-   @DF-ROHF iter  10:   -14.83984651201068   -7.10543e-15   6.74061e-11 DIIS
+   @DF-RHF iter   1:   -13.86328592226844   -1.38633e+01   1.32705e-01 DIIS
+   @DF-RHF iter   2:   -14.83151256644317   -9.68227e-01   8.08932e-03 DIIS
+   @DF-RHF iter   3:   -14.83897643446973   -7.46387e-03   1.49734e-03 DIIS
+   @DF-RHF iter   4:   -14.83973856509425   -7.62131e-04   5.08047e-04 DIIS
+   @DF-RHF iter   5:   -14.83984354512973   -1.04980e-04   7.77538e-05 DIIS
+   @DF-RHF iter   6:   -14.83984644064841   -2.89552e-06   1.24963e-05 DIIS
+   @DF-RHF iter   7:   -14.83984651200914   -7.13607e-08   7.92564e-08 DIIS
+   @DF-RHF iter   8:   -14.83984651201063   -1.48148e-12   1.04058e-08 DIIS
+   @DF-RHF iter   9:   -14.83984651201068   -4.97380e-14   2.68735e-09 DIIS
+   @DF-RHF iter  10:   -14.83984651201066    1.59872e-14   8.74421e-11 DIIS
   Energy and wave function converged.
 
 
@@ -244,14 +252,10 @@ compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
 
        1Ag    -2.470948     1B1u   -2.465815     2Ag    -0.194380  
 
-    Singly Occupied:                                                      
-
-    
-
     Virtual:                                                              
 
        2B1u    0.012721     1B2u    0.026034     1B3u    0.026034  
-       3Ag     0.049075     1B2g    0.069563     1B3g    0.069563  
+       3Ag     0.049075     1B3g    0.069563     1B2g    0.069563  
        3B1u    0.080420     4Ag     0.130086     2B2u    0.137741  
        2B3u    0.137741     5Ag     0.171764     2B3g    0.242777  
        2B2g    0.242777     4B1u    0.246004     5B1u    0.480486  
@@ -260,16 +264,15 @@ compare_values(refacipt2, variable("ACI+PT2 ENERGY"),8, "ACI+PT2 energy") #TEST
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     2,    0,    0,    0,    0,    1,    0,    0 ]
-    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
 
-  @DF-ROHF Final Energy:   -14.83984651201068
+  @DF-RHF Final Energy:   -14.83984651201066
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              2.3812974480149989
-    One-Electron Energy =                 -24.1800018423486272
-    Two-Electron Energy =                   6.9588578823229499
-    Total Energy =                        -14.8398465120106806
+    One-Electron Energy =                 -24.1800018421956793
+    Two-Electron Energy =                   6.9588578821700224
+    Total Energy =                        -14.8398465120106593
 
 Computation Completed
 
@@ -291,21 +294,24 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on DESKTOP-SQPD2D3 at Sun Aug  9 17:50:12 2020
+*** tstop() called on Yorks-Mac.local at Sat Jan 30 03:41:38 2021
 Module time:
-	user time   =       0.25 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.14 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.25 seconds =       0.00 minutes
-	system time =       0.02 seconds =       0.00 minutes
+	user time   =       0.14 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
+    SCF energy............................................................................PASSED
+
+Scratch directory: /Users/york/scratch/psi4/
 
   Forte
   ----------------------------------------------------------------------------
   A suite of quantum chemistry methods for strongly correlated electrons
 
-    git branch: gas-ci - git commit: d39916cc
+    git branch: relax_overlap - git commit: 416ba2ac
 
   Developed by:
     Francesco A. Evangelista, Chenyang Li, Kevin P. Hannon,
@@ -314,25 +320,26 @@ Total time:
   ----------------------------------------------------------------------------
 
   Size of Determinant class: 128 bits
-  Preparing forte objects from a psi4 Wavefunction object
-  No reference wavefunction provided. Computing SCF orbitals with psi4
 
-*** tstart() called on DESKTOP-SQPD2D3
-*** at Sun Aug  9 17:50:12 2020
+  Preparing forte objects from a Psi4 Wavefunction object
+  No reference wave function provided for Forte. Computing SCF orbitals using Psi4 ...
+
+*** tstart() called on Yorks-Mac.local
+*** at Sat Jan 30 03:41:38 2021
 
    => Loading Basis Set <=
 
     Name: DZ
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1-2 entry LI         line    20 file /home/mhuang/psi4_install/share/psi4/basis/dz.gbs 
+    atoms 1-2 entry LI         line    20 file /Users/york/src/psi4new/psi4/share/psi4/basis/dz.gbs 
 
 
          ---------------------------------------------------------
                                    SCF
                by Justin Turney, Rob Parrish, Andy Simmonett
                           and Daniel G. A. Smith
-                             ROHF Reference
+                              RHF Reference
                         1 Threads,    500 MiB Core
          ---------------------------------------------------------
 
@@ -369,7 +376,7 @@ Total time:
   Guess Type is GWH.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -380,23 +387,6 @@ Total time:
     Number of Cartesian functions: 20
     Spherical Harmonics?: false
     Max angular momentum: 1
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     Ag         6       6       0       0       0       0
-     B1g        0       0       0       0       0       0
-     B2g        2       2       0       0       0       0
-     B3g        2       2       0       0       0       0
-     Au         0       0       0       0       0       0
-     B1u        6       6       0       0       0       0
-     B2u        2       2       0       0       0       0
-     B3u        2       2       0       0       0       0
-   -------------------------------------------------------
-    Total      20      20       3       3       3       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -426,10 +416,28 @@ Total time:
 
     OpenMP threads:              1
 
-  Minimum eigenvalue in the overlap matrix is 1.9077688868E-03.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 6.5960170734E-03.
+  Reciprocal condition number of the overlap matrix is 1.7658990716E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Generalized Wolfsberg-Helmholtz.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     Ag         6       6       1       1       1       0
+     B1g        0       0       0       0       0       0
+     B2g        2       2       0       0       0       0
+     B3g        2       2       0       0       0       0
+     Au         0       0       0       0       0       0
+     B1u        6       6       2       2       2       0
+     B2u        2       2       0       0       0       0
+     B3u        2       2       0       0       0       0
+   -------------------------------------------------------
+    Total      20      20       3       3       3       0
+   -------------------------------------------------------
 
   ==> Iterations <==
 
@@ -438,18 +446,17 @@ Total time:
     Occupation by irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     2,    0,    0,    0,    0,    1,    0,    0 ]
-    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
 
-   @ROHF iter   1:   -13.86328592226849   -1.38633e+01   9.38367e-02 DIIS
-   @ROHF iter   2:   -14.83151256644319   -9.68227e-01   5.72002e-03 DIIS
-   @ROHF iter   3:   -14.83897650580173   -7.46394e-03   1.05869e-03 DIIS
-   @ROHF iter   4:   -14.83973801876337   -7.61513e-04   3.60085e-04 DIIS
-   @ROHF iter   5:   -14.83984352118058   -1.05502e-04   5.52298e-05 DIIS
-   @ROHF iter   6:   -14.83984643708391   -2.91590e-06   9.06964e-06 DIIS
-   @ROHF iter   7:   -14.83984651201011   -7.49262e-08   4.58804e-08 DIIS
-   @ROHF iter   8:   -14.83984651201066   -5.50671e-13   5.89178e-09 DIIS
-   @ROHF iter   9:   -14.83984651201067   -1.77636e-14   1.60078e-09 DIIS
-   @ROHF iter  10:   -14.83984651201068   -7.10543e-15   6.74059e-11 DIIS
+   @RHF iter   1:   -13.86328592226980   -1.38633e+01   1.32705e-01 DIIS
+   @RHF iter   2:   -14.83151256644317   -9.68227e-01   8.08932e-03 DIIS
+   @RHF iter   3:   -14.83897643446973   -7.46387e-03   1.49734e-03 DIIS
+   @RHF iter   4:   -14.83973856509425   -7.62131e-04   5.08047e-04 DIIS
+   @RHF iter   5:   -14.83984354512974   -1.04980e-04   7.77538e-05 DIIS
+   @RHF iter   6:   -14.83984644064840   -2.89552e-06   1.24963e-05 DIIS
+   @RHF iter   7:   -14.83984651200914   -7.13607e-08   7.92564e-08 DIIS
+   @RHF iter   8:   -14.83984651201062   -1.47260e-12   1.04058e-08 DIIS
+   @RHF iter   9:   -14.83984651201066   -4.08562e-14   2.68735e-09 DIIS
+   @RHF iter  10:   -14.83984651201067   -8.88178e-15   8.74417e-11 DIIS
   Energy and wave function converged.
 
 
@@ -462,13 +469,9 @@ Total time:
 
        1Ag    -2.470948     1B1u   -2.465815     2Ag    -0.194380  
 
-    Singly Occupied:                                                      
-
-    
-
     Virtual:                                                              
 
-       2B1u    0.012721     1B2u    0.026034     1B3u    0.026034  
+       2B1u    0.012721     1B3u    0.026034     1B2u    0.026034  
        3Ag     0.049075     1B2g    0.069563     1B3g    0.069563  
        3B1u    0.080420     4Ag     0.130086     2B2u    0.137741  
        2B3u    0.137741     5Ag     0.171764     2B2g    0.242777  
@@ -478,16 +481,15 @@ Total time:
     Final Occupation by Irrep:
              Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
     DOCC [     2,    0,    0,    0,    0,    1,    0,    0 ]
-    SOCC [     0,    0,    0,    0,    0,    0,    0,    0 ]
 
-  @ROHF Final Energy:   -14.83984651201068
+  @RHF Final Energy:   -14.83984651201067
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              2.3812974480149975
-    One-Electron Energy =                 -24.1800018423486165
-    Two-Electron Energy =                   6.9588578823229401
-    Total Energy =                        -14.8398465120106788
+    One-Electron Energy =                 -24.1800018421956899
+    Two-Electron Energy =                   6.9588578821700260
+    Total Energy =                        -14.8398465120106664
 
 Computation Completed
 
@@ -509,22 +511,15 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     0.0000     Total:     0.0000
 
 
-*** tstop() called on DESKTOP-SQPD2D3 at Sun Aug  9 17:50:12 2020
+*** tstop() called on Yorks-Mac.local at Sat Jan 30 03:41:38 2021
 Module time:
-	user time   =       0.09 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.36 seconds =       0.01 minutes
-	system time =       0.05 seconds =       0.00 minutes
+	user time   =       0.26 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
-   => Loading Basis Set <=
-
-    Name: STO-3G
-    Role: ORBITAL
-    Keyword: MINAO_BASIS
-    atoms 1-2 entry LI         line    31 file /home/mhuang/psi4_install/share/psi4/basis/sto-3g.gbs 
-
 
   Read options for space GAS1
   Read options for space GAS2
@@ -547,36 +542,80 @@ Total time:
     RESTRICTED_UOCC     0     0     0     0     0     0     0     0     0
     FROZEN_UOCC         0     0     0     0     0     0     0     0     0
     Total               6     0     2     2     0     6     2     2    20
-  -------------------------------------------------------------------------
+  -------------------------------------------------------------------------   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: MINAO_BASIS
+    atoms 1-2 entry LI         line    31 file /Users/york/src/psi4new/psi4/share/psi4/basis/sto-3g.gbs 
+
+
   Forte will use psi4 integrals
+
+  ==> Primary Basis Set Summary <==
+
+  Basis Set: DZ
+    Blend: DZ
+    Number of shells: 12
+    Number of basis function: 20
+    Number of Cartesian functions: 20
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+
+  JK created using conventional PK integrals
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              12
+      Number of primitives:             26
+      Number of atomic orbitals:        20
+      Number of basis functions:        20
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 44310 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              400
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+
 
   ==> Integral Transformation <==
 
-  Number of molecular orbitals:                    20
-  Number of correlated molecular orbitals:         20
-  Number of frozen occupied orbitals:               0
-  Number of frozen unoccupied orbitals:             0
-  Two-electron integral type:              Conventional
-
-
-  Overall Conventional Integrals timings
+  Number of molecular orbitals:                         20
+  Number of correlated molecular orbitals:              20
+  Number of frozen occupied orbitals:                    0
+  Number of frozen unoccupied orbitals:                  0
+  Two-electron integral type:                 Conventional
 
 
   Computing Conventional Integrals	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
 
-  Integral transformation done. 0.03912960 s
+  Integral transformation done. 0.01485273 s
   Reading the two-electron integrals from disk
   Size of two-electron integrals:   0.003576 GB
-  Timing for conventional integral transformation:            0.092 s.
+  Timing for conventional integral transformation:            0.031 s.
   Timing for freezing core and virtual orbitals:              0.000 s.
-  Conventional integrals take 0.09209320 s
+  Timing for computing conventional integrals:                0.031 s.
 
   ==> Summary of Active Space Solver Input <==
 
@@ -639,42 +678,57 @@ Total time:
   Number of active alpha electrons: 3
   Number of active beta electrons: 3
   Maximum reference space size: 1000
-  The maximum number of electrons in GAS1 is 6
-  The minimum number of electrons in GAS1 is 4
-  The maximum number of electrons in GAS2 is 2
-  The minimum number of electrons in GAS2 is 0
-  
-  Possible electron occupations in the GAS 
-  GAS1_A  GAS1_B  GAS2_A  GAS2_B  
-     3       3       0       0    
-     3       2       0       1    
-     3       1       0       2    
-     2       3       1       0    
-     2       2       1       1    
-     1       3       2       0    
 
-  GAS Orbital Energies
-  GAS   Energies    Orb 
-   1  -2.470947885  0 
-   1  -2.465815083  10 
-   1  -0.194380070  1 
-   1   0.012720773  11 
-   1   0.049074878  2 
-   1   0.069562788  6 
-   1   0.069562788  8 
-   1   0.080420422  12 
-   1   0.130086224  3 
-   1   0.171764484  4 
-   1   0.242776531  7 
-   1   0.242776531  9 
-   1   0.246003744  13 
-   1   0.480485865  14 
-   1   1.695539433  5 
-   1   1.801801669  15 
-   2   0.026034302  16 
-   2   0.026034302  18 
-   2   0.137740563  17 
-   2   0.137740563  19 
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1    -2.47094788      0
+     1    -0.19438007      1
+     1     0.04907488      2
+     1     0.13008622      3
+     1     0.17176448      4
+     1     1.69553943      5
+     1     0.06956279      6
+     1     0.24277653      7
+     1     0.06956279      8
+     1     0.24277653      9
+     1    -2.46581508     10
+     1     0.01272077     11
+     1     0.08042042     12
+     1     0.24600374     13
+     1     0.48048586     14
+     1     1.80180167     15
+     2     0.02603430     16
+     2     0.13774056     17
+     2     0.02603430     18
+     2     0.13774056     19
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    6    4
+      2    2    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B
+    ---------------------------
+         1     3    3    0    0
+         2     3    2    0    1
+         3     3    1    0    2
+         4     2    3    1    0
+         5     2    2    1    1
+         6     1    3    2    0
+    ---------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Reference determinant: |22000000002000000000>
 
   ---------------------------------- Cycle 0 -----------------------------------
 
@@ -686,17 +740,17 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.000031 s
-        β          0.000015 s
-        αα         0.000034 s
-        ββ         0.000017 s
-        αβ         0.000033 s
+        α          0.000006 s
+        β          0.000003 s
+        αα         0.000004 s
+        ββ         0.000003 s
+        αβ         0.000007 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Time spent diagonalizing H:   0.000612 s
+  Time spent diagonalizing H:   0.000115 s
 
     P-space  CI Energy Root   0        = -14.839846512011 Eh =   0.0000 eV, S^2 = 0.000000
 
@@ -704,13 +758,12 @@ Total time:
   ==> Finding the Q space <==
 
   Using SR screening algorithm
-  Time spent forming F space:             0.000693
-  Time spent merging thread F spaces:             0.000336
-  size of hash: 683
-  Time spent building sorting list: 0.000697
-  Size of F space: 683
+  Time spent forming F space:             0.000109
+  Time spent merging thread F spaces:             0.000070
+  Size of F space: 685
+  Time spent building sorting list: 0.000041
   Added 1 missing determinants in aimed selection.
-  Time spent building the model space: 0.002371
+  Time spent building the model space: 0.000413
 
   ==> Diagonalizing the Hamiltonian in the P + Q space <==
 
@@ -718,40 +771,44 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.000945 s
-        β          0.000883 s
-        αα         0.001020 s
-        ββ         0.001010 s
-        αβ         0.002701 s
+        α          0.000154 s
+        β          0.000154 s
+        αα         0.000157 s
+        ββ         0.000148 s
+        αβ         0.000391 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Total time spent diagonalizing H:   0.040154 s
+  Total time spent diagonalizing H:   0.004161 s
 
-    PQ-space CI Energy Root   0        = -14.887247841388 Eh =   0.0000 eV, S^2 = 0.000041
+    PQ-space CI Energy Root   0        = -14.887247841389 Eh =   0.0000 eV, S^2 = 0.000041
     PQ-space CI Energy + EPT2 Root   0 = -14.888239879644 Eh =   0.0000 eV
 
-  
-  GAS Contribution Analysis  
-  GAS contributions root 0: 
-  GAS1_A    GASI_B    GAS2_A    GAS2_B        Cont  
-     3         3         0         0        0.912951050  
-     3         2         0         1        0.000007246  
-     3         1         0         2        0.000000000  
-     2         3         1         0        0.000007246  
-     2         2         1         1        0.087034457  
-     1         3         2         0        0.000000000  
 
-           4                  2            0.087034457  
-           5                  1            0.000014493  
-           6                  0            0.912951050  
+  ==> GAS Contribution Analysis <==
 
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  Contribution
+    -----------------------------------------
+         1     3    3    0    0  91.29510499%
+         2     3    2    0    1   0.00072464%
+         3     3    1    0    2   0.00000000%
+         4     2    3    1    0   0.00072464%
+         5     2    2    1    1   8.70344574%
+         6     1    3    2    0   0.00000000%
+    -----------------------------------------
+               GAS1      GAS2    Contribution
+    -----------------------------------------
+                  4         2     8.70344574%
+                  5         1     0.00144927%
+                  6         0    91.29510499%
+    -----------------------------------------
 
   ==> Pruning the Q space <==
 
-  Cycle 0 took: 0.047155 s
+  Cycle 0 took: 0.005565 s
 
   ---------------------------------- Cycle 1 -----------------------------------
 
@@ -763,17 +820,17 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.000285 s
-        β          0.000268 s
-        αα         0.000319 s
-        ββ         0.000307 s
-        αβ         0.000875 s
+        α          0.000050 s
+        β          0.000051 s
+        αα         0.000050 s
+        ββ         0.000047 s
+        αβ         0.000132 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Time spent diagonalizing H:   0.007930 s
+  Time spent diagonalizing H:   0.000750 s
 
     P-space  CI Energy Root   0        = -14.883654851185 Eh =   0.0000 eV, S^2 = 0.000000
 
@@ -781,12 +838,11 @@ Total time:
   ==> Finding the Q space <==
 
   Using SR screening algorithm
-  Time spent forming F space:             0.020501
-  Time spent merging thread F spaces:             0.005024
-  size of hash: 11189
-  Time spent building sorting list: 0.010187
+  Time spent forming F space:             0.002567
+  Time spent merging thread F spaces:             0.001200
   Size of F space: 11189
-  Time spent building the model space: 0.043959
+  Time spent building sorting list: 0.000500
+  Time spent building the model space: 0.006954
 
   ==> Diagonalizing the Hamiltonian in the P + Q space <==
 
@@ -794,11 +850,11 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.001742 s
-        β          0.001734 s
-        αα         0.001993 s
-        ββ         0.001978 s
-        αβ         0.005329 s
+        α          0.000316 s
+        β          0.000319 s
+        αα         0.000315 s
+        ββ         0.000299 s
+        αβ         0.000812 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
@@ -836,32 +892,36 @@ Total time:
       5      -17.270450995445  +0.000e+00  +3.993e-04
   -----------------------------------------------------
   The Davidson-Liu algorithm converged in 6 iterations.
-  Davidson-Liu procedure took  0.028279 s
-  Total time spent diagonalizing H:   0.043113 s
+  Davidson-Liu procedure took  0.003058 s
+  Total time spent diagonalizing H:   0.005424 s
 
     PQ-space CI Energy Root   0        = -14.889153547430 Eh =   0.0000 eV, S^2 = 0.000084
     PQ-space CI Energy + EPT2 Root   0 = -14.890152622913 Eh =   0.0000 eV
 
-  
-  GAS Contribution Analysis  
-  GAS contributions root 0: 
-  GAS1_A    GASI_B    GAS2_A    GAS2_B        Cont  
-     3         3         0         0        0.902658718  
-     3         2         0         1        0.000007573  
-     3         1         0         2        0.000000000  
-     2         3         1         0        0.000007573  
-     2         2         1         1        0.097326136  
-     1         3         2         0        0.000000000  
 
-           4                  2            0.097326136  
-           5                  1            0.000015146  
-           6                  0            0.902658718  
+  ==> GAS Contribution Analysis <==
 
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  Contribution
+    -----------------------------------------
+         1     3    3    0    0  90.26587180%
+         2     3    2    0    1   0.00075730%
+         3     3    1    0    2   0.00000000%
+         4     2    3    1    0   0.00075730%
+         5     2    2    1    1   9.73261361%
+         6     1    3    2    0   0.00000000%
+    -----------------------------------------
+               GAS1      GAS2    Contribution
+    -----------------------------------------
+                  4         2     9.73261361%
+                  5         1     0.00151460%
+                  6         0    90.26587180%
+    -----------------------------------------
 
   ==> Pruning the Q space <==
 
   Added 1 missing determinants in aimed selection.
-  Cycle 1 took: 0.101744 s
+  Cycle 1 took: 0.014687 s
 
   ---------------------------------- Cycle 2 -----------------------------------
 
@@ -873,17 +933,17 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.000380 s
-        β          0.000329 s
-        αα         0.000389 s
-        ββ         0.000357 s
-        αβ         0.001028 s
+        α          0.000062 s
+        β          0.000061 s
+        αα         0.000061 s
+        ββ         0.000059 s
+        αβ         0.000167 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Time spent diagonalizing H:   0.011677 s
+  Time spent diagonalizing H:   0.001003 s
 
     P-space  CI Energy Root   0        = -14.884019633131 Eh =   0.0000 eV, S^2 = 0.000000
 
@@ -891,13 +951,12 @@ Total time:
   ==> Finding the Q space <==
 
   Using SR screening algorithm
-  Time spent forming F space:             0.025146
-  Time spent merging thread F spaces:             0.005258
-  size of hash: 12211
-  Time spent building sorting list: 0.010409
+  Time spent forming F space:             0.003020
+  Time spent merging thread F spaces:             0.001308
   Size of F space: 12211
+  Time spent building sorting list: 0.000545
   Added 1 missing determinants in aimed selection.
-  Time spent building the model space: 0.049623
+  Time spent building the model space: 0.008047
 
   ==> Diagonalizing the Hamiltonian in the P + Q space <==
 
@@ -905,11 +964,11 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.001689 s
-        β          0.001696 s
-        αα         0.001920 s
-        ββ         0.001971 s
-        αβ         0.005027 s
+        α          0.000344 s
+        β          0.000349 s
+        αα         0.000341 s
+        ββ         0.000320 s
+        αβ         0.000865 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
@@ -947,32 +1006,36 @@ Total time:
       5      -17.270464392321  +0.000e+00  +4.042e-04
   -----------------------------------------------------
   The Davidson-Liu algorithm converged in 6 iterations.
-  Davidson-Liu procedure took  0.026993 s
-  Total time spent diagonalizing H:   0.041193 s
+  Davidson-Liu procedure took  0.002979 s
+  Total time spent diagonalizing H:   0.005522 s
 
     PQ-space CI Energy Root   0        = -14.889166944306 Eh =   0.0000 eV, S^2 = 0.000098
     PQ-space CI Energy + EPT2 Root   0 = -14.890163810516 Eh =   0.0000 eV
 
-  
-  GAS Contribution Analysis  
-  GAS contributions root 0: 
-  GAS1_A    GASI_B    GAS2_A    GAS2_B        Cont  
-     3         3         0         0        0.902723575  
-     3         2         0         1        0.000007575  
-     3         1         0         2        0.000000000  
-     2         3         1         0        0.000007575  
-     2         2         1         1        0.097261274  
-     1         3         2         0        0.000000000  
 
-           4                  2            0.097261274  
-           5                  1            0.000015151  
-           6                  0            0.902723575  
+  ==> GAS Contribution Analysis <==
 
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  Contribution
+    -----------------------------------------
+         1     3    3    0    0  90.27235752%
+         2     3    2    0    1   0.00075754%
+         3     3    1    0    2   0.00000000%
+         4     2    3    1    0   0.00075754%
+         5     2    2    1    1   9.72612740%
+         6     1    3    2    0   0.00000000%
+    -----------------------------------------
+               GAS1      GAS2    Contribution
+    -----------------------------------------
+                  4         2     9.72612740%
+                  5         1     0.00151509%
+                  6         0    90.27235752%
+    -----------------------------------------
 
   ==> Pruning the Q space <==
 
   Added 1 missing determinants in aimed selection.
-  Cycle 2 took: 0.109029 s
+  Cycle 2 took: 0.016094 s
 
   ---------------------------------- Cycle 3 -----------------------------------
 
@@ -984,17 +1047,17 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.000321 s
-        β          0.000311 s
-        αα         0.000367 s
-        ββ         0.000343 s
-        αβ         0.000990 s
+        α          0.000063 s
+        β          0.000063 s
+        αα         0.000062 s
+        ββ         0.000060 s
+        αβ         0.000169 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Time spent diagonalizing H:   0.011021 s
+  Time spent diagonalizing H:   0.001001 s
 
     P-space  CI Energy Root   0        = -14.884019633131 Eh =   0.0000 eV, S^2 = 0.000000
 
@@ -1002,13 +1065,12 @@ Total time:
   ==> Finding the Q space <==
 
   Using SR screening algorithm
-  Time spent forming F space:             0.024930
-  Time spent merging thread F spaces:             0.005227
-  size of hash: 12211
-  Time spent building sorting list: 0.010456
+  Time spent forming F space:             0.003107
+  Time spent merging thread F spaces:             0.001320
   Size of F space: 12211
+  Time spent building sorting list: 0.000547
   Added 1 missing determinants in aimed selection.
-  Time spent building the model space: 0.049378
+  Time spent building the model space: 0.007992
 
   ==> Diagonalizing the Hamiltonian in the P + Q space <==
 
@@ -1016,11 +1078,11 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.001680 s
-        β          0.001699 s
-        αα         0.001934 s
-        ββ         0.001928 s
-        αβ         0.005315 s
+        α          0.000345 s
+        β          0.000347 s
+        αα         0.000334 s
+        ββ         0.000315 s
+        αβ         0.000807 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
@@ -1058,27 +1120,31 @@ Total time:
       5      -17.270464392321  +0.000e+00  +4.042e-04
   -----------------------------------------------------
   The Davidson-Liu algorithm converged in 6 iterations.
-  Davidson-Liu procedure took  0.026718 s
-  Total time spent diagonalizing H:   0.041258 s
+  Davidson-Liu procedure took  0.003050 s
+  Total time spent diagonalizing H:   0.005498 s
 
     PQ-space CI Energy Root   0        = -14.889166944306 Eh =   0.0000 eV, S^2 = 0.000098
     PQ-space CI Energy + EPT2 Root   0 = -14.890163810516 Eh =   0.0000 eV
 
-  
-  GAS Contribution Analysis  
-  GAS contributions root 0: 
-  GAS1_A    GASI_B    GAS2_A    GAS2_B        Cont  
-     3         3         0         0        0.902723575  
-     3         2         0         1        0.000007575  
-     3         1         0         2        0.000000000  
-     2         3         1         0        0.000007575  
-     2         2         1         1        0.097261274  
-     1         3         2         0        0.000000000  
 
-           4                  2            0.097261274  
-           5                  1            0.000015151  
-           6                  0            0.902723575  
+  ==> GAS Contribution Analysis <==
 
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  Contribution
+    -----------------------------------------
+         1     3    3    0    0  90.27235752%
+         2     3    2    0    1   0.00075754%
+         3     3    1    0    2   0.00000000%
+         4     2    3    1    0   0.00075754%
+         5     2    2    1    1   9.72612740%
+         6     1    3    2    0   0.00000000%
+    -----------------------------------------
+               GAS1      GAS2    Contribution
+    -----------------------------------------
+                  4         2     9.72612740%
+                  5         1     0.00151509%
+                  6         0    90.27235752%
+    -----------------------------------------
   ***** Calculation Converged *****
 
   ==> ACI Natural Orbitals <==
@@ -1086,14 +1152,14 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.001729 s
-        β          0.001743 s
+        α          0.000347 s
+        β          0.000343 s
         1Ag     1.997677      1B1u    1.997660      2Ag     1.770717  
         1B3u    0.097252      1B2u    0.097252      3Ag     0.018308  
         2B1u    0.016493      3B1u    0.002183      4Ag     0.002178  
         5Ag     0.000084      4B1u    0.000065      6Ag     0.000026  
         5B1u    0.000024      1B3g    0.000023      1B2g    0.000023  
-        2B2u    0.000017      2B3u    0.000017      6B1u    0.000002  
+        2B3u    0.000017      2B2u    0.000017      6B1u    0.000002  
         2B3g    0.000000      2B2g    0.000000  
 
   ==> Excited state solver summary <==
@@ -1108,10 +1174,10 @@ Total time:
 
   Most important contributions to root   0:
     0  -0.939519 0.882695916          46 |22000000002000000000>
-    1   0.149833 0.022450019          45 |20000000002000000020>
-    2   0.149833 0.022450019          44 |20000000002000002000>
-    3   0.102299 0.010465171          43 |200000000020000000-+>
-    4   0.102299 0.010465171          42 |200000000020000000+->
+    1   0.149833 0.022450019          44 |20000000002000002000>
+    2   0.149833 0.022450019          45 |20000000002000000020>
+    3   0.102299 0.010465171          42 |200000000020000000-+>
+    4   0.102299 0.010465171          43 |200000000020000000+->
     5   0.102299 0.010465171          40 |2000000000200000-+00>
     6   0.102299 0.010465171          41 |2000000000200000+-00>
     7   0.071788 0.005153568          39 |20000000002000000002>
@@ -1127,12 +1193,12 @@ Total time:
        1  (  0)    Ag     0      -14.889166944306
     ---------------------------------------------
 
-  Time to prepare integrals:        0.105 seconds
-  Time to run job          :        0.459 seconds
-  Total                    :        0.459 seconds	ACI energy........................................................PASSED
-	ACI+PT2 energy....................................................PASSED
+  Time to prepare integrals:        0.049 seconds
+  Time to run job          :        0.067 seconds
+  Total                    :        0.116 seconds    ACI energy............................................................................PASSED
+    ACI+PT2 energy........................................................................PASSED
 
-    Psi4 stopped on: Sunday, 09 August 2020 05:50PM
-    Psi4 wall time for execution: 0:00:01.11
+    Psi4 stopped on: Saturday, 30 January 2021 03:41AM
+    Psi4 wall time for execution: 0:00:00.43
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/methods/gasaci-4/output.ref
+++ b/tests/methods/gasaci-4/output.ref
@@ -3,31 +3,38 @@
           Psi4: An Open-Source Ab Initio Electronic Structure Package
                                Psi4 undefined 
 
-                         Git: Rev {master} 45315cb dirty
+                         Git: Rev {x2c-norm} b906495 
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
 
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
 
-                         Additional Contributions by
-    P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, R. A. Shaw,
-    A. Alenaizan, R. Galvelis, Z. L. Glick, S. Lehtola, and J. P. Misiewicz
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Tuesday, 11 August 2020 10:14AM
+    Psi4 started on: Saturday, 30 January 2021 03:41AM
 
-    Process ID: 12784
-    Host:       DESKTOP-SQPD2D3
-    PSIDATADIR: /home/mhuang/psi4_install/share/psi4
+    Process ID: 63897
+    Host:       Yorks-Mac.local
+    PSIDATADIR: /Users/york/src/psi4new/psi4/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -72,12 +79,12 @@ set forte {
   charge 0
   sci_enforce_spin_complete true
   active_ref_type gas_single
-  aci_screen_alg MULTI_GAS
   charge 0
   GAS1 [1,0,0,0]
   GAS2 [5,0,2,2]
   AVG_STATE [[0,1,1],[2,1,1]]
-  GAS1MAX_MULTI [[0,1,2],[2,1,1]]
+  GAS1MAX [2,1]
+  aci_n_average 2
 }
 
 escf ,wfn = energy('scf',return_wfn = True)
@@ -90,16 +97,18 @@ compare_values(aveaci, ave_e, 9, "AVERAGE ACI ENERGY") #TEST
 
   Memory set to   5.588 GiB by Python driver.
 
-*** tstart() called on DESKTOP-SQPD2D3
-*** at Tue Aug 11 10:14:10 2020
+Scratch directory: /Users/york/scratch/psi4/
+
+*** tstart() called on Yorks-Mac.local
+*** at Sat Jan 30 03:41:47 2021
 
    => Loading Basis Set <=
 
     Name: 6-31G**
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry C          line   115 file /home/mhuang/psi4_install/share/psi4/basis/6-31gss.gbs 
-    atoms 2 entry O          line   149 file /home/mhuang/psi4_install/share/psi4/basis/6-31gss.gbs 
+    atoms 1 entry C          line   115 file /Users/york/src/psi4new/psi4/share/psi4/basis/6-31gss.gbs 
+    atoms 2 entry O          line   149 file /Users/york/src/psi4new/psi4/share/psi4/basis/6-31gss.gbs 
 
 
          ---------------------------------------------------------
@@ -126,7 +135,7 @@ compare_values(aveaci, ave_e, 9, "AVERAGE ACI ENERGY") #TEST
 
   Rotational constants: A = ************  B =      1.94718  C =      1.94718 [cm^-1]
   Rotational constants: A = ************  B =  58374.91066  C =  58374.91066 [MHz]
-  Nuclear repulsion =   22.604187308589065
+  Nuclear repulsion =   22.604187308589072
 
   Charge       = 0
   Multiplicity = 1
@@ -143,7 +152,7 @@ compare_values(aveaci, ave_e, 9, "AVERAGE ACI ENERGY") #TEST
   Guess Type is GWH.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -154,19 +163,6 @@ compare_values(aveaci, ave_e, 9, "AVERAGE ACI ENERGY") #TEST
     Number of Cartesian functions: 30
     Spherical Harmonics?: false
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        16      16       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         6       6       0       0       0       0
-     B2         6       6       0       0       0       0
-   -------------------------------------------------------
-    Total      30      30       7       7       7       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -197,27 +193,41 @@ compare_values(aveaci, ave_e, 9, "AVERAGE ACI ENERGY") #TEST
     OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 7.6561678406E-03.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.4485031790E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Generalized Wolfsberg-Helmholtz.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        16      16       5       5       5       0
+     A2         2       2       0       0       0       0
+     B1         6       6       1       1       1       0
+     B2         6       6       1       1       1       0
+   -------------------------------------------------------
+    Total      30      30       7       7       7       0
+   -------------------------------------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @ROHF iter   1:  -111.55875766978518   -1.11559e+02   7.47973e-02 DIIS
-   @ROHF iter   2:  -112.25282615537445   -6.94068e-01   4.55450e-02 DIIS
-   @ROHF iter   3:  -112.68232123436239   -4.29495e-01   1.48650e-02 DIIS
-   @ROHF iter   4:  -112.73739759824976   -5.50764e-02   7.16915e-04 DIIS
-   @ROHF iter   5:  -112.73760131665766   -2.03718e-04   1.49149e-04 DIIS
-   @ROHF iter   6:  -112.73761091467038   -9.59801e-06   1.26205e-05 DIIS
-   @ROHF iter   7:  -112.73761100863281   -9.39624e-08   2.36513e-06 DIIS
-   @ROHF iter   8:  -112.73761101088711   -2.25430e-09   5.73508e-07 DIIS
-   @ROHF iter   9:  -112.73761101102265   -1.35543e-10   1.77318e-07 DIIS
-   @ROHF iter  10:  -112.73761101103840   -1.57456e-11   2.13186e-08 DIIS
-   @ROHF iter  11:  -112.73761101103851   -1.13687e-13   1.43484e-09 DIIS
-   @ROHF iter  12:  -112.73761101103857   -5.68434e-14   2.66319e-10 DIIS
-   @ROHF iter  13:  -112.73761101103857    0.00000e+00   1.51116e-11 DIIS
+   @ROHF iter   1:  -111.55875766978539   -1.11559e+02   7.47973e-02 DIIS
+   @ROHF iter   2:  -112.25282615537458   -6.94068e-01   4.55450e-02 DIIS
+   @ROHF iter   3:  -112.68232123436255   -4.29495e-01   1.48650e-02 DIIS
+   @ROHF iter   4:  -112.73739759824997   -5.50764e-02   7.16915e-04 DIIS
+   @ROHF iter   5:  -112.73760131665779   -2.03718e-04   1.49149e-04 DIIS
+   @ROHF iter   6:  -112.73761091467054   -9.59801e-06   1.26205e-05 DIIS
+   @ROHF iter   7:  -112.73761100863288   -9.39623e-08   2.36513e-06 DIIS
+   @ROHF iter   8:  -112.73761101088721   -2.25432e-09   5.73508e-07 DIIS
+   @ROHF iter   9:  -112.73761101102286   -1.35657e-10   1.77318e-07 DIIS
+   @ROHF iter  10:  -112.73761101103844   -1.55751e-11   2.13186e-08 DIIS
+   @ROHF iter  11:  -112.73761101103864   -1.98952e-13   1.43484e-09 DIIS
+   @ROHF iter  12:  -112.73761101103867   -2.84217e-14   2.66320e-10 DIIS
+   @ROHF iter  13:  -112.73761101103869   -2.84217e-14   1.51114e-11 DIIS
   Energy and wave function converged.
 
 
@@ -240,9 +250,9 @@ compare_values(aveaci, ave_e, 9, "AVERAGE ACI ENERGY") #TEST
 
        2B1     0.163685     2B2     0.163685     6A1     0.409061  
        3B1     0.733489     3B2     0.733489     7A1     0.758352  
-       8A1     0.995752     9A1     1.103683     4B2     1.207063  
-       4B1     1.207063    10A1     1.611233     1A2     1.747874  
-      11A1     1.747874     5B1     1.848075     5B2     1.848075  
+       8A1     0.995752     9A1     1.103683     4B1     1.207063  
+       4B2     1.207063    10A1     1.611233    11A1     1.747874  
+       1A2     1.747874     5B1     1.848075     5B2     1.848075  
        2A2     2.264383    12A1     2.264383    13A1     2.782669  
        6B2     2.957883     6B1     2.957883    14A1     3.360305  
       15A1     4.103048    16A1     4.302533  
@@ -252,14 +262,14 @@ compare_values(aveaci, ave_e, 9, "AVERAGE ACI ENERGY") #TEST
     DOCC [     5,    0,    1,    1 ]
     SOCC [     0,    0,    0,    0 ]
 
-  @ROHF Final Energy:  -112.73761101103857
+  @ROHF Final Energy:  -112.73761101103869
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             22.6041873085890650
-    One-Electron Energy =                -198.3428006717377627
-    Two-Electron Energy =                  63.0010023521101346
-    Total Energy =                       -112.7376110110385525
+    Nuclear Repulsion Energy =             22.6041873085890721
+    One-Electron Energy =                -198.3428006717379617
+    Two-Electron Energy =                  63.0010023521101985
+    Total Energy =                       -112.7376110110386946
 
 Computation Completed
 
@@ -281,25 +291,25 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:    -0.3109     Total:     0.3109
 
 
-*** tstop() called on DESKTOP-SQPD2D3 at Tue Aug 11 10:14:11 2020
+*** tstop() called on Yorks-Mac.local at Sat Jan 30 03:41:47 2021
 Module time:
-	user time   =       0.16 seconds =       0.00 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.16 seconds =       0.00 minutes
-	system time =       0.05 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 
- Data is an array -> call again
- Data is an array -> call again
+Scratch directory: /Users/york/scratch/psi4/
+
  Data is an array -> call again
  Data is an array -> call again
   Forte
   ----------------------------------------------------------------------------
   A suite of quantum chemistry methods for strongly correlated electrons
 
-    git branch: gas-ci - git commit: 3d8a6e74
+    git branch: relax_overlap - git commit: 416ba2ac
 
   Developed by:
     Francesco A. Evangelista, Chenyang Li, Kevin P. Hannon,
@@ -308,19 +318,20 @@ Total time:
   ----------------------------------------------------------------------------
 
   Size of Determinant class: 128 bits
-  Preparing forte objects from a psi4 Wavefunction object
-  No reference wavefunction provided. Computing SCF orbitals with psi4
 
-*** tstart() called on DESKTOP-SQPD2D3
-*** at Tue Aug 11 10:14:11 2020
+  Preparing forte objects from a Psi4 Wavefunction object
+  No reference wave function provided for Forte. Computing SCF orbitals using Psi4 ...
+
+*** tstart() called on Yorks-Mac.local
+*** at Sat Jan 30 03:41:47 2021
 
    => Loading Basis Set <=
 
     Name: 6-31G**
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1 entry C          line   115 file /home/mhuang/psi4_install/share/psi4/basis/6-31gss.gbs 
-    atoms 2 entry O          line   149 file /home/mhuang/psi4_install/share/psi4/basis/6-31gss.gbs 
+    atoms 1 entry C          line   115 file /Users/york/src/psi4new/psi4/share/psi4/basis/6-31gss.gbs 
+    atoms 2 entry O          line   149 file /Users/york/src/psi4new/psi4/share/psi4/basis/6-31gss.gbs 
 
 
          ---------------------------------------------------------
@@ -347,7 +358,7 @@ Total time:
 
   Rotational constants: A = ************  B =      1.94718  C =      1.94718 [cm^-1]
   Rotational constants: A = ************  B =  58374.91066  C =  58374.91066 [MHz]
-  Nuclear repulsion =   22.604187308589065
+  Nuclear repulsion =   22.604187308589072
 
   Charge       = 0
   Multiplicity = 1
@@ -364,7 +375,7 @@ Total time:
   Guess Type is GWH.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -375,19 +386,6 @@ Total time:
     Number of Cartesian functions: 30
     Spherical Harmonics?: false
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        16      16       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         6       6       0       0       0       0
-     B2         6       6       0       0       0       0
-   -------------------------------------------------------
-    Total      30      30       7       7       7       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -418,27 +416,41 @@ Total time:
     OpenMP threads:              1
 
   Minimum eigenvalue in the overlap matrix is 7.6561678406E-03.
-  Using Symmetric Orthogonalization.
+  Reciprocal condition number of the overlap matrix is 1.4485031790E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Generalized Wolfsberg-Helmholtz.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        16      16       5       5       5       0
+     A2         2       2       0       0       0       0
+     B1         6       6       1       1       1       0
+     B2         6       6       1       1       1       0
+   -------------------------------------------------------
+    Total      30      30       7       7       7       0
+   -------------------------------------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @ROHF iter   1:  -111.55875766978518   -1.11559e+02   7.47973e-02 DIIS
-   @ROHF iter   2:  -112.25282615537445   -6.94068e-01   4.55450e-02 DIIS
-   @ROHF iter   3:  -112.68232123436239   -4.29495e-01   1.48650e-02 DIIS
-   @ROHF iter   4:  -112.73739759824976   -5.50764e-02   7.16915e-04 DIIS
-   @ROHF iter   5:  -112.73760131665766   -2.03718e-04   1.49149e-04 DIIS
-   @ROHF iter   6:  -112.73761091467038   -9.59801e-06   1.26205e-05 DIIS
-   @ROHF iter   7:  -112.73761100863281   -9.39624e-08   2.36513e-06 DIIS
-   @ROHF iter   8:  -112.73761101088711   -2.25430e-09   5.73508e-07 DIIS
-   @ROHF iter   9:  -112.73761101102265   -1.35543e-10   1.77318e-07 DIIS
-   @ROHF iter  10:  -112.73761101103840   -1.57456e-11   2.13186e-08 DIIS
-   @ROHF iter  11:  -112.73761101103851   -1.13687e-13   1.43484e-09 DIIS
-   @ROHF iter  12:  -112.73761101103857   -5.68434e-14   2.66319e-10 DIIS
-   @ROHF iter  13:  -112.73761101103857    0.00000e+00   1.51116e-11 DIIS
+   @ROHF iter   1:  -111.55875766978539   -1.11559e+02   7.47973e-02 DIIS
+   @ROHF iter   2:  -112.25282615537458   -6.94068e-01   4.55450e-02 DIIS
+   @ROHF iter   3:  -112.68232123436255   -4.29495e-01   1.48650e-02 DIIS
+   @ROHF iter   4:  -112.73739759824997   -5.50764e-02   7.16915e-04 DIIS
+   @ROHF iter   5:  -112.73760131665779   -2.03718e-04   1.49149e-04 DIIS
+   @ROHF iter   6:  -112.73761091467054   -9.59801e-06   1.26205e-05 DIIS
+   @ROHF iter   7:  -112.73761100863288   -9.39623e-08   2.36513e-06 DIIS
+   @ROHF iter   8:  -112.73761101088721   -2.25432e-09   5.73508e-07 DIIS
+   @ROHF iter   9:  -112.73761101102286   -1.35657e-10   1.77318e-07 DIIS
+   @ROHF iter  10:  -112.73761101103844   -1.55751e-11   2.13186e-08 DIIS
+   @ROHF iter  11:  -112.73761101103864   -1.98952e-13   1.43484e-09 DIIS
+   @ROHF iter  12:  -112.73761101103867   -2.84217e-14   2.66320e-10 DIIS
+   @ROHF iter  13:  -112.73761101103869   -2.84217e-14   1.51114e-11 DIIS
   Energy and wave function converged.
 
 
@@ -461,9 +473,9 @@ Total time:
 
        2B1     0.163685     2B2     0.163685     6A1     0.409061  
        3B1     0.733489     3B2     0.733489     7A1     0.758352  
-       8A1     0.995752     9A1     1.103683     4B2     1.207063  
-       4B1     1.207063    10A1     1.611233     1A2     1.747874  
-      11A1     1.747874     5B1     1.848075     5B2     1.848075  
+       8A1     0.995752     9A1     1.103683     4B1     1.207063  
+       4B2     1.207063    10A1     1.611233    11A1     1.747874  
+       1A2     1.747874     5B1     1.848075     5B2     1.848075  
        2A2     2.264383    12A1     2.264383    13A1     2.782669  
        6B2     2.957883     6B1     2.957883    14A1     3.360305  
       15A1     4.103048    16A1     4.302533  
@@ -473,14 +485,14 @@ Total time:
     DOCC [     5,    0,    1,    1 ]
     SOCC [     0,    0,    0,    0 ]
 
-  @ROHF Final Energy:  -112.73761101103857
+  @ROHF Final Energy:  -112.73761101103869
 
    => Energetics <=
 
-    Nuclear Repulsion Energy =             22.6041873085890650
-    One-Electron Energy =                -198.3428006717377627
-    Two-Electron Energy =                  63.0010023521101346
-    Total Energy =                       -112.7376110110385525
+    Nuclear Repulsion Energy =             22.6041873085890721
+    One-Electron Energy =                -198.3428006717379617
+    Two-Electron Energy =                  63.0010023521101985
+    Total Energy =                       -112.7376110110386946
 
 Computation Completed
 
@@ -502,23 +514,15 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:    -0.3109     Total:     0.3109
 
 
-*** tstop() called on DESKTOP-SQPD2D3 at Tue Aug 11 10:14:11 2020
+*** tstop() called on Yorks-Mac.local at Sat Jan 30 03:41:48 2021
 Module time:
-	user time   =       0.09 seconds =       0.00 minutes
-	system time =       0.08 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
-Total time:
-	user time   =       0.25 seconds =       0.00 minutes
-	system time =       0.13 seconds =       0.00 minutes
+	user time   =       0.08 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          1 seconds =       0.02 minutes
-   => Loading Basis Set <=
-
-    Name: STO-3G
-    Role: ORBITAL
-    Keyword: MINAO_BASIS
-    atoms 1 entry C          line    61 file /home/mhuang/psi4_install/share/psi4/basis/sto-3g.gbs 
-    atoms 2 entry O          line    81 file /home/mhuang/psi4_install/share/psi4/basis/sto-3g.gbs 
-
+Total time:
+	user time   =       0.18 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 
   Read options for space GAS1
   Read options for space GAS2
@@ -541,36 +545,81 @@ Total time:
     RESTRICTED_UOCC    10     2     4     4    20
     FROZEN_UOCC         0     0     0     0     0
     Total              16     2     6     6    30
-  -------------------------------------------------
+  -------------------------------------------------   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: MINAO_BASIS
+    atoms 1 entry C          line    61 file /Users/york/src/psi4new/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2 entry O          line    81 file /Users/york/src/psi4new/psi4/share/psi4/basis/sto-3g.gbs 
+
+
   Forte will use psi4 integrals
+
+  ==> Primary Basis Set Summary <==
+
+  Basis Set: 6-31G**
+    Blend: 6-31G**
+    Number of shells: 12
+    Number of basis function: 30
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+
+  JK created using conventional PK integrals
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   2
+      Number of AO shells:              12
+      Number of primitives:             30
+      Number of atomic orbitals:        30
+      Number of basis functions:        30
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 216690 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:             4577
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+
 
   ==> Integral Transformation <==
 
-  Number of molecular orbitals:                    30
-  Number of correlated molecular orbitals:         30
-  Number of frozen occupied orbitals:               0
-  Number of frozen unoccupied orbitals:             0
-  Two-electron integral type:              Conventional
-
-
-  Overall Conventional Integrals timings
+  Number of molecular orbitals:                         30
+  Number of correlated molecular orbitals:              30
+  Number of frozen occupied orbitals:                    0
+  Number of frozen unoccupied orbitals:                  0
+  Two-electron integral type:                 Conventional
 
 
   Computing Conventional Integrals	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
 
-  Integral transformation done. 0.06999330 s
+  Integral transformation done. 0.02112085 s
   Reading the two-electron integrals from disk
   Size of two-electron integrals:   0.018105 GB
-  Timing for conventional integral transformation:            0.181 s.
+  Timing for conventional integral transformation:            0.048 s.
   Timing for freezing core and virtual orbitals:              0.000 s.
-  Conventional integrals take 0.18163560 s
+  Timing for computing conventional integrals:                0.048 s.
 
   ==> Summary of Active Space Solver Input <==
 
@@ -634,30 +683,45 @@ Total time:
   Number of active alpha electrons: 7
   Number of active beta electrons: 7
   Maximum reference space size: 1000
-  The maximum number of electrons in GAS1 is 2
-  The minimum number of electrons in GAS1 is 0
-  The maximum number of electrons in GAS2 is 14 
-  The minimum number of electrons in GAS2 is 0
-  
-  Possible electron occupations in the GAS 
-  GAS1_A  GAS1_B  GAS2_A  GAS2_B  
-     1       1       6       6    
-     1       0       6       7    
-     0       1       7       6    
-     0       0       7       7    
 
-  GAS Orbital Energies
-  GAS   Energies    Orb 
-   1  -20.675093265  0 
-   2  -11.359271820  1 
-   2  -1.522248358  2 
-   2  -0.796930857  3 
-   2  -0.634858118  6 
-   2  -0.634858118  8 
-   2  -0.547137448  4 
-   2   0.163684976  7 
-   2   0.163684976  9 
-   2   0.409060657  5 
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.67509326      0
+     2   -11.35927182      1
+     2    -1.52224836      2
+     2    -0.79693086      3
+     2    -0.54713745      4
+     2     0.40906066      5
+     2    -0.63485812      6
+     2     0.16368498      7
+     2    -0.63485812      8
+     2     0.16368498      9
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    0
+      2   14    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B
+    ---------------------------
+         1     1    1    6    6
+         2     1    0    6    7
+         3     0    1    7    6
+         4     0    0    7    7
+    ---------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Reference determinant: |2222202020>
 
   ---------------------------------- Cycle 0 -----------------------------------
 
@@ -669,31 +733,30 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.000052 s
-        β          0.000019 s
-        αα         0.000063 s
-        ββ         0.000051 s
-        αβ         0.000106 s
+        α          0.000010 s
+        β          0.000005 s
+        αα         0.000012 s
+        ββ         0.000010 s
+        αβ         0.000026 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Time spent diagonalizing H:   0.000784 s
+  Time spent diagonalizing H:   0.000182 s
 
-    P-space  CI Energy Root   0        = -112.737611011038 Eh =   0.0000 eV, S^2 = 0.000000
+    P-space  CI Energy Root   0        = -112.737611011039 Eh =   0.0000 eV, S^2 = 0.000000
 
 
   ==> Finding the Q space <==
 
-  Using MULTI_GAS screening algorithm
-  Time spent forming F space:             0.000290
-  Time spent merging thread F spaces:             0.000108
-  size of hash: 157
-  Time spent building sorting list: 0.000699
+  Using SR screening algorithm
+  Time spent forming F space:             0.000048
+  Time spent merging thread F spaces:             0.000023
   Size of F space: 157
+  Time spent building sorting list: 0.000026
   Added 1 missing determinants in aimed selection.
-  Time spent building the model space: 0.001549
+  Time spent building the model space: 0.000181
   Spin-complete dimension of the PQ space: 53
 
   ==> Diagonalizing the Hamiltonian in the P + Q space <==
@@ -702,26 +765,43 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.000961 s
-        β          0.000662 s
-        αα         0.005013 s
-        ββ         0.002140 s
-        αβ         0.015347 s
+        α          0.000153 s
+        β          0.000151 s
+        αα         0.000388 s
+        ββ         0.000379 s
+        αβ         0.000980 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Total time spent diagonalizing H:   0.035635 s
+  Total time spent diagonalizing H:   0.003188 s
 
     PQ-space CI Energy Root   0        = -112.790124530582 Eh =   0.0000 eV, S^2 = 0.000000
     PQ-space CI Energy + EPT2 Root   0 = -112.791052248150 Eh =   0.0000 eV
 
 
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  Contribution
+    -----------------------------------------
+         1     1    1    6    6 100.00000000%
+         2     1    0    6    7   0.00000000%
+         3     0    1    7    6   0.00000000%
+         4     0    0    7    7   0.00000000%
+    -----------------------------------------
+               GAS1      GAS2    Contribution
+    -----------------------------------------
+                  0        14     0.00000000%
+                  1        13     0.00000000%
+                  2        12   100.00000000%
+    -----------------------------------------
+
   ==> Pruning the Q space <==
 
   Added 1 missing determinants in aimed selection.
-  Cycle 0 took: 0.039349 s
+  Cycle 0 took: 0.004177 s
 
   ---------------------------------- Cycle 1 -----------------------------------
 
@@ -733,31 +813,30 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.000695 s
-        β          0.000999 s
-        αα         0.004723 s
-        ββ         0.001864 s
-        αβ         0.005416 s
+        α          0.000127 s
+        β          0.000125 s
+        αα         0.000311 s
+        ββ         0.000304 s
+        αβ         0.000792 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Time spent diagonalizing H:   0.020492 s
+  Time spent diagonalizing H:   0.002153 s
 
-    P-space  CI Energy Root   0        = -112.789304789928 Eh =   0.0000 eV, S^2 = -0.000000
+    P-space  CI Energy Root   0        = -112.789304789929 Eh =   0.0000 eV, S^2 = 0.000000
 
 
   ==> Finding the Q space <==
 
-  Using MULTI_GAS screening algorithm
-  Time spent forming F space:             0.014712
-  Time spent merging thread F spaces:             0.001193
-  size of hash: 1724
-  Time spent building sorting list: 0.012909
+  Using SR screening algorithm
+  Time spent forming F space:             0.000725
+  Time spent merging thread F spaces:             0.000186
   Size of F space: 1724
+  Time spent building sorting list: 0.000239
   Added 3 missing determinants in aimed selection.
-  Time spent building the model space: 0.031351
+  Time spent building the model space: 0.001612
   Spin-complete dimension of the PQ space: 146
 
   ==> Diagonalizing the Hamiltonian in the P + Q space <==
@@ -766,26 +845,43 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.003324 s
-        β          0.003147 s
-        αα         0.013500 s
-        ββ         0.018669 s
-        αβ         0.026202 s
+        α          0.000375 s
+        β          0.000361 s
+        αα         0.000906 s
+        ββ         0.000897 s
+        αβ         0.002397 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Total time spent diagonalizing H:   0.106883 s
+  Total time spent diagonalizing H:   0.008765 s
 
-    PQ-space CI Energy Root   0        = -112.796040156341 Eh =   0.0000 eV, S^2 = -0.000000
-    PQ-space CI Energy + EPT2 Root   0 = -112.797023896336 Eh =   0.0000 eV
+    PQ-space CI Energy Root   0        = -112.796040156341 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -112.797023896337 Eh =   0.0000 eV
 
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  Contribution
+    -----------------------------------------
+         1     1    1    6    6 100.00000000%
+         2     1    0    6    7   0.00000000%
+         3     0    1    7    6   0.00000000%
+         4     0    0    7    7   0.00000000%
+    -----------------------------------------
+               GAS1      GAS2    Contribution
+    -----------------------------------------
+                  0        14     0.00000000%
+                  1        13     0.00000000%
+                  2        12   100.00000000%
+    -----------------------------------------
 
   ==> Pruning the Q space <==
 
   Added 2 missing determinants in aimed selection.
-  Cycle 1 took: 0.161274 s
+  Cycle 1 took: 0.013725 s
 
   ---------------------------------- Cycle 2 -----------------------------------
 
@@ -797,30 +893,29 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.001851 s
-        β          0.000893 s
-        αα         0.003898 s
-        ββ         0.003527 s
-        αβ         0.013366 s
+        α          0.000154 s
+        β          0.000155 s
+        αα         0.000385 s
+        ββ         0.000374 s
+        αβ         0.000982 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Time spent diagonalizing H:   0.035868 s
+  Time spent diagonalizing H:   0.002896 s
 
     P-space  CI Energy Root   0        = -112.794513595312 Eh =   0.0000 eV, S^2 = 0.000000
 
 
   ==> Finding the Q space <==
 
-  Using MULTI_GAS screening algorithm
-  Time spent forming F space:             0.013211
-  Time spent merging thread F spaces:             0.000894
-  size of hash: 2098
-  Time spent building sorting list: 0.009423
+  Using SR screening algorithm
+  Time spent forming F space:             0.000935
+  Time spent merging thread F spaces:             0.000205
   Size of F space: 2098
-  Time spent building the model space: 0.025188
+  Time spent building sorting list: 0.000273
+  Time spent building the model space: 0.001925
   Spin-complete dimension of the PQ space: 124
 
   ==> Diagonalizing the Hamiltonian in the P + Q space <==
@@ -829,26 +924,43 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.001632 s
-        β          0.002245 s
-        αα         0.006013 s
-        ββ         0.006580 s
-        αβ         0.022826 s
+        α          0.000301 s
+        β          0.000300 s
+        αα         0.000813 s
+        ββ         0.000875 s
+        αβ         0.002105 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Total time spent diagonalizing H:   0.068053 s
+  Total time spent diagonalizing H:   0.006846 s
 
-    PQ-space CI Energy Root   0        = -112.795961273185 Eh =   0.0000 eV, S^2 = -0.000000
-    PQ-space CI Energy + EPT2 Root   0 = -112.796944312399 Eh =   0.0000 eV
+    PQ-space CI Energy Root   0        = -112.795961273185 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -112.796944312400 Eh =   0.0000 eV
 
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  Contribution
+    -----------------------------------------
+         1     1    1    6    6 100.00000000%
+         2     1    0    6    7   0.00000000%
+         3     0    1    7    6   0.00000000%
+         4     0    0    7    7   0.00000000%
+    -----------------------------------------
+               GAS1      GAS2    Contribution
+    -----------------------------------------
+                  0        14     0.00000000%
+                  1        13     0.00000000%
+                  2        12   100.00000000%
+    -----------------------------------------
 
   ==> Pruning the Q space <==
 
   Added 3 missing determinants in aimed selection.
-  Cycle 2 took: 0.132420 s
+  Cycle 2 took: 0.012777 s
 
   ---------------------------------- Cycle 3 -----------------------------------
 
@@ -860,30 +972,29 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.002080 s
-        β          0.001740 s
-        αα         0.003962 s
-        ββ         0.003581 s
-        αβ         0.007654 s
+        α          0.000179 s
+        β          0.000176 s
+        αα         0.000427 s
+        ββ         0.000416 s
+        αβ         0.001080 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Time spent diagonalizing H:   0.027938 s
+  Time spent diagonalizing H:   0.003064 s
 
-    P-space  CI Energy Root   0        = -112.794513595312 Eh =   0.0000 eV, S^2 = 0.000000
+    P-space  CI Energy Root   0        = -112.794513595312 Eh =   0.0000 eV, S^2 = -0.000000
 
 
   ==> Finding the Q space <==
 
-  Using MULTI_GAS screening algorithm
-  Time spent forming F space:             0.013217
-  Time spent merging thread F spaces:             0.001293
-  size of hash: 2098
-  Time spent building sorting list: 0.008329
+  Using SR screening algorithm
+  Time spent forming F space:             0.000932
+  Time spent merging thread F spaces:             0.000203
   Size of F space: 2098
-  Time spent building the model space: 0.024568
+  Time spent building sorting list: 0.000274
+  Time spent building the model space: 0.001928
   Spin-complete dimension of the PQ space: 124
 
   ==> Diagonalizing the Hamiltonian in the P + Q space <==
@@ -892,21 +1003,38 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.002487 s
-        β          0.002353 s
-        αα         0.006367 s
-        ββ         0.007029 s
-        αβ         0.016131 s
+        α          0.000329 s
+        β          0.000328 s
+        αα         0.000819 s
+        ββ         0.000811 s
+        αβ         0.002077 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Total time spent diagonalizing H:   0.057993 s
+  Total time spent diagonalizing H:   0.006776 s
 
     PQ-space CI Energy Root   0        = -112.795961273185 Eh =   0.0000 eV, S^2 = 0.000000
     PQ-space CI Energy + EPT2 Root   0 = -112.796944312399 Eh =   0.0000 eV
 
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  Contribution
+    -----------------------------------------
+         1     1    1    6    6 100.00000000%
+         2     1    0    6    7   0.00000000%
+         3     0    1    7    6   0.00000000%
+         4     0    0    7    7   0.00000000%
+    -----------------------------------------
+               GAS1      GAS2    Contribution
+    -----------------------------------------
+                  0        14     0.00000000%
+                  1        13     0.00000000%
+                  2        12   100.00000000%
+    -----------------------------------------
   ***** Calculation Converged *****
 
   ==> ACI Natural Orbitals <==
@@ -914,8 +1042,8 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.001702 s
-        β          0.001363 s
+        α          0.000332 s
+        β          0.000331 s
         2A1     2.000000      1A1     2.000000      3A1     1.999173  
         4A1     1.998626      5A1     1.971987      1B1     1.967179  
         1B2     1.967179      2B2     0.045872      2B1     0.045872  
@@ -935,13 +1063,13 @@ Total time:
     0  -0.975319 0.951247056          53 |2222202020>
     1   0.084404 0.007124077          52 |2222202002>
     2   0.084404 0.007124077          51 |2222200220>
-    3   0.066693 0.004447994          49 |2222002022>
-    4   0.066693 0.004447994          50 |2222002220>
-    5   0.064901 0.004212159          48 |222220+--+>
-    6   0.064901 0.004212159          47 |222220-++->
-    7   0.052267 0.002731833          45 |222220-+-+>
-    8   0.052267 0.002731833          46 |222220+-+->
-    9  -0.023963 0.000574206          44 |222+-02220>
+    3   0.066693 0.004447994          50 |2222002220>
+    4   0.066693 0.004447994          49 |2222002022>
+    5   0.064901 0.004212159          47 |222220-++->
+    6   0.064901 0.004212159          48 |222220+--+>
+    7   0.052267 0.002731833          46 |222220+-+->
+    8   0.052267 0.002731833          45 |222220-+-+>
+    9  -0.023963 0.000574206          42 |222+-02022>
 
   Saving information for root: 0
 
@@ -994,29 +1122,44 @@ Total time:
   Number of active alpha electrons: 7
   Number of active beta electrons: 7
   Maximum reference space size: 1000
-  The maximum number of electrons in GAS1 is 1
-  The minimum number of electrons in GAS1 is 0
-  The maximum number of electrons in GAS2 is 14 
-  The minimum number of electrons in GAS2 is 0
-  
-  Possible electron occupations in the GAS 
-  GAS1_A  GAS1_B  GAS2_A  GAS2_B  
-     1       0       6       7    
-     0       1       7       6    
-     0       0       7       7    
 
-  GAS Orbital Energies
-  GAS   Energies    Orb 
-   1  -20.675093265  0 
-   2  -11.359271820  1 
-   2  -1.522248358  2 
-   2  -0.796930857  3 
-   2  -0.634858118  6 
-   2  -0.634858118  8 
-   2  -0.547137448  4 
-   2   0.163684976  7 
-   2   0.163684976  9 
-   2   0.409060657  5 
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.67509326      0
+     2   -11.35927182      1
+     2    -1.52224836      2
+     2    -0.79693086      3
+     2    -0.54713745      4
+     2     0.40906066      5
+     2    -0.63485812      6
+     2     0.16368498      7
+     2    -0.63485812      8
+     2     0.16368498      9
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    1    0
+      2   14    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B
+    ---------------------------
+         1     1    0    6    7
+         2     0    1    7    6
+         3     0    0    7    7
+    ---------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Reference determinant: |+222202-20>
 
   ---------------------------------- Cycle 0 -----------------------------------
 
@@ -1028,30 +1171,29 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.000063 s
-        β          0.000052 s
-        αα         0.000217 s
-        ββ         0.000188 s
-        αβ         0.000485 s
+        α          0.000008 s
+        β          0.000008 s
+        αα         0.000019 s
+        ββ         0.000017 s
+        αβ         0.000043 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Time spent diagonalizing H:   0.001790 s
+  Time spent diagonalizing H:   0.000166 s
 
     P-space  CI Energy Root   0        = -92.424092538923 Eh =   0.0000 eV, S^2 = 2.000000
 
 
   ==> Finding the Q space <==
 
-  Using MULTI_GAS screening algorithm
-  Time spent forming F space:             0.000311
-  Time spent merging thread F spaces:             0.000120
-  size of hash: 212
-  Time spent building sorting list: 0.000689
+  Using SR screening algorithm
+  Time spent forming F space:             0.000050
+  Time spent merging thread F spaces:             0.000022
   Size of F space: 212
-  Time spent building the model space: 0.001736
+  Time spent building sorting list: 0.000030
+  Time spent building the model space: 0.000175
   Spin-complete dimension of the PQ space: 106
 
   ==> Diagonalizing the Hamiltonian in the P + Q space <==
@@ -1060,25 +1202,40 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.001207 s
-        β          0.001200 s
-        αα         0.004399 s
-        ββ         0.005613 s
-        αβ         0.014811 s
+        α          0.000281 s
+        β          0.000281 s
+        αα         0.000713 s
+        ββ         0.000705 s
+        αβ         0.001805 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Total time spent diagonalizing H:   0.042713 s
+  Total time spent diagonalizing H:   0.005586 s
 
     PQ-space CI Energy Root   0        = -92.687775591145 Eh =   0.0000 eV, S^2 = 2.000000
     PQ-space CI Energy + EPT2 Root   0 = -92.688740757591 Eh =   0.0000 eV
 
 
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  Contribution
+    -----------------------------------------
+         1     1    0    6    7  49.99903357%
+         2     0    1    7    6  49.99903357%
+         3     0    0    7    7   0.00193287%
+    -----------------------------------------
+               GAS1      GAS2    Contribution
+    -----------------------------------------
+                  0        14     0.00193287%
+                  1        13    99.99806713%
+    -----------------------------------------
+
   ==> Pruning the Q space <==
 
-  Cycle 0 took: 0.048055 s
+  Cycle 0 took: 0.006725 s
 
   ---------------------------------- Cycle 1 -----------------------------------
 
@@ -1090,30 +1247,29 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.001887 s
-        β          0.001378 s
-        αα         0.004510 s
-        ββ         0.003498 s
-        αβ         0.011213 s
+        α          0.000256 s
+        β          0.000253 s
+        αα         0.000621 s
+        ββ         0.000603 s
+        αβ         0.001688 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Time spent diagonalizing H:   0.037466 s
+  Time spent diagonalizing H:   0.005082 s
 
     P-space  CI Energy Root   0        = -92.687258780321 Eh =   0.0000 eV, S^2 = 2.000000
 
 
   ==> Finding the Q space <==
 
-  Using MULTI_GAS screening algorithm
-  Time spent forming F space:             0.013890
-  Time spent merging thread F spaces:             0.000804
-  size of hash: 1322
-  Time spent building sorting list: 0.005693
+  Using SR screening algorithm
+  Time spent forming F space:             0.001117
+  Time spent merging thread F spaces:             0.000130
   Size of F space: 1322
-  Time spent building the model space: 0.021651
+  Time spent building sorting list: 0.000173
+  Time spent building the model space: 0.001758
   Spin-complete dimension of the PQ space: 168
 
   ==> Diagonalizing the Hamiltonian in the P + Q space <==
@@ -1122,25 +1278,40 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.003022 s
-        β          0.002079 s
-        αα         0.007295 s
-        ββ         0.005932 s
-        αβ         0.018693 s
+        α          0.000415 s
+        β          0.000413 s
+        αα         0.001021 s
+        ββ         0.001074 s
+        αβ         0.002793 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Total time spent diagonalizing H:   0.072547 s
+  Total time spent diagonalizing H:   0.010047 s
 
     PQ-space CI Energy Root   0        = -92.691091983582 Eh =   0.0000 eV, S^2 = 2.000000
     PQ-space CI Energy + EPT2 Root   0 = -92.692079808627 Eh =   0.0000 eV
 
 
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  Contribution
+    -----------------------------------------
+         1     1    0    6    7  49.99906557%
+         2     0    1    7    6  49.99906557%
+         3     0    0    7    7   0.00186887%
+    -----------------------------------------
+               GAS1      GAS2    Contribution
+    -----------------------------------------
+                  0        14     0.00186887%
+                  1        13    99.99813113%
+    -----------------------------------------
+
   ==> Pruning the Q space <==
 
-  Cycle 1 took: 0.135227 s
+  Cycle 1 took: 0.018280 s
 
   ---------------------------------- Cycle 2 -----------------------------------
 
@@ -1152,31 +1323,30 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.001469 s
-        β          0.001627 s
-        αα         0.004654 s
-        ββ         0.003835 s
-        αβ         0.014039 s
+        α          0.000276 s
+        β          0.000270 s
+        αα         0.000664 s
+        ββ         0.000649 s
+        αβ         0.001811 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Time spent diagonalizing H:   0.041640 s
+  Time spent diagonalizing H:   0.005535 s
 
     P-space  CI Energy Root   0        = -92.688867667132 Eh =   0.0000 eV, S^2 = 2.000000
 
 
   ==> Finding the Q space <==
 
-  Using MULTI_GAS screening algorithm
-  Time spent forming F space:             0.012706
-  Time spent merging thread F spaces:             0.000589
-  size of hash: 1382
-  Time spent building sorting list: 0.005759
+  Using SR screening algorithm
+  Time spent forming F space:             0.001225
+  Time spent merging thread F spaces:             0.000135
   Size of F space: 1382
+  Time spent building sorting list: 0.000181
   Added 1 missing determinants in aimed selection.
-  Time spent building the model space: 0.020224
+  Time spent building the model space: 0.001910
   Spin-complete dimension of the PQ space: 170
 
   ==> Diagonalizing the Hamiltonian in the P + Q space <==
@@ -1185,26 +1355,41 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.001817 s
-        β          0.001787 s
-        αα         0.006287 s
-        ββ         0.005496 s
-        αβ         0.018962 s
+        α          0.000421 s
+        β          0.000417 s
+        αα         0.001026 s
+        ββ         0.001071 s
+        αβ         0.002754 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Total time spent diagonalizing H:   0.066660 s
+  Total time spent diagonalizing H:   0.010154 s
 
     PQ-space CI Energy Root   0        = -92.691156796377 Eh =   0.0000 eV, S^2 = 2.000000
     PQ-space CI Energy + EPT2 Root   0 = -92.692138281500 Eh =   0.0000 eV
 
 
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  Contribution
+    -----------------------------------------
+         1     1    0    6    7  49.99906546%
+         2     0    1    7    6  49.99906546%
+         3     0    0    7    7   0.00186907%
+    -----------------------------------------
+               GAS1      GAS2    Contribution
+    -----------------------------------------
+                  0        14     0.00186907%
+                  1        13    99.99813093%
+    -----------------------------------------
+
   ==> Pruning the Q space <==
 
   Added 1 missing determinants in aimed selection.
-  Cycle 2 took: 0.131732 s
+  Cycle 2 took: 0.019037 s
 
   ---------------------------------- Cycle 3 -----------------------------------
 
@@ -1216,30 +1401,29 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.001229 s
-        β          0.001276 s
-        αα         0.004974 s
-        ββ         0.003801 s
-        αβ         0.010164 s
+        α          0.000308 s
+        β          0.000312 s
+        αα         0.000816 s
+        ββ         0.000783 s
+        αβ         0.001945 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Time spent diagonalizing H:   0.037016 s
+  Time spent diagonalizing H:   0.006187 s
 
     P-space  CI Energy Root   0        = -92.689195120702 Eh =   0.0000 eV, S^2 = 2.000000
 
 
   ==> Finding the Q space <==
 
-  Using MULTI_GAS screening algorithm
-  Time spent forming F space:             0.012763
-  Time spent merging thread F spaces:             0.000623
-  size of hash: 1456
-  Time spent building sorting list: 0.004260
+  Using SR screening algorithm
+  Time spent forming F space:             0.001280
+  Time spent merging thread F spaces:             0.000141
   Size of F space: 1456
-  Time spent building the model space: 0.018636
+  Time spent building sorting list: 0.000193
+  Time spent building the model space: 0.001987
   Spin-complete dimension of the PQ space: 172
 
   ==> Diagonalizing the Hamiltonian in the P + Q space <==
@@ -1248,25 +1432,40 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.002341 s
-        β          0.002121 s
-        αα         0.005616 s
-        ββ         0.007073 s
-        αβ         0.016452 s
+        α          0.000451 s
+        β          0.000464 s
+        αα         0.001139 s
+        ββ         0.001125 s
+        αβ         0.002854 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Total time spent diagonalizing H:   0.067913 s
+  Total time spent diagonalizing H:   0.010636 s
 
     PQ-space CI Energy Root   0        = -92.691245384184 Eh =   0.0000 eV, S^2 = 2.000000
     PQ-space CI Energy + EPT2 Root   0 = -92.692238645861 Eh =   0.0000 eV
 
 
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  Contribution
+    -----------------------------------------
+         1     1    0    6    7  49.99906566%
+         2     0    1    7    6  49.99906567%
+         3     0    0    7    7   0.00186867%
+    -----------------------------------------
+               GAS1      GAS2    Contribution
+    -----------------------------------------
+                  0        14     0.00186867%
+                  1        13    99.99813133%
+    -----------------------------------------
+
   ==> Pruning the Q space <==
 
-  Cycle 3 took: 0.127105 s
+  Cycle 3 took: 0.020219 s
 
   ---------------------------------- Cycle 4 -----------------------------------
 
@@ -1278,30 +1477,29 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.001265 s
-        β          0.001251 s
-        αα         0.003938 s
-        ββ         0.006542 s
-        αβ         0.011191 s
+        α          0.000302 s
+        β          0.000307 s
+        αα         0.000777 s
+        ββ         0.000770 s
+        αβ         0.001966 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Time spent diagonalizing H:   0.044003 s
+  Time spent diagonalizing H:   0.006221 s
 
     P-space  CI Energy Root   0        = -92.689195120702 Eh =   0.0000 eV, S^2 = 2.000000
 
 
   ==> Finding the Q space <==
 
-  Using MULTI_GAS screening algorithm
-  Time spent forming F space:             0.015733
-  Time spent merging thread F spaces:             0.000529
-  size of hash: 1456
-  Time spent building sorting list: 0.005600
+  Using SR screening algorithm
+  Time spent forming F space:             0.001277
+  Time spent merging thread F spaces:             0.000153
   Size of F space: 1456
-  Time spent building the model space: 0.022968
+  Time spent building sorting list: 0.000193
+  Time spent building the model space: 0.001989
   Spin-complete dimension of the PQ space: 172
 
   ==> Diagonalizing the Hamiltonian in the P + Q space <==
@@ -1310,21 +1508,36 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.001911 s
-        β          0.002715 s
-        αα         0.010411 s
-        ββ         0.006472 s
-        αβ         0.016399 s
+        α          0.000444 s
+        β          0.000462 s
+        αα         0.001137 s
+        ββ         0.001117 s
+        αβ         0.002845 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Total time spent diagonalizing H:   0.072675 s
+  Total time spent diagonalizing H:   0.010303 s
 
     PQ-space CI Energy Root   0        = -92.691245384184 Eh =   0.0000 eV, S^2 = 2.000000
     PQ-space CI Energy + EPT2 Root   0 = -92.692238645861 Eh =   0.0000 eV
 
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  Contribution
+    -----------------------------------------
+         1     1    0    6    7  49.99906567%
+         2     0    1    7    6  49.99906566%
+         3     0    0    7    7   0.00186867%
+    -----------------------------------------
+               GAS1      GAS2    Contribution
+    -----------------------------------------
+                  0        14     0.00186867%
+                  1        13    99.99813133%
+    -----------------------------------------
   ***** Calculation Converged *****
 
   ==> ACI Natural Orbitals <==
@@ -1332,8 +1545,8 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.002558 s
-        β          0.002045 s
+        α          0.000430 s
+        β          0.000440 s
         1A1     2.000000      2A1     1.999789      3A1     1.999580  
         1B1     1.999184      1B2     1.997983      4A1     1.963023  
         2B1     1.000816      5A1     0.999996      2B2     0.036632  
@@ -1350,16 +1563,16 @@ Total time:
   ==> Wavefunction Information <==
 
   Most important contributions to root   0:
-    0   0.623729 0.389038344          69 |-222202+20>
-    1  -0.623729 0.389038344          68 |+222202-20>
-    2  -0.176472 0.031142374          67 |-222202++->
-    3   0.176472 0.031142374          66 |+222202--+>
-    4  -0.174884 0.030584553          65 |-22220+220>
-    5   0.174884 0.030584553          64 |+22220-220>
-    6  -0.164180 0.026954930          63 |-222202+-+>
-    7   0.164180 0.026954930          62 |+222202-+->
-    8   0.078367 0.006141452          61 |-222002+22>
-    9  -0.078367 0.006141452          60 |+222002-22>
+    0   0.623729 0.389038344          68 |+222202-20>
+    1  -0.623729 0.389038344          69 |-222202+20>
+    2  -0.176472 0.031142374          66 |+222202--+>
+    3   0.176472 0.031142374          67 |-222202++->
+    4  -0.174884 0.030584553          64 |+22220-220>
+    5   0.174884 0.030584553          65 |-22220+220>
+    6  -0.164180 0.026954930          62 |+222202-+->
+    7   0.164180 0.026954930          63 |-222202+-+>
+    8   0.078367 0.006141452          60 |+222002-22>
+    9  -0.078367 0.006141452          61 |-222002+22>
 
   Saving information for root: 0
 
@@ -1372,13 +1585,13 @@ Total time:
        1  (  0)    B1     0      -92.691245384184
     ---------------------------------------------
 
-  Time to prepare integrals:        0.218 seconds
-  Time to run job          :        1.059 seconds
-  Total                    :        1.059 seconds	ACI energy........................................................PASSED
-	ACI+PT2 energy....................................................PASSED
-	AVERAGE ACI ENERGY................................................PASSED
+  Time to prepare integrals:        0.074 seconds
+  Time to run job          :        0.133 seconds
+  Total                    :        0.207 seconds    ACI energy............................................................................PASSED
+    ACI+PT2 energy........................................................................PASSED
+    AVERAGE ACI ENERGY....................................................................PASSED
 
-    Psi4 stopped on: Tuesday, 11 August 2020 10:14AM
-    Psi4 wall time for execution: 0:00:01.76
+    Psi4 stopped on: Saturday, 30 January 2021 03:41AM
+    Psi4 wall time for execution: 0:00:00.43
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/methods/gasci-1/output.ref
+++ b/tests/methods/gasci-1/output.ref
@@ -3,31 +3,38 @@
           Psi4: An Open-Source Ab Initio Electronic Structure Package
                                Psi4 undefined 
 
-                         Git: Rev {master} 45315cb dirty
+                         Git: Rev {x2c-norm} b906495 
 
 
-    R. M. Parrish, L. A. Burns, D. G. A. Smith, A. C. Simmonett,
-    A. E. DePrince III, E. G. Hohenstein, U. Bozkaya, A. Yu. Sokolov,
-    R. Di Remigio, R. M. Richard, J. F. Gonthier, A. M. James,
-    H. R. McAlexander, A. Kumar, M. Saitow, X. Wang, B. P. Pritchard,
-    P. Verma, H. F. Schaefer III, K. Patkowski, R. A. King, E. F. Valeev,
-    F. A. Evangelista, J. M. Turney, T. D. Crawford, and C. D. Sherrill,
-    J. Chem. Theory Comput. 13(7) pp 3185--3197 (2017).
-    (doi: 10.1021/acs.jctc.7b00174)
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
 
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
 
-                         Additional Contributions by
-    P. Kraus, H. Kruse, M. H. Lechner, M. C. Schieber, R. A. Shaw,
-    A. Alenaizan, R. Galvelis, Z. L. Glick, S. Lehtola, and J. P. Misiewicz
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
 
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Friday, 07 August 2020 04:42PM
+    Psi4 started on: Saturday, 30 January 2021 03:41AM
 
-    Process ID: 32209
-    Host:       DESKTOP-SQPD2D3
-    PSIDATADIR: /home/mhuang/psi4_install/share/psi4
+    Process ID: 63833
+    Host:       Yorks-Mac.local
+    PSIDATADIR: /Users/york/src/psi4new/psi4/share/psi4
     Memory:     500.0 MiB
     Threads:    1
     
@@ -35,7 +42,7 @@
 
 --------------------------------------------------------------------------
 #! Generated using commit GITCOMMIT 
-#gasci(rasci) calculation on h20
+#gasci(rasci) calculation on h2o
 
 import forte
 
@@ -62,10 +69,9 @@ set scf {
 
 set forte {
   active_space_solver aci
-  single_calculation True
   multiplicity 1
   ms 0.0
-  sigma 0.001
+  sigma 0.000
   nroot 1
   root_sym 0
   charge 0
@@ -76,7 +82,7 @@ set forte {
   restricted_uocc [8,2,3,5]
   GAS1 [2,0,1,1]
   GAS2 [1,0,0,1]
-  GAS1MIN 6
+  GAS1MIN [6]
 }
 
 energy('scf')
@@ -86,16 +92,18 @@ energy('forte')
 compare_values(refgasci, variable("ACI ENERGY"),9, "ACI energy") #TEST
 --------------------------------------------------------------------------
 
-*** tstart() called on DESKTOP-SQPD2D3
-*** at Fri Aug  7 16:42:01 2020
+Scratch directory: /Users/york/scratch/psi4/
+
+*** tstart() called on Yorks-Mac.local
+*** at Sat Jan 30 03:41:03 2021
 
    => Loading Basis Set <=
 
     Name: 6-31G**
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   149 file /home/mhuang/psi4_install/share/psi4/basis/6-31gss.gbs 
-    atoms 2-3 entry H          line    44 file /home/mhuang/psi4_install/share/psi4/basis/6-31gss.gbs 
+    atoms 1   entry O          line   149 file /Users/york/src/psi4new/psi4/share/psi4/basis/6-31gss.gbs 
+    atoms 2-3 entry H          line    44 file /Users/york/src/psi4new/psi4/share/psi4/basis/6-31gss.gbs 
 
 
          ---------------------------------------------------------
@@ -140,7 +148,7 @@ compare_values(refgasci, variable("ACI ENERGY"),9, "ACI energy") #TEST
   Guess Type is GWH.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -157,21 +165,8 @@ compare_values(refgasci, variable("ACI ENERGY"),9, "ACI energy") #TEST
     Name: (6-31G** AUX)
     Role: JKFIT
     Keyword: DF_BASIS_SCF
-    atoms 1   entry O          line   221 file /home/mhuang/psi4_install/share/psi4/basis/cc-pvdz-jkfit.gbs 
-    atoms 2-3 entry H          line    51 file /home/mhuang/psi4_install/share/psi4/basis/cc-pvdz-jkfit.gbs 
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        12      12       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         4       4       0       0       0       0
-     B2         7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      25      25       5       5       5       0
-   -------------------------------------------------------
+    atoms 1   entry O          line   221 file /Users/york/src/psi4new/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
+    atoms 2-3 entry H          line    51 file /Users/york/src/psi4new/psi4/share/psi4/basis/cc-pvdz-jkfit.gbs 
 
   ==> Integral Setup <==
 
@@ -201,28 +196,42 @@ compare_values(refgasci, variable("ACI ENERGY"),9, "ACI energy") #TEST
 
     OpenMP threads:              1
 
-  Minimum eigenvalue in the overlap matrix is 2.3361254379E-02.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 2.2571686435E-02.
+  Reciprocal condition number of the overlap matrix is 5.1514795888E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Generalized Wolfsberg-Helmholtz.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        12      12       3       3       3       0
+     A2         2       2       0       0       0       0
+     B1         4       4       1       1       1       0
+     B2         7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      25      25       5       5       5       0
+   -------------------------------------------------------
 
   ==> Iterations <==
 
                            Total Energy        Delta E     RMS |[F,P]|
 
    @DF-ROHF iter   1:   -74.69504180587793   -7.46950e+01   8.44137e-02 DIIS
-   @DF-ROHF iter   2:   -75.63888192728950   -9.43840e-01   5.10185e-02 DIIS
+   @DF-ROHF iter   2:   -75.63888192728945   -9.43840e-01   5.10185e-02 DIIS
    @DF-ROHF iter   3:   -76.00949918159461   -3.70617e-01   6.03452e-03 DIIS
    @DF-ROHF iter   4:   -76.01707250387210   -7.57332e-03   7.73121e-04 DIIS
-   @DF-ROHF iter   5:   -76.01728301323575   -2.10509e-04   1.93837e-04 DIIS
-   @DF-ROHF iter   6:   -76.01729581731556   -1.28041e-05   3.88419e-05 DIIS
-   @DF-ROHF iter   7:   -76.01729653728773   -7.19972e-07   7.28353e-06 DIIS
-   @DF-ROHF iter   8:   -76.01729655479539   -1.75077e-08   1.27096e-06 DIIS
-   @DF-ROHF iter   9:   -76.01729655603384   -1.23845e-09   2.97703e-07 DIIS
-   @DF-ROHF iter  10:   -76.01729655609111   -5.72697e-11   3.63960e-08 DIIS
-   @DF-ROHF iter  11:   -76.01729655609159   -4.83169e-13   3.85088e-09 DIIS
-   @DF-ROHF iter  12:   -76.01729655609159    0.00000e+00   3.54029e-10 DIIS
-   @DF-ROHF iter  13:   -76.01729655609159    0.00000e+00   2.43243e-11 DIIS
+   @DF-ROHF iter   5:   -76.01728301323564   -2.10509e-04   1.93837e-04 DIIS
+   @DF-ROHF iter   6:   -76.01729581731550   -1.28041e-05   3.88419e-05 DIIS
+   @DF-ROHF iter   7:   -76.01729653728768   -7.19972e-07   7.28353e-06 DIIS
+   @DF-ROHF iter   8:   -76.01729655479534   -1.75077e-08   1.27096e-06 DIIS
+   @DF-ROHF iter   9:   -76.01729655603373   -1.23839e-09   2.97703e-07 DIIS
+   @DF-ROHF iter  10:   -76.01729655609105   -5.73266e-11   3.63960e-08 DIIS
+   @DF-ROHF iter  11:   -76.01729655609162   -5.68434e-13   3.85088e-09 DIIS
+   @DF-ROHF iter  12:   -76.01729655609151    1.13687e-13   3.54030e-10 DIIS
+   @DF-ROHF iter  13:   -76.01729655609154   -2.84217e-14   2.43246e-11 DIIS
   Energy and wave function converged.
 
 
@@ -255,14 +264,14 @@ compare_values(refgasci, variable("ACI ENERGY"),9, "ACI energy") #TEST
     DOCC [     3,    0,    1,    1 ]
     SOCC [     0,    0,    0,    0 ]
 
-  @DF-ROHF Final Energy:   -76.01729655609159
+  @DF-ROHF Final Energy:   -76.01729655609154
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              8.8046866532470247
-    One-Electron Energy =                -122.3894315646914492
-    Two-Electron Energy =                  37.5674483553528304
-    Total Energy =                        -76.0172965560915941
+    One-Electron Energy =                -122.3894315646913356
+    Two-Electron Energy =                  37.5674483553527807
+    Total Energy =                        -76.0172965560915372
 
 Computation Completed
 
@@ -284,26 +293,45 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.2414     Total:     2.2414
 
 
-*** tstop() called on DESKTOP-SQPD2D3 at Fri Aug  7 16:42:02 2020
+*** tstop() called on Yorks-Mac.local at Sat Jan 30 03:41:03 2021
 Module time:
-	user time   =       0.19 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.19 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       0.11 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 
-*** tstart() called on DESKTOP-SQPD2D3
-*** at Fri Aug  7 16:42:02 2020
+Scratch directory: /Users/york/scratch/psi4/
+
+  Forte
+  ----------------------------------------------------------------------------
+  A suite of quantum chemistry methods for strongly correlated electrons
+
+    git branch: relax_overlap - git commit: 416ba2ac
+
+  Developed by:
+    Francesco A. Evangelista, Chenyang Li, Kevin P. Hannon,
+    Jeffrey B. Schriber, Tianyuan Zhang, Chenxi Cai,
+    Nan He, Nicholas Stair, Shuhe Wang, Renke Huang
+  ----------------------------------------------------------------------------
+
+  Size of Determinant class: 128 bits
+
+  Preparing forte objects from a Psi4 Wavefunction object
+  No reference wave function provided for Forte. Computing SCF orbitals using Psi4 ...
+
+*** tstart() called on Yorks-Mac.local
+*** at Sat Jan 30 03:41:03 2021
 
    => Loading Basis Set <=
 
     Name: 6-31G**
     Role: ORBITAL
     Keyword: BASIS
-    atoms 1   entry O          line   149 file /home/mhuang/psi4_install/share/psi4/basis/6-31gss.gbs 
-    atoms 2-3 entry H          line    44 file /home/mhuang/psi4_install/share/psi4/basis/6-31gss.gbs 
+    atoms 1   entry O          line   149 file /Users/york/src/psi4new/psi4/share/psi4/basis/6-31gss.gbs 
+    atoms 2-3 entry H          line    44 file /Users/york/src/psi4new/psi4/share/psi4/basis/6-31gss.gbs 
 
 
          ---------------------------------------------------------
@@ -348,7 +376,7 @@ Total time:
   Guess Type is GWH.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -359,19 +387,6 @@ Total time:
     Number of Cartesian functions: 25
     Spherical Harmonics?: false
     Max angular momentum: 2
-
-  ==> Pre-Iterations <==
-
-   -------------------------------------------------------
-    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
-   -------------------------------------------------------
-     A1        12      12       0       0       0       0
-     A2         2       2       0       0       0       0
-     B1         4       4       0       0       0       0
-     B2         7       7       0       0       0       0
-   -------------------------------------------------------
-    Total      25      25       5       5       5       0
-   -------------------------------------------------------
 
   ==> Integral Setup <==
 
@@ -401,28 +416,42 @@ Total time:
 
     OpenMP threads:              1
 
-  Minimum eigenvalue in the overlap matrix is 2.3361254379E-02.
-  Using Symmetric Orthogonalization.
+  Minimum eigenvalue in the overlap matrix is 2.2571686435E-02.
+  Reciprocal condition number of the overlap matrix is 5.1514795888E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
 
   SCF Guess: Generalized Wolfsberg-Helmholtz.
+
+   -------------------------------------------------------
+    Irrep   Nso     Nmo     Nalpha   Nbeta   Ndocc  Nsocc
+   -------------------------------------------------------
+     A1        12      12       3       3       3       0
+     A2         2       2       0       0       0       0
+     B1         4       4       1       1       1       0
+     B2         7       7       1       1       1       0
+   -------------------------------------------------------
+    Total      25      25       5       5       5       0
+   -------------------------------------------------------
 
   ==> Iterations <==
 
                         Total Energy        Delta E     RMS |[F,P]|
 
-   @ROHF iter   1:   -74.69504180587788   -7.46950e+01   8.44137e-02 DIIS
-   @ROHF iter   2:   -75.63888192728950   -9.43840e-01   5.10185e-02 DIIS
-   @ROHF iter   3:   -76.00949918159461   -3.70617e-01   6.03452e-03 DIIS
-   @ROHF iter   4:   -76.01707250387206   -7.57332e-03   7.73121e-04 DIIS
-   @ROHF iter   5:   -76.01728301323573   -2.10509e-04   1.93837e-04 DIIS
-   @ROHF iter   6:   -76.01729581731543   -1.28041e-05   3.88419e-05 DIIS
-   @ROHF iter   7:   -76.01729653728771   -7.19972e-07   7.28353e-06 DIIS
-   @ROHF iter   8:   -76.01729655479531   -1.75076e-08   1.27096e-06 DIIS
-   @ROHF iter   9:   -76.01729655603374   -1.23843e-09   2.97703e-07 DIIS
-   @ROHF iter  10:   -76.01729655609110   -5.73550e-11   3.63960e-08 DIIS
-   @ROHF iter  11:   -76.01729655609151   -4.12115e-13   3.85088e-09 DIIS
-   @ROHF iter  12:   -76.01729655609154   -2.84217e-14   3.54029e-10 DIIS
-   @ROHF iter  13:   -76.01729655609157   -2.84217e-14   2.43243e-11 DIIS
+   @ROHF iter   1:   -74.69504180587785   -7.46950e+01   8.44137e-02 DIIS
+   @ROHF iter   2:   -75.63888192728939   -9.43840e-01   5.10185e-02 DIIS
+   @ROHF iter   3:   -76.00949918159455   -3.70617e-01   6.03452e-03 DIIS
+   @ROHF iter   4:   -76.01707250387196   -7.57332e-03   7.73121e-04 DIIS
+   @ROHF iter   5:   -76.01728301323561   -2.10509e-04   1.93837e-04 DIIS
+   @ROHF iter   6:   -76.01729581731544   -1.28041e-05   3.88419e-05 DIIS
+   @ROHF iter   7:   -76.01729653728766   -7.19972e-07   7.28353e-06 DIIS
+   @ROHF iter   8:   -76.01729655479525   -1.75076e-08   1.27096e-06 DIIS
+   @ROHF iter   9:   -76.01729655603376   -1.23850e-09   2.97703e-07 DIIS
+   @ROHF iter  10:   -76.01729655609103   -5.72697e-11   3.63960e-08 DIIS
+   @ROHF iter  11:   -76.01729655609148   -4.54747e-13   3.85088e-09 DIIS
+   @ROHF iter  12:   -76.01729655609144    4.26326e-14   3.54029e-10 DIIS
+   @ROHF iter  13:   -76.01729655609142    1.42109e-14   2.43241e-11 DIIS
   Energy and wave function converged.
 
 
@@ -455,14 +484,14 @@ Total time:
     DOCC [     3,    0,    1,    1 ]
     SOCC [     0,    0,    0,    0 ]
 
-  @ROHF Final Energy:   -76.01729655609157
+  @ROHF Final Energy:   -76.01729655609142
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              8.8046866532470229
-    One-Electron Energy =                -122.3894315646913356
+    One-Electron Energy =                -122.3894315646911934
     Two-Electron Energy =                  37.5674483553527523
-    Total Energy =                        -76.0172965560915657
+    Total Energy =                        -76.0172965560914236
 
 Computation Completed
 
@@ -484,37 +513,22 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.2414     Total:     2.2414
 
 
-*** tstop() called on DESKTOP-SQPD2D3 at Fri Aug  7 16:42:02 2020
+*** tstop() called on Yorks-Mac.local at Sat Jan 30 03:41:03 2021
 Module time:
-	user time   =       0.11 seconds =       0.00 minutes
-	system time =       0.03 seconds =       0.00 minutes
+	user time   =       0.08 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
 	total time  =          0 seconds =       0.00 minutes
 Total time:
-	user time   =       0.32 seconds =       0.01 minutes
-	system time =       0.06 seconds =       0.00 minutes
-	total time  =          1 seconds =       0.02 minutes
-   => Loading Basis Set <=
+	user time   =       0.20 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
 
-    Name: STO-3G
-    Role: ORBITAL
-    Keyword: MINAO_BASIS
-    atoms 1   entry O          line    81 file /home/mhuang/psi4_install/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3 entry H          line    19 file /home/mhuang/psi4_install/share/psi4/basis/sto-3g.gbs 
-
-
-  Forte
-  ----------------------------------------------------------------------------
-  A suite of quantum chemistry methods for strongly correlated electrons
-
-    git branch: HEAD - git commit: 98867ecc
-
-  Developed by:
-    Francesco A. Evangelista, Chenyang Li, Kevin P. Hannon,
-    Jeffrey B. Schriber, Tianyuan Zhang, Chenxi Cai,
-    Nan He, Nicholas Stair, Shuhe Wang, Renke Huang
-  ----------------------------------------------------------------------------
-
-  Size of Determinant class: 128 bits
+  Read options for space RESTRICTED_DOCC
+  Read options for space GAS1
+  Read options for space GAS2
+  Read options for space RESTRICTED_UOCC
+  Read options for space GAS1
+  Read options for space GAS2
   Read options for space RESTRICTED_DOCC
   Read options for space RESTRICTED_UOCC
 
@@ -525,37 +539,90 @@ Total time:
   -------------------------------------------------
     FROZEN_DOCC         0     0     0     0     0
     RESTRICTED_DOCC     1     0     0     0     1
-    ACTIVE              3     0     1     2     6
+    GAS1                2     0     1     1     4
+    GAS2                1     0     0     1     2
+    GAS3                0     0     0     0     0
+    GAS4                0     0     0     0     0
+    GAS5                0     0     0     0     0
+    GAS6                0     0     0     0     0
     RESTRICTED_UOCC     8     2     3     5    18
     FROZEN_UOCC         0     0     0     0     0
     Total              12     2     4     7    25
-  -------------------------------------------------
+  -------------------------------------------------   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: MINAO_BASIS
+    atoms 1   entry O          line    81 file /Users/york/src/psi4new/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /Users/york/src/psi4new/psi4/share/psi4/basis/sto-3g.gbs 
+
+
+  Forte will use psi4 integrals
+
+  ==> Primary Basis Set Summary <==
+
+  Basis Set: 6-31G**
+    Blend: 6-31G**
+    Number of shells: 12
+    Number of basis function: 25
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+
+  JK created using conventional PK integrals
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              12
+      Number of primitives:             25
+      Number of atomic orbitals:        25
+      Number of basis functions:        25
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 105950 doubles for integral storage.
+  We computed 3081 shell quartets total.
+  Whereas there are 3081 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              400
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+
 
   ==> Integral Transformation <==
 
-  Number of molecular orbitals:                    25
-  Number of correlated molecular orbitals:         25
-  Number of frozen occupied orbitals:               0
-  Number of frozen unoccupied orbitals:             0
-  Two-electron integral type:              Conventional
+  Number of molecular orbitals:                         25
+  Number of correlated molecular orbitals:              25
+  Number of frozen occupied orbitals:                    0
+  Number of frozen unoccupied orbitals:                  0
+  Two-electron integral type:                 Conventional
 
 
-  Overall Conventional Integrals timings
-
-	Presorting SO-basis two-electron integrals.
+  Computing Conventional Integrals	Presorting SO-basis two-electron integrals.
 	Sorting File: SO Ints (nn|nn) nbuckets = 1
-	Transforming the one-electron integrals and constructing Fock matrices
+	Constructing frozen core operators
 	Starting first half-transformation.
 	Sorting half-transformed integrals.
 	First half integral transformation complete.
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
 
-  Integral transformation done. 0.04764710 s
+  Integral transformation done. 0.01268295 s
   Reading the two-electron integrals from disk
   Size of two-electron integrals:   0.008731 GB
+  Timing for conventional integral transformation:            0.028 s.
   Timing for freezing core and virtual orbitals:              0.000 s.
-  Conventional integrals take 0.12258200 s
+  Timing for computing conventional integrals:                0.028 s.
 
   ==> Summary of Active Space Solver Input <==
 
@@ -605,7 +672,7 @@ Total time:
     Symmetry                                 0    
     Number of roots                          1    
     Root used for properties                 0    
-    Sigma (Eh)                               1.00e-03
+    Sigma (Eh)                               0.00e+00
     Gamma (Eh^(-1))                          1.00e+00
     Convergence threshold                    1.00e-09
     Ms                                       0
@@ -618,41 +685,90 @@ Total time:
   Number of active alpha electrons: 4
   Number of active beta electrons: 4
   Maximum reference space size: 1000
-  Read options for space GAS1
-  Read options for space GAS2
 
-  ==> Generalized Active Space Information <==
+  ==> GAS Orbital Energies from SCF <==
 
-  There are total 2 GAS space.
-  --------------------------------------
-            A1    A2    B1    B2   Sum
-  --------------------------------------
-    GAS1     2     0     1     1     4
-    GAS2     1     0     0     1     2
-   Total     3     0     1     2     6
-  --------------------------------------
-  The maximum number of electrons in GAS1 is 8 
-  The minimum number of electrons in GAS1 is 6
-  The maximum number of electrons in GAS2 is 4 
-  The minimum number of electrons in GAS2 is 0
-  
-  Possible electron occupations in the GAS 
-  GAS1_A  GASI_B  GAS2_A  GAS2_B  
-     4       4       0       0    
-     4       3       0       1    
-     4       2       0       2    
-     3       4       1       0    
-     3       3       1       1    
-     2       4       2       0    
+    GAS        Energy  Index
+    ------------------------
+     1    -1.32060927      0
+     1    -0.56393045      1
+     1    -0.49500394      3
+     1    -0.67872419      4
+     2     0.20246590      2
+     2     0.29271934      5
+    ------------------------
 
-  GAS Orbital Energies
-  GAS   Energies    Orb 
-  1  -1.320609273  0 
-  1  -0.563930450  1 
-  1  -0.495003944  3 
-  1  -0.678724187  4 
-  2   0.202465902  2 
-  2   0.292719335  5 
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    8    6
+      2    4    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B
+    ---------------------------
+         1     4    4    0    0
+         2     4    3    0    1
+         3     4    2    0    2
+         4     3    4    1    0
+         5     3    3    1    1
+         6     2    4    2    0
+    ---------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1               1  3.798e-05
+         2               3  4.488e-05
+         3               2  4.299e-05
+         4               3  4.019e-05
+         5              20  5.622e-05
+         6               2  4.002e-05
+    ---------------------------------
+    Total:              31  3.094e-04
+    ---------------------------------
+
+  ---------------------------------- Cycle 0 -----------------------------------
+
+
+  ==> Diagonalizing the Hamiltonian in the P space <==
+
+  Initial P space dimension: 31
+  Not checking for spin-completeness.
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000054 s
+        β          0.000053 s
+        αα         0.000071 s
+        ββ         0.000066 s
+        αβ         0.000162 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 18 roots with 2S+1 = 1 *
+  Found 11 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Time spent diagonalizing H:   0.000830 s
+
+    P-space  CI Energy Root   0        = -76.029683013020 Eh =   0.0000 eV, S^2 = -0.000000
+
+
+  ==> Finding the Q space <==
+
+  Using SR screening algorithm
+  Time spent forming F space:             0.000266
+  Time spent merging thread F spaces:             0.000020
+  Size of F space: 0
+  Time spent building sorting list: 0.000001
+  Time spent building the model space: 0.000353
 
   ==> Diagonalizing the Hamiltonian in the P + Q space <==
 
@@ -660,68 +776,161 @@ Total time:
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.000216 s
-        β          0.000200 s
-        αα         0.000345 s
-        ββ         0.000333 s
-        αβ         0.000926 s
+        α          0.000050 s
+        β          0.000051 s
+        αα         0.000067 s
+        ββ         0.000064 s
+        αβ         0.000159 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
 
   Performing diagonalization of the H matrix
-  Total time spent diagonalizing H:   0.004391 s
+  Found 18 roots with 2S+1 = 1 *
+  Found 11 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.000806 s
 
-    PQ-space CI Energy Root   0        = -76.029683013021 Eh =   0.0000 eV, S^2 = -0.000000
-    PQ-space CI Energy + EPT2 Root   0 = -76.029683013021 Eh =   0.0000 eV
+    PQ-space CI Energy Root   0        = -76.029683013020 Eh =   0.0000 eV, S^2 = -0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -76.029683013020 Eh =   0.0000 eV
 
-  
-  GAS Contribution Analysis  
-  GAS contributions root 0: 
-  GAS1_A    GASI_B    GAS2_A    GAS2_B        Cont  
-     4         4         0         0        0.991468934  
-     4         3         0         1        0.000332779  
-     4         2         0         2        0.000335243  
-     3         4         1         0        0.000332779  
-     3         3         1         1        0.007195022  
-     2         4         2         0        0.000335243  
 
-           6                  2            0.007865507  
-           7                  1            0.000665558  
-           8                  0            0.991468934  
+  ==> GAS Contribution Analysis <==
 
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  Contribution
+    -----------------------------------------
+         1     4    4    0    0  99.14689344%
+         2     4    3    0    1   0.03327792%
+         3     4    2    0    2   0.03352426%
+         4     3    4    1    0   0.03327792%
+         5     3    3    1    1   0.71950219%
+         6     2    4    2    0   0.03352426%
+    -----------------------------------------
+               GAS1      GAS2    Contribution
+    -----------------------------------------
+                  6         2     0.78655071%
+                  7         1     0.06655584%
+                  8         0    99.14689344%
+    -----------------------------------------
+
+  ==> Pruning the Q space <==
+
+  Cycle 0 took: 0.002433 s
+
+  ---------------------------------- Cycle 1 -----------------------------------
+
+
+  ==> Diagonalizing the Hamiltonian in the P space <==
+
+  Initial P space dimension: 31
+  Not checking for spin-completeness.
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000052 s
+        β          0.000053 s
+        αα         0.000071 s
+        ββ         0.000067 s
+        αβ         0.000163 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 18 roots with 2S+1 = 1 *
+  Found 11 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Time spent diagonalizing H:   0.000737 s
+
+    P-space  CI Energy Root   0        = -76.029683013020 Eh =   0.0000 eV, S^2 = -0.000000
+
+
+  ==> Finding the Q space <==
+
+  Using SR screening algorithm
+  Time spent forming F space:             0.000155
+  Time spent merging thread F spaces:             0.000005
+  Size of F space: 0
+  Time spent building sorting list: 0.000001
+  Time spent building the model space: 0.000187
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing Coupling Lists <==
+  --------------------------------
+        α          0.000053 s
+        β          0.000053 s
+        αα         0.000069 s
+        ββ         0.000066 s
+        αβ         0.000163 s
+  --------------------------------
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 18 roots with 2S+1 = 1 *
+  Found 11 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.000736 s
+
+    PQ-space CI Energy Root   0        = -76.029683013020 Eh =   0.0000 eV, S^2 = -0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -76.029683013020 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  Contribution
+    -----------------------------------------
+         1     4    4    0    0  99.14689344%
+         2     4    3    0    1   0.03327792%
+         3     4    2    0    2   0.03352426%
+         4     3    4    1    0   0.03327792%
+         5     3    3    1    1   0.71950219%
+         6     2    4    2    0   0.03352426%
+    -----------------------------------------
+               GAS1      GAS2    Contribution
+    -----------------------------------------
+                  6         2     0.78655071%
+                  7         1     0.06655584%
+                  8         0    99.14689344%
+    -----------------------------------------
+  ***** Calculation Converged *****
 
   ==> ACI Natural Orbitals <==
 
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.000222 s
-        β          0.000294 s
+        α          0.000052 s
+        β          0.000052 s
         1B1     1.999783      1A1     1.999639      2A1     1.993312  
         1B2     1.991424      2B2     0.008564      3A1     0.007278  
 
   ==> Excited state solver summary <==
 
-  Iterations required:                         0
+  Iterations required:                         1
   Dimension of optimized determinant space:    31
 
-  * Selected-CI Energy Root   0        = -76.029683013021 Eh =   0.0000 eV
-  * Selected-CI Energy Root   0 + EPT2 = -76.029683013021 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0        = -76.029683013020 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -76.029683013020 Eh =   0.0000 eV
 
   ==> Wavefunction Information <==
 
   Most important contributions to root   0:
-    0  -0.995725 0.991468934           0 |220220>
-    1   0.047200 0.002227798          27 |220202>
-    2  -0.028090 0.000789031          25 |2+-2-+>
-    3  -0.028090 0.000789031          20 |2-+2+->
-    4   0.026911 0.000724178          18 |202220>
-    5  -0.018362 0.000337170          23 |+2-2-+>
-    6  -0.018362 0.000337170          14 |-2+2+->
-    7   0.018302 0.000334955          28 |222200>
-    8   0.016443 0.000270374          12 |-+2220>
-    9   0.016443 0.000270374          16 |+-2220>
+    0  -0.995725 0.991468934          30 |220220>
+    1   0.047200 0.002227798          29 |220202>
+    2  -0.028090 0.000789031          28 |2+-2-+>
+    3  -0.028090 0.000789031          27 |2-+2+->
+    4   0.026911 0.000724178          26 |202220>
+    5  -0.018362 0.000337170          25 |+2-2-+>
+    6  -0.018362 0.000337170          24 |-2+2+->
+    7   0.018302 0.000334955          23 |222200>
+    8   0.016443 0.000270374          22 |+-2220>
+    9   0.016443 0.000270374          21 |-+2220>
 
   Saving information for root: 0
 
@@ -729,14 +938,14 @@ Total time:
 
     Multi.(2ms)  Irrep.  No.               Energy
     ---------------------------------------------
-       1  (  0)    A1     0      -76.029683013021
+       1  (  0)    A1     0      -76.029683013020
     ---------------------------------------------
 
-  Time to prepare integrals:        0.125 seconds
-  Time to run job          :        0.013 seconds
-  Total                    :        0.013 seconds	ACI energy........................................................PASSED
+  Time to prepare integrals:        0.043 seconds
+  Time to run job          :        0.006 seconds
+  Total                    :        0.049 seconds    ACI energy............................................................................PASSED
 
-    Psi4 stopped on: Friday, 07 August 2020 04:42PM
-    Psi4 wall time for execution: 0:00:00.63
+    Psi4 stopped on: Saturday, 30 January 2021 03:41AM
+    Psi4 wall time for execution: 0:00:00.29
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/methods/gasci-2/output.ref
+++ b/tests/methods/gasci-2/output.ref
@@ -1,9 +1,9 @@
 
     -----------------------------------------------------------------------
           Psi4: An Open-Source Ab Initio Electronic Structure Package
-                               Psi4 1.4a2.dev1024 
+                               Psi4 undefined 
 
-                         Git: Rev {master} b603cfc dirty
+                         Git: Rev {x2c-norm} b906495 
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,9 +30,9 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Thursday, 12 November 2020 09:12PM
+    Psi4 started on: Saturday, 30 January 2021 03:41AM
 
-    Process ID: 86745
+    Process ID: 63847
     Host:       Yorks-Mac.local
     PSIDATADIR: /Users/york/src/psi4new/psi4/share/psi4
     Memory:     500.0 MiB
@@ -100,7 +100,7 @@ compare_values(refaci, eaci, 8, "Averaged ACI energy")
 Scratch directory: /Users/york/scratch/psi4/
 
 *** tstart() called on Yorks-Mac.local
-*** at Thu Nov 12 21:12:02 2020
+*** at Sat Jan 30 03:41:16 2021
 
    => Loading Basis Set <=
 
@@ -153,7 +153,7 @@ Scratch directory: /Users/york/scratch/psi4/
   Guess Type is GWH.
   Energy threshold   = 1.00e-10
   Density threshold  = 1.00e-10
-  Integral threshold = 0.00e+00
+  Integral threshold = 1.00e-12
 
   ==> Primary Basis <==
 
@@ -224,19 +224,19 @@ Scratch directory: /Users/york/scratch/psi4/
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter   1:   -74.69502194331994   -7.46950e+01   1.19380e-01 DIIS
-   @DF-RHF iter   2:   -75.63883488360746   -9.43813e-01   7.21524e-02 DIIS
-   @DF-RHF iter   3:   -76.01065330024663   -3.71818e-01   7.66497e-03 DIIS
-   @DF-RHF iter   4:   -76.01705150839236   -6.39821e-03   1.07848e-03 DIIS
-   @DF-RHF iter   5:   -76.01724771498378   -1.96207e-04   2.45196e-04 DIIS
-   @DF-RHF iter   6:   -76.01725930218001   -1.15872e-05   5.17439e-05 DIIS
-   @DF-RHF iter   7:   -76.01725996692933   -6.64749e-07   8.86755e-06 DIIS
-   @DF-RHF iter   8:   -76.01725998301265   -1.60833e-08   1.68546e-06 DIIS
-   @DF-RHF iter   9:   -76.01725998411617   -1.10352e-09   3.99731e-07 DIIS
-   @DF-RHF iter  10:   -76.01725998416693   -5.07612e-11   4.32937e-08 DIIS
-   @DF-RHF iter  11:   -76.01725998416728   -3.55271e-13   4.33252e-09 DIIS
-   @DF-RHF iter  12:   -76.01725998416723    5.68434e-14   4.75419e-10 DIIS
-   @DF-RHF iter  13:   -76.01725998416731   -8.52651e-14   4.32046e-11 DIIS
+   @DF-RHF iter   1:   -74.69502194331292   -7.46950e+01   1.19380e-01 DIIS
+   @DF-RHF iter   2:   -75.63883488359986   -9.43813e-01   7.21524e-02 DIIS
+   @DF-RHF iter   3:   -76.01065330024043   -3.71818e-01   7.66497e-03 DIIS
+   @DF-RHF iter   4:   -76.01705150838622   -6.39821e-03   1.07848e-03 DIIS
+   @DF-RHF iter   5:   -76.01724771497759   -1.96207e-04   2.45196e-04 DIIS
+   @DF-RHF iter   6:   -76.01725930217384   -1.15872e-05   5.17439e-05 DIIS
+   @DF-RHF iter   7:   -76.01725996692316   -6.64749e-07   8.86755e-06 DIIS
+   @DF-RHF iter   8:   -76.01725998300643   -1.60833e-08   1.68546e-06 DIIS
+   @DF-RHF iter   9:   -76.01725998410998   -1.10356e-09   3.99731e-07 DIIS
+   @DF-RHF iter  10:   -76.01725998416075   -5.07612e-11   4.32937e-08 DIIS
+   @DF-RHF iter  11:   -76.01725998416110   -3.55271e-13   4.33252e-09 DIIS
+   @DF-RHF iter  12:   -76.01725998416109    1.42109e-14   4.75420e-10 DIIS
+   @DF-RHF iter  13:   -76.01725998416119   -9.94760e-14   4.32045e-11 DIIS
 
   DF guess converged.
 
@@ -248,15 +248,15 @@ Scratch directory: /Users/york/scratch/psi4/
     Integrals threads:           1
     Schwarz Cutoff:          1E-12
 
-   @RHF iter  14:   -76.01729654450097   -7.60173e+01   1.19915e-05 DIIS
-   @RHF iter  15:   -76.01729655577866   -1.12777e-08   1.64017e-06 DIIS
-   @RHF iter  16:   -76.01729655606727   -2.88608e-10   4.89639e-07 DIIS
-   @RHF iter  17:   -76.01729655608833   -2.10605e-11   1.68507e-07 DIIS
-   @RHF iter  18:   -76.01729655609125   -2.92744e-12   4.58642e-08 DIIS
-   @RHF iter  19:   -76.01729655609148   -2.27374e-13   5.21060e-09 DIIS
-   @RHF iter  20:   -76.01729655609148    0.00000e+00   7.84812e-10 DIIS
-   @RHF iter  21:   -76.01729655609154   -5.68434e-14   1.27029e-10 DIIS
-   @RHF iter  22:   -76.01729655609157   -2.84217e-14   2.82298e-11 DIIS
+   @RHF iter  14:   -76.01729654450095   -7.60173e+01   1.19915e-05 DIIS
+   @RHF iter  15:   -76.01729655577867   -1.12777e-08   1.64017e-06 DIIS
+   @RHF iter  16:   -76.01729655606729   -2.88622e-10   4.89639e-07 DIIS
+   @RHF iter  17:   -76.01729655608825   -2.09610e-11   1.68507e-07 DIIS
+   @RHF iter  18:   -76.01729655609124   -2.98428e-12   4.58642e-08 DIIS
+   @RHF iter  19:   -76.01729655609152   -2.84217e-13   5.21060e-09 DIIS
+   @RHF iter  20:   -76.01729655609152    0.00000e+00   7.84812e-10 DIIS
+   @RHF iter  21:   -76.01729655609147    5.68434e-14   1.27029e-10 DIIS
+   @RHF iter  22:   -76.01729655609152   -5.68434e-14   2.82299e-11 DIIS
   Energy and wave function converged.
 
 
@@ -284,14 +284,14 @@ Scratch directory: /Users/york/scratch/psi4/
              A1    A2    B1    B2 
     DOCC [     3,    0,    1,    1 ]
 
-  @RHF Final Energy:   -76.01729655609157
+  @RHF Final Energy:   -76.01729655609152
 
    => Energetics <=
 
     Nuclear Repulsion Energy =              8.8046866532470247
-    One-Electron Energy =                -122.3894315645718223
-    Two-Electron Energy =                  37.5674483552332390
-    Total Energy =                        -76.0172965560915657
+    One-Electron Energy =                -122.3894315645717938
+    Two-Electron Energy =                  37.5674483552332532
+    Total Energy =                        -76.0172965560915230
 
 Computation Completed
 
@@ -313,15 +313,15 @@ Properties computed using the SCF density matrix
      X:     0.0000      Y:     0.0000      Z:     2.2414     Total:     2.2414
 
 
-*** tstop() called on Yorks-Mac.local at Thu Nov 12 21:12:02 2020
+*** tstop() called on Yorks-Mac.local at Sat Jan 30 03:41:17 2021
 Module time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.20 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       0.23 seconds =       0.00 minutes
-	system time =       0.01 seconds =       0.00 minutes
-	total time  =          0 seconds =       0.00 minutes
+	user time   =       0.20 seconds =       0.00 minutes
+	system time =       0.02 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
     SCF energy............................................................................PASSED
 
 Scratch directory: /Users/york/scratch/psi4/
@@ -332,7 +332,7 @@ Scratch directory: /Users/york/scratch/psi4/
   ----------------------------------------------------------------------------
   A suite of quantum chemistry methods for strongly correlated electrons
 
-    git branch: gasci-msaverage - git commit: 6561a55f
+    git branch: relax_overlap - git commit: 416ba2ac
 
   Developed by:
     Francesco A. Evangelista, Chenyang Li, Kevin P. Hannon,
@@ -340,16 +340,9 @@ Scratch directory: /Users/york/scratch/psi4/
     Nan He, Nicholas Stair, Shuhe Wang, Renke Huang
   ----------------------------------------------------------------------------
 
-  Size of Determinant class: 256 bits
-  Preparing forte objects from a psi4 Wavefunction object   => Loading Basis Set <=
+  Size of Determinant class: 128 bits
 
-    Name: STO-3G
-    Role: ORBITAL
-    Keyword: MINAO_BASIS
-    atoms 1   entry O          line    81 file /Users/york/src/psi4new/psi4/share/psi4/basis/sto-3g.gbs 
-    atoms 2-3 entry H          line    19 file /Users/york/src/psi4new/psi4/share/psi4/basis/sto-3g.gbs 
-
-
+  Preparing forte objects from a Psi4 Wavefunction object
   Read options for space GAS1
   Read options for space GAS2
   Read options for space GAS1
@@ -372,7 +365,40 @@ Scratch directory: /Users/york/scratch/psi4/
     FROZEN_UOCC         0     0     0     0     0
     Total              12     2     4     7    25
   -------------------------------------------------
+
+   => Loading Basis Set <=
+
+    Name: 6-31G**
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   149 file /Users/york/src/psi4new/psi4/share/psi4/basis/6-31gss.gbs 
+    atoms 2-3 entry H          line    44 file /Users/york/src/psi4new/psi4/share/psi4/basis/6-31gss.gbs 
+
+
+  Checking orbital orthonormality against current geometry ... Done (OK)
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: MINAO_BASIS
+    atoms 1   entry O          line    81 file /Users/york/src/psi4new/psi4/share/psi4/basis/sto-3g.gbs 
+    atoms 2-3 entry H          line    19 file /Users/york/src/psi4new/psi4/share/psi4/basis/sto-3g.gbs 
+
+
   Forte will use psi4 integrals
+
+  ==> Primary Basis Set Summary <==
+
+  Basis Set: 6-31G**
+    Blend: 6-31G**
+    Number of shells: 12
+    Number of basis function: 25
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: false
+    Max angular momentum: 2
+
+
   JK created using conventional PK integrals
   Using in-core PK algorithm.
    Calculation information:
@@ -390,18 +416,25 @@ Scratch directory: /Users/york/scratch/psi4/
   We computed 3081 shell quartets total.
   Whereas there are 3081 unique shell quartets.
 
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:             4577
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
 
 
   ==> Integral Transformation <==
 
-  Number of molecular orbitals:                    25
-  Number of correlated molecular orbitals:         25
-  Number of frozen occupied orbitals:               0
-  Number of frozen unoccupied orbitals:             0
-  Two-electron integral type:              Conventional
-
-
-  Overall Conventional Integrals timings
+  Number of molecular orbitals:                         25
+  Number of correlated molecular orbitals:              25
+  Number of frozen occupied orbitals:                    0
+  Number of frozen unoccupied orbitals:                  0
+  Two-electron integral type:                 Conventional
 
 
   Computing Conventional Integrals	Presorting SO-basis two-electron integrals.
@@ -413,12 +446,12 @@ Scratch directory: /Users/york/scratch/psi4/
 	Starting second half-transformation.
 	Two-electron integral transformation complete.
 
-  Integral transformation done. 0.01171926 s
+  Integral transformation done. 0.01275206 s
   Reading the two-electron integrals from disk
   Size of two-electron integrals:   0.008731 GB
-  Timing for conventional integral transformation:            0.030 s.
+  Timing for conventional integral transformation:            0.028 s.
   Timing for freezing core and virtual orbitals:              0.000 s.
-  Conventional integrals take 0.03054577 s
+  Timing for computing conventional integrals:                0.028 s.
 
   ==> Summary of Active Space Solver Input <==
 
@@ -482,26 +515,48 @@ Scratch directory: /Users/york/scratch/psi4/
   Number of active alpha electrons: 5
   Number of active beta electrons: 5
   Maximum reference space size: 1000
-  The maximum number of electrons in GAS1 is 1
-  The minimum number of electrons in GAS1 is 0
-  The maximum number of electrons in GAS2 is 10 
-  The minimum number of electrons in GAS2 is 0
-  
-  Possible electron occupations in the GAS 
-  GAS1_A  GAS1_B  GAS2_A  GAS2_B  
-     1       0       4       5    
-     0       1       5       4    
-     0       0       5       5    
 
-  GAS Orbital Energies
-  GAS   Energies    Orb 
-  1  -20.568999574  0 
-  2  -1.320609273  1 
-  2  -0.563930450  2 
-  2   0.202465902  3 
-  2  -0.495003944  4 
-  2  -0.678724187  5 
-  2   0.292719335  6 
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.56899957      0
+     2    -1.32060927      1
+     2    -0.56393045      2
+     2     0.20246590      3
+     2    -0.49500394      4
+     2    -0.67872419      5
+     2     0.29271934      6
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    1    0
+      2   10    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B
+    ---------------------------
+         1     1    0    4    5
+         2     0    1    5    4
+         3     0    0    5    5
+    ---------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              27  7.851e-05
+         2              27  5.608e-05
+         3              14  4.124e-05
+    ---------------------------------
+    Total:              68  2.094e-04
+    ---------------------------------
 
   ==> Diagonalizing the Hamiltonian in the P + Q space <==
 
@@ -509,11 +564,11 @@ Scratch directory: /Users/york/scratch/psi4/
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.000150 s
-        β          0.000151 s
-        αα         0.000233 s
-        ββ         0.000232 s
-        αβ         0.000585 s
+        α          0.000137 s
+        β          0.000136 s
+        αα         0.000228 s
+        ββ         0.000217 s
+        αβ         0.000566 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
@@ -522,30 +577,34 @@ Scratch directory: /Users/york/scratch/psi4/
   Found 33 roots with 2S+1 = 1 *
   Found 31 roots with 2S+1 = 3
   Found 4 roots with 2S+1 = 5
-  Total time spent diagonalizing H:   0.002822 s
+  Total time spent diagonalizing H:   0.002507 s
 
-    PQ-space CI Energy Root   0        = -55.841944166829 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy Root   0        = -55.841944166829 Eh =   0.0000 eV, S^2 = -0.000000
     PQ-space CI Energy + EPT2 Root   0 = -55.841944166829 Eh =   0.0000 eV
 
-  
-  GAS Contribution Analysis  
-  GAS contributions root 0: 
-  GAS1_A    GASI_B    GAS2_A    GAS2_B        Cont  
-     1         0         4         5        0.499976323  
-     0         1         5         4        0.499976323  
-     0         0         5         5        0.000047353  
 
-           0                  10            0.000047353  
-           1                  9            0.999952647  
+  ==> GAS Contribution Analysis <==
 
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  Contribution
+    -----------------------------------------
+         1     1    0    4    5  49.99763233%
+         2     0    1    5    4  49.99763233%
+         3     0    0    5    5   0.00473534%
+    -----------------------------------------
+               GAS1      GAS2    Contribution
+    -----------------------------------------
+                  0        10     0.00473534%
+                  1         9    99.99526466%
+    -----------------------------------------
 
   ==> ACI Natural Orbitals <==
 
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.000145 s
-        β          0.000148 s
+        α          0.000135 s
+        β          0.000143 s
         1B1     1.999996      1A1     1.999966      2A1     1.999260  
         1B2     1.997347      3A1     1.009512      4A1     0.990076  
         2B2     0.003842  
@@ -561,16 +620,16 @@ Scratch directory: /Users/york/scratch/psi4/
   ==> Wavefunction Information <==
 
   Most important contributions to root   0:
-    0   0.658040 0.433017134          53 |-22+220>
-    1   0.658040 0.433017134          23 |+22-220>
-    2   0.161418 0.026055697          52 |-22+2+->
-    3   0.161418 0.026055697          21 |+22-2-+>
-    4   0.136652 0.018673696          47 |-22+2-+>
-    5   0.136652 0.018673696          22 |+22-2+->
-    6  -0.107422 0.011539587          51 |-2+2220>
-    7  -0.107422 0.011539587          18 |+2-2220>
-    8  -0.087938 0.007733024          49 |-+22220>
-    9  -0.087938 0.007733024          10 |+-22220>
+    0  -0.658040 0.433017134          41 |-22+220>
+    1  -0.658040 0.433017134          14 |+22-220>
+    2  -0.161418 0.026055697          40 |-22+2+->
+    3  -0.161418 0.026055697          12 |+22-2-+>
+    4  -0.136652 0.018673696          13 |+22-2+->
+    5  -0.136652 0.018673696          35 |-22+2-+>
+    6   0.107422 0.011539587          39 |-2+2220>
+    7   0.107422 0.011539587          10 |+2-2220>
+    8   0.087938 0.007733024          37 |-+22220>
+    9   0.087938 0.007733024           6 |+-22220>
 
   Saving information for root: 0
 
@@ -623,27 +682,50 @@ Scratch directory: /Users/york/scratch/psi4/
   Number of active alpha electrons: 5
   Number of active beta electrons: 5
   Maximum reference space size: 1000
-  The maximum number of electrons in GAS1 is 2
-  The minimum number of electrons in GAS1 is 0
-  The maximum number of electrons in GAS2 is 10 
-  The minimum number of electrons in GAS2 is 0
-  
-  Possible electron occupations in the GAS 
-  GAS1_A  GAS1_B  GAS2_A  GAS2_B  
-     1       1       4       4    
-     1       0       4       5    
-     0       1       5       4    
-     0       0       5       5    
 
-  GAS Orbital Energies
-  GAS   Energies    Orb 
-  1  -20.568999574  0 
-  2  -1.320609273  1 
-  2  -0.563930450  2 
-  2   0.202465902  3 
-  2  -0.495003944  4 
-  2  -0.678724187  5 
-  2   0.292719335  6 
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.56899957      0
+     2    -1.32060927      1
+     2    -0.56393045      2
+     2     0.20246590      3
+     2    -0.49500394      4
+     2    -0.67872419      5
+     2     0.29271934      6
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    0
+      2   10    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B
+    ---------------------------
+         1     1    1    4    4
+         2     1    0    4    5
+         3     0    1    5    4
+         4     0    0    5    5
+    ---------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              65  7.638e-05
+         2              27  5.617e-05
+         3              27  5.300e-05
+         4              14  4.269e-05
+    ---------------------------------
+    Total:             133  2.717e-04
+    ---------------------------------
 
   ==> Diagonalizing the Hamiltonian in the P + Q space <==
 
@@ -651,11 +733,11 @@ Scratch directory: /Users/york/scratch/psi4/
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.000278 s
-        β          0.000281 s
-        αα         0.000416 s
-        ββ         0.000415 s
-        αβ         0.001141 s
+        α          0.000244 s
+        β          0.000248 s
+        αα         0.000392 s
+        ββ         0.000460 s
+        αβ         0.001014 s
   --------------------------------
 
   Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
@@ -664,32 +746,36 @@ Scratch directory: /Users/york/scratch/psi4/
   Found 70 roots with 2S+1 = 1 *
   Found 56 roots with 2S+1 = 3
   Found 7 roots with 2S+1 = 5
-  Total time spent diagonalizing H:   0.006980 s
+  Total time spent diagonalizing H:   0.005502 s
 
     PQ-space CI Energy Root   0        = -76.029945793736 Eh =   0.0000 eV, S^2 = 0.000000
     PQ-space CI Energy + EPT2 Root   0 = -76.029945793736 Eh =   0.0000 eV
 
-  
-  GAS Contribution Analysis  
-  GAS contributions root 0: 
-  GAS1_A    GASI_B    GAS2_A    GAS2_B        Cont  
-     1         1         4         4        0.999999549  
-     1         0         4         5        0.000000181  
-     0         1         5         4        0.000000181  
-     0         0         5         5        0.000000090  
 
-           0                  10            0.000000090  
-           1                  9            0.000000362  
-           2                  8            0.999999549  
+  ==> GAS Contribution Analysis <==
 
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  Contribution
+    -----------------------------------------
+         1     1    1    4    4  99.99995488%
+         2     1    0    4    5   0.00001808%
+         3     0    1    5    4   0.00001808%
+         4     0    0    5    5   0.00000897%
+    -----------------------------------------
+               GAS1      GAS2    Contribution
+    -----------------------------------------
+                  0        10     0.00000897%
+                  1         9     0.00003616%
+                  2         8    99.99995488%
+    -----------------------------------------
 
   ==> ACI Natural Orbitals <==
 
 
   ==> Computing Coupling Lists <==
   --------------------------------
-        α          0.000270 s
-        β          0.000272 s
+        α          0.000249 s
+        β          0.000253 s
         1A1     2.000000      1B1     1.999763      2A1     1.999632  
         3A1     1.992837      1B2     1.990959      2B2     0.009046  
         4A1     0.007763  
@@ -705,16 +791,16 @@ Scratch directory: /Users/york/scratch/psi4/
   ==> Wavefunction Information <==
 
   Most important contributions to root   0:
-    0   0.995550 0.991119643          56 |2220220>
-    1  -0.047916 0.002295913          49 |2220202>
-    2   0.028911 0.000835846          40 |22-+2+->
-    3   0.028911 0.000835846          48 |22+-2-+>
-    4  -0.027687 0.000766589          39 |2202220>
-    5   0.018759 0.000351914          46 |2+2-2-+>
-    6   0.018759 0.000351914          21 |2-2+2+->
-    7  -0.018138 0.000328970          64 |2222200>
-    8  -0.016774 0.000281351          20 |2-+2220>
-    9  -0.016774 0.000281351          37 |2+-2220>
+    0   0.995550 0.991119643          44 |2220220>
+    1  -0.047916 0.002295913          37 |2220202>
+    2   0.028911 0.000835846          36 |22+-2-+>
+    3   0.028911 0.000835846          31 |22-+2+->
+    4  -0.027687 0.000766589          30 |2202220>
+    5   0.018759 0.000351914          34 |2+2-2-+>
+    6   0.018759 0.000351914          19 |2-2+2+->
+    7  -0.018138 0.000328970          60 |2222200>
+    8  -0.016774 0.000281351          28 |2+-2220>
+    9  -0.016774 0.000281351          18 |2-+2220>
 
   Saving information for root: 0
 
@@ -727,11 +813,11 @@ Scratch directory: /Users/york/scratch/psi4/
        1  (  0)    A1     0      -76.029945793736
     ---------------------------------------------
 
-  Time to prepare integrals:        0.056 seconds
-  Time to run job          :        0.014 seconds
-  Total                    :        0.014 seconds    Averaged ACI energy...................................................................PASSED
+  Time to prepare integrals:        0.043 seconds
+  Time to run job          :        0.013 seconds
+  Total                    :        0.056 seconds    Averaged ACI energy...................................................................PASSED
 
-    Psi4 stopped on: Thursday, 12 November 2020 09:12PM
-    Psi4 wall time for execution: 0:00:00.34
+    Psi4 stopped on: Saturday, 30 January 2021 03:41AM
+    Psi4 wall time for execution: 0:00:00.32
 
 *** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
## Description
Make the GAS reference code more compact.
The algorithm for generating GAS determinants is the following:
```
1. for each GAS electron occupation, do
2.     generate alpha/beta strings for each GAS subspace, classified according to irrep
3.     compute the Cartesian product (i.e., itertools.product in Python) of the result of line 2
4.     for each product in line 3, do
5.         build alpha/beta string of size the number of active orbitals, classified according to irrep
6.         end do
7.     combine alpha/beta strings to match the required symmetry
8.     end do
```

## Checklist
- [x] Added tests of new features (no change)
- [x] Removed comments in code and input files
- [x] Documented source code
- [x] Checked for redundant headers
- [x] Checked for consistency in the formatting of the output file
- [x] Documented new features in the manual (no change)
- [x] Ready to go!
