### PR TITLE
Added "#include <algorithm>" in a couple of files

### DIFF
--- a/forte/orbital-helpers/ci-no/ci-no.cc
+++ b/forte/orbital-helpers/ci-no/ci-no.cc
@@ -27,6 +27,7 @@
  * @END LICENSE
  */
 
+#include <algorithm>
 #include "psi4/libpsi4util/PsiOutStream.h"
 #include "psi4/libmints/vector.h"
 

--- a/forte/orbital-helpers/ci-no/mrci-no.cc
+++ b/forte/orbital-helpers/ci-no/mrci-no.cc
@@ -27,6 +27,7 @@
  * @END LICENSE
  */
 
+#include <algorithm>
 #include <numeric>
 
 #include "psi4/libpsi4util/PsiOutStream.h"


### PR DESCRIPTION
## Description

Added the "#include <algorithm>" line in the ci-no.cc and mrci-no.cc files. The std::sort function that is used in these files is defined in header <algorithm>. This fixes potential problems with compilation, especially with gcc compilers.