### PR TITLE
make setup.py more flexible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import find_packages
 
 import os
+import psutil
 import re
 import sys
 import sysconfig
@@ -22,13 +23,20 @@ class CMakeBuild(build_ext):
     build_ext.user_options = build_ext.user_options + [
         ('ambitpath', None, 'the path to ambit'),
         ('max_det_orb', 64, 'the maximum number of orbitals used by the Determinant class'),
-        ('enable_codecov',False,'enable code coverage')
+        ('enable_codecov', False, 'enable code coverage'),
+        ('cmake_config_options', '', 'cmake configuration'),
+        ('cmake_build_options', '', 'cmake build options')
         ]
 
     def initialize_options(self):
         self.ambitpath = None
         self.max_det_orb = 64
         self.enable_codecov = 'OFF'
+        self.cmake_config_options = ''
+        ncore_phys = psutil.cpu_count(logical=False)
+        ncore_virt = psutil.cpu_count(logical=True)
+        nprocs = ncore_phys + 1 if ncore_phys != ncore_virt else ncore_phys
+        self.cmake_build_options = f'-j{nprocs}'
         return build_ext.initialize_options(self)
 
     def run(self):
@@ -57,23 +65,26 @@ class CMakeBuild(build_ext):
         print(f'\n    BUILD_TYPE = {cfg}')
         print(f'    AMBITPATH = {self.ambitpath}')
         print(f'    MAX_DET_ORB = {self.max_det_orb}')
-        print(f'    ENABLE_CODECOV = {str(self.enable_codecov).upper()}\n')
+        print(f'    ENABLE_CODECOV = {str(self.enable_codecov).upper()}')
+        print(f'    CMAKE_CONFIG_OPTIONS = {self.cmake_config_options}')
+        print(f'    CMAKE_BUILD_OPTIONS = {self.cmake_build_options}\n')
 
         if 'AMBITPATH' in os.environ:
             self.ambitpath = os.environ['AMBITPATH']
-        
-        if self.ambitpath == None or self.ambitpath == 'None' or self.ambitpath == '':
+
+        if self.ambitpath in [None, 'None', '']:
             msg = """
     Please specifiy a correct ambit path. This can be done in two ways:
     1) Set the environmental variable AMBITPATH to the ambit install directory.
-    2) Modify the setup.cfg file to include the lines:                
+    2) Modify the setup.cfg file to include the lines:
         >[CMakeBuild]
         >ambitpath=<path to ambit install dir>
 """
             raise RuntimeError(msg)
-       
+
         # grab the cmake configuration from psi4
-        process = subprocess.Popen(['psi4', '--plugin-compile'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        process = subprocess.Popen(['psi4', '--plugin-compile'],
+                                   stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = process.communicate()
         cmake_args = out.decode("utf-8").split()[1:]
 
@@ -83,9 +94,10 @@ class CMakeBuild(build_ext):
         cmake_args += [f'-DMAX_DET_ORB={self.max_det_orb}']
         cmake_args += [f'-DENABLE_CODECOV={str(self.enable_codecov).upper()}']
         cmake_args += [f'-DENABLE_ForteTests=TRUE']
+        cmake_args += self.cmake_config_options.split()
 
         # define build arguments
-        build_args = ['-j2']
+        build_args = self.cmake_build_options.split()
 
         # call cmake and build
         subprocess.check_call(['cmake'] + cmake_args)
@@ -97,7 +109,7 @@ setup(
     name='forte',
     version='0.2.0',
     author='Forte team',
-    description='A hybrid Python/C++ quantum chemistry ipackage for strongly correlated electrons.',
+    description='A hybrid Python/C++ quantum chemistry package for strongly correlated electrons.',
     long_description='Forte is an open-source plugin to Psi4 that implements a variety of quantum chemistry methods for strongly correlated electrons.',
     packages=['forte'],
     # tell setuptools that all packages will be under the '.' directory


### PR DESCRIPTION
## Description
I just realized there is a setup.py. This PR makes the cmake commands more configurable from setup.cfg. For example,

```
[CMakeBuild]
ambitpath=/Users/york/src/ambit-bin-debug
cmake_build_options=-j8 -v
cmake_config_options=-DCMAKE_C_COMPILER=/usr/local/Cellar/llvm/12.0.0/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/Cellar/llvm/12.0.0/bin/clang++ -DCMAKE_Fortran_COMPILER=/usr/local/Cellar/gcc/10.2.0_4/bin/gfortran
```

## User Notes
- [x] Changes to compilation (if any)
- [x] The default maximum number of concurrent processes to use for cmake building is adapted to the number of physical CPU cores (+1 if hyperthreading).

## Checklist
- [x] Ready to go!
