### PR TITLE
Adding algorithm header for 6 source files

### DIFF
--- a/forte/fci/fci_vector_h_diag.cc
+++ b/forte/fci/fci_vector_h_diag.cc
@@ -25,7 +25,7 @@
  *
  * @END LICENSE
  */
-
+#include <algorithm>
 #include <cmath>
 #include <numeric>
 #include <vector>

--- a/forte/fci/fci_vector_rdm.cc
+++ b/forte/fci/fci_vector_rdm.cc
@@ -25,7 +25,7 @@
  *
  * @END LICENSE
  */
-
+#include <algorithm>
 #include <cmath>
 
 #include "psi4/psi4-dec.h"

--- a/forte/integrals/integrals_psi4_interface.cc
+++ b/forte/integrals/integrals_psi4_interface.cc
@@ -25,6 +25,7 @@
  *
  * @END LICENSE
  */
+#include <algorithm>
 
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"

--- a/forte/mrdsrg-spin-adapted/sadsrg_block_labels.cc
+++ b/forte/mrdsrg-spin-adapted/sadsrg_block_labels.cc
@@ -25,7 +25,7 @@
  *
  * @END LICENSE
  */
-
+#include <algorithm>
 #include "sadsrg.h"
 
 using namespace psi;

--- a/forte/mrdsrg-spin-adapted/sadsrg_comm.cc
+++ b/forte/mrdsrg-spin-adapted/sadsrg_comm.cc
@@ -25,6 +25,7 @@
  *
  * @END LICENSE
  */
+#include <algorithm>
 
 #include "psi4/libpsi4util/PsiOutStream.h"
 

--- a/forte/mrdsrg-spin-integrated/master_mrdsrg.cc
+++ b/forte/mrdsrg-spin-integrated/master_mrdsrg.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <numeric>
 
 #include "psi4/libpsi4util/PsiOutStream.h"


### PR DESCRIPTION
## Description
This PR adds 6 <algorithm> header for 6 source files which leads to an error compiling with g++ on ubuntu.

## User Notes
- Add #include<algorithm> for source code used them.

## Checklist

