### PR TITLE
Add missing include

### DIFF
--- a/forte/sparse_ci/sparse_exp.cc
+++ b/forte/sparse_ci/sparse_exp.cc
@@ -26,6 +26,7 @@
  * @END LICENSE
  */
 
+#include <algorithm>
 #include <cmath>
 
 #include "sparse_ci/sparse_exp.h"


### PR DESCRIPTION
## Description
Adds a missing include file in `sparse_exp.cc`.