### PR TITLE
Enable rotation between the orbitals in CASSCF_ACTIVE_FROZEN_ORBITAL

### DIFF
--- a/forte/casscf/casscf_orb_grad.cc
+++ b/forte/casscf/casscf_orb_grad.cc
@@ -232,6 +232,16 @@ void CASSCF_ORB_GRAD::read_options() {
                 zero_rots_[irrep][nu].emplace(p);
                 zero_rots_[irrep][p].emplace(nu);
             }
+
+            // enable rotation between the orbitals within CASSCF_ACTIVE_FROZEN_ORBITAL
+            for (size_t j = 0; j < i; ++j) {
+                size_t v = frza_rot[j];
+                if (actv_rel_mos[v].first == irrep) {
+                    auto ki = actv_rel_mos[v].second;
+                    zero_rots_[irrep][nu].erase(ki);
+                    zero_rots_[irrep][ki].erase(nu);
+                }
+            }
         }
     }
 

--- a/forte/orbital-helpers/orbitaloptimizer.cc
+++ b/forte/orbital-helpers/orbitaloptimizer.cc
@@ -366,14 +366,16 @@ void OrbitalOptimizer::orbital_gradient() {
         std::set_difference(active.begin(), active.end(), active_frozen.begin(),
                             active_frozen.end(), std::inserter(unfrozen, unfrozen.begin()));
 
-        for (int i : active_frozen) {
-            for (int j : active_frozen) {
-                size_t ii = active_abs_[i];
-                size_t jj = active_abs_[j];
-                Orb_grad_Fock->set(nhole_map_[ii], npart_map_[jj], 0.0);
-                Orb_grad_Fock->set(nhole_map_[jj], npart_map_[ii], 0.0);
-            }
-        }
+        // This part is removed to enable the rotation between the orbitals within
+        // CASSCF_ACTIVE_FROZEN_ORBITAL
+        // for (int i : active_frozen) {
+        //    for (int j : active_frozen) {
+        //        size_t ii = active_abs_[i];
+        //        size_t jj = active_abs_[j];
+        //        Orb_grad_Fock->set(nhole_map_[ii], npart_map_[jj], 0.0);
+        //        Orb_grad_Fock->set(nhole_map_[jj], npart_map_[ii], 0.0);
+        //    }
+        // }
         for (int i : active_frozen) {
             for (int j : unfrozen) {
                 size_t ii = active_abs_[i];

--- a/forte/orbital-helpers/orbitaloptimizer.cc
+++ b/forte/orbital-helpers/orbitaloptimizer.cc
@@ -366,16 +366,6 @@ void OrbitalOptimizer::orbital_gradient() {
         std::set_difference(active.begin(), active.end(), active_frozen.begin(),
                             active_frozen.end(), std::inserter(unfrozen, unfrozen.begin()));
 
-        // This part is removed to enable the rotation between the orbitals within
-        // CASSCF_ACTIVE_FROZEN_ORBITAL
-        // for (int i : active_frozen) {
-        //    for (int j : active_frozen) {
-        //        size_t ii = active_abs_[i];
-        //        size_t jj = active_abs_[j];
-        //        Orb_grad_Fock->set(nhole_map_[ii], npart_map_[jj], 0.0);
-        //        Orb_grad_Fock->set(nhole_map_[jj], npart_map_[ii], 0.0);
-        //    }
-        // }
         for (int i : active_frozen) {
             for (int j : unfrozen) {
                 size_t ii = active_abs_[i];

--- a/tests/methods/sa-gasscf-4/input.dat
+++ b/tests/methods/sa-gasscf-4/input.dat
@@ -1,0 +1,50 @@
+# Test correct implementation of casscf_active_frozen_orbital
+refgasscf = -168.895998770165 #TEST
+import forte
+memory 2gb
+
+molecule n2o{
+ N          0.00000        0.00000       -1.21202
+ N          0.00000        0.00000       -0.06157
+ O          0.00000        0.00000        1.11439
+}
+
+set basis cc-pvdz
+
+set {
+scf_type            pk
+reference           rohf
+e_convergence       8
+d_convergence       8
+}
+
+Ezero, wfn = energy('scf', return_wfn=True)
+
+set forte {
+  ms 0.0
+  multiplicity 1
+  job_type            mcscf_two_step
+  active_space_solver aci
+  casscf_ci_solver    aci
+  active_ref_type     gas
+  one_cycle           true
+  gas1                [1,0,0,0]
+  gas2                [1,0,0,0]
+  gas3                [1,0,0,0]
+  gas4                [4,0,1,1]
+  gas5                [0,0,2,2]
+  gas1max             [2,2]
+  gas1min             [2,2]
+  gas2max             [2,2]
+  gas2min             [2,2]
+  gas3max             [1,1]
+  gas4max             [12,12]
+  gas4min             [12,12]
+  avg_state           [[2,1,1],[3,1,1]]
+  casscf_active_frozen_orbital [1,2] #This option now freezes all rotations 
+  # between orbital 1/2 and all other orbitals EXCEPT the rotation between 1 and 2.
+   
+}
+egasscf, wfn_gasscf = energy('forte', return_wfn = True, ref_wfn=wfn)
+compare_values(refgasscf, egasscf ,9, "GASSCF energy") #TEST
+                                                                           

--- a/tests/methods/sa-gasscf-4/output.ref
+++ b/tests/methods/sa-gasscf-4/output.ref
@@ -1,0 +1,5511 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.4a3.dev225 
+
+                         Git: Rev {HEAD} 7105e37 
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Wednesday, 28 July 2021 05:39PM
+
+    Process ID: 3514
+    Host:       DESKTOP-SQPD2D3
+    PSIDATADIR: /home/mhuang/psi4_install/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+# Test correct implementation of casscf_active_frozen_orbital
+refgasscf = -168.895998770165 #TEST
+import forte
+memory 2gb
+
+molecule n2o{
+ N          0.00000        0.00000       -1.21202
+ N          0.00000        0.00000       -0.06157
+ O          0.00000        0.00000        1.11439
+}
+
+set basis cc-pvdz
+
+set {
+scf_type            pk
+reference           rohf
+e_convergence       8
+d_convergence       8
+}
+
+Ezero, wfn = energy('scf', return_wfn=True)
+
+set forte {
+  ms 0.0
+  multiplicity 1
+  job_type            mcscf_two_step
+  active_space_solver aci
+  casscf_ci_solver    aci
+  active_ref_type     gas
+  one_cycle           true
+  gas1                [1,0,0,0]
+  gas2                [1,0,0,0]
+  gas3                [1,0,0,0]
+  gas4                [4,0,1,1]
+  gas5                [0,0,2,2]
+  gas1max             [2,2]
+  gas1min             [2,2]
+  gas2max             [2,2]
+  gas2min             [2,2]
+  gas3max             [1,1]
+  gas4max             [12,12]
+  gas4min             [12,12]
+  avg_state           [[2,1,1],[3,1,1]]
+  casscf_active_frozen_orbital [1,2] #This option now freezes all rotations 
+  # between orbital 1/2 and all other orbitals EXCEPT the rotation between 1 and 2.
+   
+}
+egasscf, wfn_gasscf = energy('forte', return_wfn = True, ref_wfn=wfn)
+compare_values(refgasscf, egasscf ,9, "GASSCF energy") #TEST
+                                                                           
+--------------------------------------------------------------------------
+
+  Memory set to   1.863 GiB by Python driver.
+
+Scratch directory: /tmp/
+
+*** tstart() called on DESKTOP-SQPD2D3
+*** at Wed Jul 28 17:39:03 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry N          line   168 file /home/mhuang/psi4_install/share/psi4/basis/cc-pvdz.gbs 
+    atoms 3   entry O          line   198 file /home/mhuang/psi4_install/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                             ROHF Reference
+                        1 Threads,   1907 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         N            0.000000000000     0.000000000000    -1.211801775307    14.003074004430
+         N            0.000000000000     0.000000000000    -0.061351775307    14.003074004430
+         O            0.000000000000     0.000000000000     1.114608224693    15.994914619570
+
+  Running in c2v symmetry.
+
+  Rotational constants: A = ************  B =      0.41637  C =      0.41637 [cm^-1]
+  Rotational constants: A = ************  B =  12482.49526  C =  12482.49526 [MHz]
+  Nuclear repulsion =   60.476551807089599
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 22
+  Nalpha       = 11
+  Nbeta        = 11
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is PK.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-08
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 18
+    Number of basis functions: 42
+    Number of Cartesian functions: 45
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              18
+      Number of primitives:             66
+      Number of atomic orbitals:        45
+      Number of basis functions:        42
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 816312 doubles for integral storage.
+  We computed 14701 shell quartets total.
+  Whereas there are 14706 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:             1430
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+  Minimum eigenvalue in the overlap matrix is 3.0234083581E-03.
+  Reciprocal condition number of the overlap matrix is 8.8315118118E-04.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        21      21 
+     A2         3       3 
+     B1         9       9 
+     B2         9       9 
+   -------------------------
+    Total      42      42
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @ROHF iter SAD:  -183.04604385436028   -1.83046e+02   0.00000e+00 
+   @ROHF iter   1:  -183.60450952913698   -5.58466e-01   1.36984e-02 DIIS
+   @ROHF iter   2:  -183.63426097730002   -2.97514e-02   1.12031e-02 DIIS
+   @ROHF iter   3:  -183.68905505059323   -5.47941e-02   1.31431e-03 DIIS
+   @ROHF iter   4:  -183.68998136423798   -9.26314e-04   9.30220e-04 DIIS
+   @ROHF iter   5:  -183.69044108731987   -4.59723e-04   1.85835e-04 DIIS
+   @ROHF iter   6:  -183.69049636381169   -5.52765e-05   4.64291e-05 DIIS
+   @ROHF iter   7:  -183.69049901781813   -2.65401e-06   1.38540e-05 DIIS
+   @ROHF iter   8:  -183.69049917373113   -1.55913e-07   3.32149e-06 DIIS
+   @ROHF iter   9:  -183.69049918264466   -8.91353e-09   5.63124e-07 DIIS
+   @ROHF iter  10:  -183.69049918296167   -3.17016e-10   1.00491e-07 DIIS
+   @ROHF iter  11:  -183.69049918297026   -8.58336e-12   8.56005e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A1   -20.661061     2A1   -15.851844     3A1   -15.704146  
+       4A1    -1.619626     5A1    -1.412474     6A1    -0.833480  
+       1B1    -0.758055     1B2    -0.758055     7A1    -0.691669  
+       2B2    -0.481914     2B1    -0.481914  
+
+    Singly Occupied:                                                      
+
+    
+
+    Virtual:                                                              
+
+       3B2     0.152473     3B1     0.152473     8A1     0.365194  
+       9A1     0.590897     4B2     0.855858     4B1     0.855858  
+      10A1     0.886084    11A1     0.958310    12A1     1.007568  
+       5B2     1.013792     5B1     1.013792     6B1     1.256525  
+       6B2     1.256525    13A1     1.406207    14A1     1.660400  
+       1A2     1.696232    15A1     1.696232     7B2     1.755180  
+       7B1     1.755180     2A2     2.181275    16A1     2.181275  
+      17A1     2.370425     8B2     2.670779     8B1     2.670779  
+      18A1     2.922468     3A2     2.945779    19A1     2.945779  
+      20A1     3.576616     9B1     3.709940     9B2     3.709940  
+      21A1     4.070021  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     7,    0,    2,    2 ]
+    SOCC [     0,    0,    0,    0 ]
+
+  @ROHF Final Energy:  -183.69049918297026
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             60.4765518070895993
+    One-Electron Energy =                -369.8256276179043880
+    Two-Electron Energy =                 125.6585766278445249
+    Total Energy =                       -183.6904991829702567
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0091
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.2015
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.1925     Total:     0.1925
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -0.4892     Total:     0.4892
+
+
+*** tstop() called on DESKTOP-SQPD2D3 at Wed Jul 28 17:39:04 2021
+Module time:
+	user time   =       0.62 seconds =       0.01 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       0.62 seconds =       0.01 minutes
+	system time =       0.08 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+Scratch directory: /tmp/
+
+ Data is an array -> call again
+ Data is an array -> call again
+  Forte
+  ----------------------------------------------------------------------------
+  A suite of quantum chemistry methods for strongly correlated electrons
+
+    git branch: gas_rotation_fix - git commit: a8be117a
+
+  Developed by:
+    Francesco A. Evangelista, Chenyang Li, Kevin P. Hannon,
+    Jeffrey B. Schriber, Tianyuan Zhang, Chenxi Cai,
+    Nan He, Nicholas Stair, Shuhe Wang, Renke Huang
+  ----------------------------------------------------------------------------
+
+  Size of Determinant class: 128 bits
+
+  Preparing forte objects from a Psi4 Wavefunction object
+  Read options for space GAS1
+  Read options for space GAS2
+  Read options for space GAS3
+  Read options for space GAS4
+  Read options for space GAS5
+  Read options for space GAS1
+  Read options for space GAS2
+  Read options for space GAS3
+  Read options for space GAS4
+  Read options for space GAS5
+
+  ==> MO Space Information <==
+
+  -------------------------------------------------
+                       A1    A2    B1    B2   Sum
+  -------------------------------------------------
+    FROZEN_DOCC         0     0     0     0     0
+    RESTRICTED_DOCC     0     0     0     0     0
+    GAS1                1     0     0     0     1
+    GAS2                1     0     0     0     1
+    GAS3                1     0     0     0     1
+    GAS4                4     0     1     1     6
+    GAS5                0     0     2     2     4
+    GAS6                0     0     0     0     0
+    RESTRICTED_UOCC    14     3     6     6    29
+    FROZEN_UOCC         0     0     0     0     0
+    Total              21     3     9     9    42
+  -------------------------------------------------   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry N          line   168 file /home/mhuang/psi4_install/share/psi4/basis/cc-pvdz.gbs 
+    atoms 3   entry O          line   198 file /home/mhuang/psi4_install/share/psi4/basis/cc-pvdz.gbs 
+
+
+  Checking orbital orthonormality against current geometry ... Done (OK)
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: MINAO_BASIS
+    atoms 1-2 entry N          line    71 file /home/mhuang/psi4_install/share/psi4/basis/sto-3g.gbs 
+    atoms 3   entry O          line    81 file /home/mhuang/psi4_install/share/psi4/basis/sto-3g.gbs 
+
+
+  ==> List of Planes Requested <==
+
+  Forte will use psi4 integrals
+
+  ==> Primary Basis Set Summary <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 18
+    Number of basis functions: 42
+    Number of Cartesian functions: 45
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+
+  JK created using conventional PK integrals
+  Using in-core PK algorithm.
+   Calculation information:
+      Number of atoms:                   3
+      Number of AO shells:              18
+      Number of primitives:             66
+      Number of atomic orbitals:        45
+      Number of basis functions:        42
+
+      Integral cutoff                 1.00e-12
+      Number of threads:                 1
+
+  Performing in-core PK
+  Using 816312 doubles for integral storage.
+  We computed 14701 shell quartets total.
+  Whereas there are 14706 unique shell quartets.
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:             1525
+    Schwarz Cutoff:          1E-12
+
+    OpenMP threads:              1
+
+
+
+  ==> Integral Transformation <==
+
+  Number of molecular orbitals:                         42
+  Number of correlated molecular orbitals:              42
+  Number of frozen occupied orbitals:                    0
+  Number of frozen unoccupied orbitals:                  0
+  Two-electron integral type:                 Conventional
+
+
+  Skip integral allocation and transformation for AO-driven CASSCF.
+
+          -----------------------------------------------------------
+                  Multi-Configurational Self Consistent Field
+                Two-Step Approximate Second-Order AO Algorithm
+            written by Chenyang Li, Kevin P. Hannon, and Shuhe Wang
+          -----------------------------------------------------------
+
+
+  ==> Calculation Information <==
+
+    Integral type                               CONVENTIONAL
+    CI solver type                                       ACI
+    Final orbital type                             CANONICAL
+    Derivative type                                     NONE
+    Optimize orbitals                                   TRUE
+    Include internal rotations                         FALSE
+    Debug printing                                     FALSE
+    Energy convergence                             1.000e-08
+    Gradient convergence                           1.000e-07
+    Max value for rotation                         5.000e-01
+    Printing level                                         1
+    Max number of macro iterations                       100
+    Max number of micro iterations                        50
+    Min number of micro iterations                        15
+    DIIS start                                             2
+    Min DIIS vectors                                       2
+    Max DIIS vectors                                       8
+    Frequency of DIIS extrapolation                        1
+
+  Remove orbital 1 2.
+
+  ==> Independent Orbital Rotations <==
+
+    ORBITAL SPACES                        A1     A2     B1     B2
+    -------------------------------------------------------------
+               GAS1 /            GAS2      0      0      0      0
+               GAS1 /            GAS3      0      0      0      0
+               GAS1 /            GAS4      4      0      0      0
+               GAS1 /            GAS5      0      0      0      0
+               GAS2 /            GAS3      1      0      0      0
+               GAS2 /            GAS4      0      0      0      0
+               GAS2 /            GAS5      0      0      0      0
+               GAS3 /            GAS4      0      0      0      0
+               GAS3 /            GAS5      0      0      0      0
+               GAS4 /            GAS5      0      0      2      2
+             ACTIVE / RESTRICTED_DOCC      0      0      0      0
+    RESTRICTED_UOCC /          ACTIVE     70      0     18     18
+    RESTRICTED_UOCC / RESTRICTED_DOCC      0      0      0      0
+    -------------------------------------------------------------
+
+  ==> Summary of Active Space Solver Input <==
+
+    Irrep.  Multi.(2ms)      N
+    --------------------------
+       B1      1  (  0)      1
+       B2      1  (  0)      1
+    --------------------------
+    N: number of roots
+    ms: spin z component
+    Total number of roots:   2
+    --------------------------
+
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  8.936e-04
+         2              12  5.506e-04
+         3               0  7.944e-04
+    ---------------------------------
+    Total:              24  2.383e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          1.307e-04 seconds
+        β          1.113e-04 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         5.488e-04 seconds
+        ββ         4.856e-04 seconds
+        αβ         6.569e-04 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.003091 s
+
+    PQ-space CI Energy Root   0        = -168.616670654420 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.616670654420 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B1     1.987546  
+        2B2     1.960978      3B1     1.012228      7A1     1.000000  
+        3B2     0.039248  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.616670654420 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.616670654420 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0   0.612868 0.375607170          19 |22-222222+220>
+    1   0.612868 0.375607170           7 |22+222222-220>
+    2   0.224385 0.050348651          17 |22-22222+2220>
+    3   0.224385 0.050348651           3 |22+22222-2220>
+    4   0.198810 0.039525562           5 |22+222222-2-+>
+    5   0.198810 0.039525562          18 |22-222222+2+->
+    6   0.175094 0.030657949          15 |22-222222+2-+>
+    7   0.175094 0.030657949           6 |22+222222-2+->
+    8  -0.045634 0.002082476          12 |22-22222+2202>
+    9  -0.045634 0.002082476           0 |22+22222-2202>
+
+  Saving information for root: 0
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  8.013e-04
+         2              12  5.688e-04
+         3               0  5.717e-04
+    ---------------------------------
+    Total:              24  2.084e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          1.053e-04 seconds
+        β          8.460e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         3.654e-04 seconds
+        ββ         2.869e-04 seconds
+        αβ         4.994e-04 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.002123 s
+
+    PQ-space CI Energy Root   0        = -168.616670654420 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.616670654420 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B2     1.987546  
+        2B1     1.960978      3B2     1.012228      7A1     1.000000  
+        3B1     0.039248  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.616670654420 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.616670654420 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0   0.612868 0.375607170          23 |22-222222022+>
+    1   0.612868 0.375607170           7 |22+222222022->
+    2   0.224385 0.050348651           5 |22+22222202-2>
+    3   0.224385 0.050348651          22 |22-22222202+2>
+    4   0.198810 0.039525562          21 |22-22222+-22+>
+    5   0.198810 0.039525562           3 |22+22222-+22->
+    6   0.175094 0.030657949          19 |22-22222-+22+>
+    7   0.175094 0.030657949           6 |22+22222+-22->
+    8  -0.045634 0.002082476           0 |22+22222022-2>
+    9  -0.045634 0.002082476          16 |22-22222022+2>
+
+  Saving information for root: 0
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    B1     0     -168.616670654420   0.000000
+    --------------------------------------------------------
+       1  (  0)    B2     0     -168.616670654420   0.000000
+    --------------------------------------------------------
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          3.030e-05 seconds
+        β          7.800e-06 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         7.900e-06 seconds
+        ββ         8.800e-06 seconds
+        αβ         2.060e-05 seconds
+  1-RDM  took 0.000493 s (determinant)
+  2-RDMS took 0.002751 s (determinant)
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          1.010e-05 seconds
+        β          7.700e-06 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         8.500e-06 seconds
+        ββ         8.400e-06 seconds
+        αβ         8.300e-06 seconds
+  1-RDM  took 0.000479 s (determinant)
+  2-RDMS took 0.001604 s (determinant)
+
+  ==> Optimizing Orbitals for Current RDMs <==
+
+  L-BFGS Iter:  1; fx = -168.747910553855775; g_norm = 1.471879e+00; step = 1.000e+00
+  L-BFGS Iter:  2; fx = -168.857373104833130; g_norm = 6.741954e-01; step = 1.000e+00
+  L-BFGS Iter:  3; fx = -168.877338977009771; g_norm = 3.674941e-01; step = 1.000e+00
+  L-BFGS Iter:  4; fx = -168.886971366076494; g_norm = 3.583005e-02; step = 1.000e+00
+  L-BFGS Iter:  5; fx = -168.887373394991442; g_norm = 2.092789e-02; step = 1.000e+00
+  L-BFGS Iter:  6; fx = -168.887978795464761; g_norm = 3.351624e-02; step = 1.000e+00
+  L-BFGS Iter:  7; fx = -168.888405366506106; g_norm = 3.726711e-02; step = 1.000e+00
+  L-BFGS Iter:  8; fx = -168.888646609676158; g_norm = 2.548204e-02; step = 1.000e+00
+  L-BFGS Iter:  9; fx = -168.888765652826578; g_norm = 1.090399e-02; step = 1.000e+00
+  L-BFGS Iter: 10; fx = -168.888778368001198; g_norm = 7.742438e-03; step = 1.000e+00
+  L-BFGS Iter: 11; fx = -168.888782740914451; g_norm = 2.329957e-03; step = 1.000e+00
+  L-BFGS Iter: 12; fx = -168.888783288986190; g_norm = 5.935938e-04; step = 1.000e+00
+  L-BFGS Iter: 13; fx = -168.888783332465209; g_norm = 1.620920e-04; step = 1.000e+00
+  L-BFGS Iter: 14; fx = -168.888783336889617; g_norm = 3.962412e-05; step = 1.000e+00
+  L-BFGS Iter: 15; fx = -168.888783337078110; g_norm = 3.962412e-05; step = 1.000e+00
+
+  ==> MCSCF Macro Iter. 1 <==
+
+             Energy CI (  Delta E  )         Energy Opt. (  Delta E  )  E_OPT - E_CI   Orbital RMS  Micro  DIIS
+     -168.616670654420 (-1.6862e+02)   -168.888783337078 (-1.6889e+02)   -2.7211e-01    3.6950e-06   15/N
+
+  ==> Summary of Active Space Solver Input <==
+
+    Irrep.  Multi.(2ms)      N
+    --------------------------
+       B1      1  (  0)      1
+       B2      1  (  0)      1
+    --------------------------
+    N: number of roots
+    ms: spin z component
+    Total number of roots:   2
+    --------------------------
+
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  8.083e-04
+         2              12  1.129e-03
+         3               0  9.088e-04
+    ---------------------------------
+    Total:              24  3.125e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          1.031e-04 seconds
+        β          5.310e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         4.523e-04 seconds
+        ββ         4.256e-04 seconds
+        αβ         6.353e-04 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.002581 s
+
+    PQ-space CI Energy Root   0        = -168.892747738622 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.892747738622 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B1     1.980318  
+        2B2     1.944165      3B1     1.019282      7A1     1.000000  
+        3B2     0.056235  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.892747738622 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.892747738622 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0  -0.617576 0.381399729          19 |22-222222+220>
+    1  -0.617576 0.381399729           7 |22+222222-220>
+    2  -0.217701 0.047393893          17 |22-22222+2220>
+    3  -0.217701 0.047393893           3 |22+22222-2220>
+    4  -0.195988 0.038411279           5 |22+222222-2-+>
+    5  -0.195988 0.038411279          18 |22-222222+2+->
+    6  -0.167549 0.028072634           6 |22+222222-2+->
+    7  -0.167549 0.028072634          15 |22-222222+2-+>
+    8   0.044261 0.001959012          14 |22-222222+202>
+    9   0.044261 0.001959012           4 |22+222222-202>
+
+  Saving information for root: 0
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  6.360e-04
+         2              12  9.780e-04
+         3               0  1.064e-03
+    ---------------------------------
+    Total:              24  2.879e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          8.840e-05 seconds
+        β          5.730e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         4.347e-04 seconds
+        ββ         3.821e-04 seconds
+        αβ         6.805e-04 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.002456 s
+
+    PQ-space CI Energy Root   0        = -168.892747738622 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.892747738622 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B2     1.980318  
+        2B1     1.944165      3B2     1.019282      7A1     1.000000  
+        3B1     0.056235  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.892747738622 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.892747738622 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0  -0.617576 0.381399729          23 |22-222222022+>
+    1  -0.617576 0.381399729           7 |22+222222022->
+    2  -0.217701 0.047393893           5 |22+22222202-2>
+    3  -0.217701 0.047393893          22 |22-22222202+2>
+    4  -0.195988 0.038411279          21 |22-22222+-22+>
+    5  -0.195988 0.038411279           3 |22+22222-+22->
+    6  -0.167549 0.028072634          19 |22-22222-+22+>
+    7  -0.167549 0.028072634           6 |22+22222+-22->
+    8   0.044261 0.001959012          17 |22-222220222+>
+    9   0.044261 0.001959012           2 |22+222220222->
+
+  Saving information for root: 0
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    B1     0     -168.892747738622   0.000000
+    --------------------------------------------------------
+       1  (  0)    B2     0     -168.892747738622   0.000000
+    --------------------------------------------------------
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          8.800e-06 seconds
+        β          1.110e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         8.500e-06 seconds
+        ββ         6.400e-06 seconds
+        αβ         6.000e-06 seconds
+  1-RDM  took 0.000280 s (determinant)
+  2-RDMS took 0.001845 s (determinant)
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          6.000e-06 seconds
+        β          5.900e-06 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         5.800e-06 seconds
+        ββ         5.900e-06 seconds
+        αβ         2.470e-05 seconds
+  1-RDM  took 0.000392 s (determinant)
+  2-RDMS took 0.001492 s (determinant)
+
+  ==> Optimizing Orbitals for Current RDMs <==
+
+  L-BFGS Iter:  1; fx = -168.893134332253680; g_norm = 7.438269e-02; step = 1.000e+00
+  L-BFGS Iter:  2; fx = -168.893405679937700; g_norm = 4.179663e-02; step = 1.000e+00
+  L-BFGS Iter:  3; fx = -168.893529050782064; g_norm = 1.455043e-02; step = 1.000e+00
+  L-BFGS Iter:  4; fx = -168.893580382885830; g_norm = 7.768016e-03; step = 1.000e+00
+  L-BFGS Iter:  5; fx = -168.893660639622567; g_norm = 1.033425e-02; step = 1.000e+00
+  L-BFGS Iter:  6; fx = -168.893686441832074; g_norm = 7.384945e-03; step = 1.000e+00
+  L-BFGS Iter:  7; fx = -168.893696140370054; g_norm = 2.237845e-03; step = 1.000e+00
+  L-BFGS Iter:  8; fx = -168.893697240656735; g_norm = 6.803740e-04; step = 1.000e+00
+  L-BFGS Iter:  9; fx = -168.893697364375726; g_norm = 3.398334e-04; step = 1.000e+00
+  L-BFGS Iter: 10; fx = -168.893697375079370; g_norm = 1.919875e-04; step = 1.000e+00
+  L-BFGS Iter: 11; fx = -168.893697377346541; g_norm = 1.400033e-04; step = 1.000e+00
+  L-BFGS Iter: 12; fx = -168.893697378707799; g_norm = 2.313241e-05; step = 1.000e+00
+  L-BFGS Iter: 13; fx = -168.893697378749835; g_norm = 5.332177e-06; step = 1.000e+00
+  L-BFGS Iter: 14; fx = -168.893697378754126; g_norm = 1.464431e-06; step = 1.000e+00
+  L-BFGS Iter: 15; fx = -168.893697378754638; g_norm = 1.464431e-06; step = 1.000e+00
+
+  ==> MCSCF Macro Iter. 2 <==
+
+             Energy CI (  Delta E  )         Energy Opt. (  Delta E  )  E_OPT - E_CI   Orbital RMS  Micro  DIIS
+     -168.892747738622 (-2.7608e-01)   -168.893697378755 (-4.9140e-03)   -9.4964e-04    3.6553e-06   15/N   S
+
+  ==> Summary of Active Space Solver Input <==
+
+    Irrep.  Multi.(2ms)      N
+    --------------------------
+       B1      1  (  0)      1
+       B2      1  (  0)      1
+    --------------------------
+    N: number of roots
+    ms: spin z component
+    Total number of roots:   2
+    --------------------------
+
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  8.785e-04
+         2              12  8.067e-04
+         3               0  8.602e-04
+    ---------------------------------
+    Total:              24  2.701e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          1.042e-04 seconds
+        β          8.740e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         4.315e-04 seconds
+        ββ         4.588e-04 seconds
+        αβ         7.251e-04 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.002869 s
+
+    PQ-space CI Energy Root   0        = -168.894295631079 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.894295631079 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B1     1.977238  
+        2B2     1.940329      3B1     1.022157      7A1     1.000000  
+        3B2     0.060275  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.894295631079 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.894295631079 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0  -0.616238 0.379748786          19 |22-222222+220>
+    1  -0.616238 0.379748786           7 |22+222222-220>
+    2  -0.211145 0.044582035           3 |22+22222-2220>
+    3  -0.211145 0.044582035          17 |22-22222+2220>
+    4  -0.199344 0.039738011           5 |22+222222-2-+>
+    5  -0.199344 0.039738011          18 |22-222222+2+->
+    6  -0.177750 0.031595137           6 |22+222222-2+->
+    7  -0.177750 0.031595137          15 |22-222222+2-+>
+    8   0.046397 0.002152690          14 |22-222222+202>
+    9   0.046397 0.002152690           4 |22+222222-202>
+
+  Saving information for root: 0
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  7.835e-04
+         2              12  9.902e-04
+         3               0  7.565e-04
+    ---------------------------------
+    Total:              24  2.687e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          5.670e-05 seconds
+        β          5.450e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         3.966e-04 seconds
+        ββ         3.893e-04 seconds
+        αβ         5.890e-04 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.002382 s
+
+    PQ-space CI Energy Root   0        = -168.894295631079 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.894295631079 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B2     1.977238  
+        2B1     1.940329      3B2     1.022157      7A1     1.000000  
+        3B1     0.060275  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.894295631079 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.894295631079 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0  -0.616238 0.379748786          23 |22-222222022+>
+    1  -0.616238 0.379748786           7 |22+222222022->
+    2  -0.211145 0.044582035           5 |22+22222202-2>
+    3  -0.211145 0.044582035          22 |22-22222202+2>
+    4  -0.199344 0.039738011          21 |22-22222+-22+>
+    5  -0.199344 0.039738011           3 |22+22222-+22->
+    6  -0.177750 0.031595137          19 |22-22222-+22+>
+    7  -0.177750 0.031595137           6 |22+22222+-22->
+    8   0.046397 0.002152690          17 |22-222220222+>
+    9   0.046397 0.002152690           2 |22+222220222->
+
+  Saving information for root: 0
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    B1     0     -168.894295631079   0.000000
+    --------------------------------------------------------
+       1  (  0)    B2     0     -168.894295631079   0.000000
+    --------------------------------------------------------
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          5.800e-06 seconds
+        β          5.700e-06 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         6.100e-06 seconds
+        ββ         1.140e-05 seconds
+        αβ         6.300e-06 seconds
+  1-RDM  took 0.000216 s (determinant)
+  2-RDMS took 0.001451 s (determinant)
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          6.100e-06 seconds
+        β          6.100e-06 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         5.900e-06 seconds
+        ββ         6.200e-06 seconds
+        αβ         6.100e-06 seconds
+  1-RDM  took 0.000308 s (determinant)
+  2-RDMS took 0.002127 s (determinant)
+
+  ==> Optimizing Orbitals for Current RDMs <==
+
+  L-BFGS Iter:  1; fx = -168.894407058078798; g_norm = 2.978053e-02; step = 1.000e+00
+  L-BFGS Iter:  2; fx = -168.894571368677475; g_norm = 2.010815e-02; step = 1.000e+00
+  L-BFGS Iter:  3; fx = -168.894731109708829; g_norm = 1.899883e-02; step = 1.000e+00
+  L-BFGS Iter:  4; fx = -168.894822780545610; g_norm = 9.648254e-03; step = 1.000e+00
+  L-BFGS Iter:  5; fx = -168.894834547894476; g_norm = 3.335601e-03; step = 1.000e+00
+  L-BFGS Iter:  6; fx = -168.894836113611660; g_norm = 8.833059e-04; step = 1.000e+00
+  L-BFGS Iter:  7; fx = -168.894836230968082; g_norm = 3.701063e-04; step = 1.000e+00
+  L-BFGS Iter:  8; fx = -168.894836242738108; g_norm = 1.052641e-04; step = 1.000e+00
+  L-BFGS Iter:  9; fx = -168.894836244226354; g_norm = 3.866112e-05; step = 1.000e+00
+  L-BFGS Iter: 10; fx = -168.894836244283397; g_norm = 5.836905e-05; step = 1.000e+00
+  L-BFGS Iter: 11; fx = -168.894836244490904; g_norm = 5.921197e-06; step = 1.000e+00
+  L-BFGS Iter: 12; fx = -168.894836244494741; g_norm = 2.496558e-06; step = 1.000e+00
+  L-BFGS Iter: 13; fx = -168.894836244495480; g_norm = 7.643037e-07; step = 1.000e+00
+
+  ==> MCSCF Macro Iter. 3 <==
+
+             Energy CI (  Delta E  )         Energy Opt. (  Delta E  )  E_OPT - E_CI   Orbital RMS  Micro  DIIS
+     -168.894295631079 (-1.5479e-03)   -168.894836244495 (-1.1389e-03)   -5.4061e-04    1.4994e-07   13/Y   S
+
+  ==> Summary of Active Space Solver Input <==
+
+    Irrep.  Multi.(2ms)      N
+    --------------------------
+       B1      1  (  0)      1
+       B2      1  (  0)      1
+    --------------------------
+    N: number of roots
+    ms: spin z component
+    Total number of roots:   2
+    --------------------------
+
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  9.282e-04
+         2              12  6.238e-04
+         3               0  7.993e-04
+    ---------------------------------
+    Total:              24  2.559e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          8.830e-05 seconds
+        β          6.030e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         5.915e-04 seconds
+        ββ         6.820e-04 seconds
+        αβ         9.285e-04 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.004047 s
+
+    PQ-space CI Energy Root   0        = -168.895331156330 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895331156330 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B1     1.975015  
+        2B2     1.936612      3B1     1.024170      7A1     1.000000  
+        3B2     0.064203  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895331156330 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895331156330 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0   0.611862 0.374374836          19 |22-222222+220>
+    1   0.611862 0.374374836           7 |22+222222-220>
+    2   0.206463 0.042626887           3 |22+22222-2220>
+    3   0.206463 0.042626887          17 |22-22222+2220>
+    4   0.205476 0.042220522           5 |22+222222-2-+>
+    5   0.205476 0.042220522          18 |22-222222+2+->
+    6   0.192257 0.036962857          15 |22-222222+2-+>
+    7   0.192257 0.036962857           6 |22+222222-2+->
+    8  -0.045394 0.002060573          14 |22-222222+202>
+    9  -0.045394 0.002060573           4 |22+222222-202>
+
+  Saving information for root: 0
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  1.683e-03
+         2              12  8.945e-04
+         3               0  1.076e-03
+    ---------------------------------
+    Total:              24  4.053e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          1.520e-04 seconds
+        β          5.540e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         4.453e-04 seconds
+        ββ         4.468e-04 seconds
+        αβ         6.807e-04 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.002780 s
+
+    PQ-space CI Energy Root   0        = -168.895331156330 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895331156330 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B2     1.975015  
+        2B1     1.936612      3B2     1.024170      7A1     1.000000  
+        3B1     0.064203  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895331156330 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895331156330 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0   0.611862 0.374374836          23 |22-222222022+>
+    1   0.611862 0.374374836           7 |22+222222022->
+    2   0.206463 0.042626887           5 |22+22222202-2>
+    3   0.206463 0.042626887          22 |22-22222202+2>
+    4   0.205476 0.042220522          21 |22-22222+-22+>
+    5   0.205476 0.042220522           3 |22+22222-+22->
+    6   0.192257 0.036962857          19 |22-22222-+22+>
+    7   0.192257 0.036962857           6 |22+22222+-22->
+    8  -0.045394 0.002060573          17 |22-222220222+>
+    9  -0.045394 0.002060573           2 |22+222220222->
+
+  Saving information for root: 0
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    B1     0     -168.895331156330   0.000000
+    --------------------------------------------------------
+       1  (  0)    B2     0     -168.895331156330   0.000000
+    --------------------------------------------------------
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          1.050e-05 seconds
+        β          1.140e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         1.110e-05 seconds
+        ββ         8.200e-06 seconds
+        αβ         1.270e-05 seconds
+  1-RDM  took 0.000519 s (determinant)
+  2-RDMS took 0.001930 s (determinant)
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          2.300e-05 seconds
+        β          7.800e-06 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         6.100e-06 seconds
+        ββ         7.300e-06 seconds
+        αβ         1.160e-05 seconds
+  1-RDM  took 0.000484 s (determinant)
+  2-RDMS took 0.002160 s (determinant)
+
+  ==> Optimizing Orbitals for Current RDMs <==
+
+  L-BFGS Iter:  1; fx = -168.895419244809148; g_norm = 1.663435e-02; step = 1.000e+00
+  L-BFGS Iter:  2; fx = -168.895499292054751; g_norm = 2.542199e-02; step = 1.000e+00
+  L-BFGS Iter:  3; fx = -168.895603149439950; g_norm = 1.588336e-02; step = 1.000e+00
+  L-BFGS Iter:  4; fx = -168.895657220739167; g_norm = 6.142711e-03; step = 1.000e+00
+  L-BFGS Iter:  5; fx = -168.895662116686822; g_norm = 2.112462e-03; step = 1.000e+00
+  L-BFGS Iter:  6; fx = -168.895662746754169; g_norm = 6.500354e-04; step = 1.000e+00
+  L-BFGS Iter:  7; fx = -168.895662798923723; g_norm = 2.230907e-04; step = 1.000e+00
+  L-BFGS Iter:  8; fx = -168.895662804511232; g_norm = 6.720310e-05; step = 1.000e+00
+  L-BFGS Iter:  9; fx = -168.895662804977036; g_norm = 2.043234e-05; step = 1.000e+00
+  L-BFGS Iter: 10; fx = -168.895662805005514; g_norm = 1.446553e-05; step = 1.000e+00
+  L-BFGS Iter: 11; fx = -168.895662805021146; g_norm = 6.885858e-06; step = 1.000e+00
+  L-BFGS Iter: 12; fx = -168.895662805025296; g_norm = 1.113640e-06; step = 1.000e+00
+  L-BFGS Iter: 13; fx = -168.895662805025580; g_norm = 4.361243e-07; step = 1.000e+00
+
+  ==> MCSCF Macro Iter. 4 <==
+
+             Energy CI (  Delta E  )         Energy Opt. (  Delta E  )  E_OPT - E_CI   Orbital RMS  Micro  DIIS
+     -168.895331156330 (-1.0355e-03)   -168.895662805026 (-8.2656e-04)   -3.3165e-04    4.7932e-08   13/Y   S/E
+
+  ==> Summary of Active Space Solver Input <==
+
+    Irrep.  Multi.(2ms)      N
+    --------------------------
+       B1      1  (  0)      1
+       B2      1  (  0)      1
+    --------------------------
+    N: number of roots
+    ms: spin z component
+    Total number of roots:   2
+    --------------------------
+
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  1.014e-03
+         2              12  8.819e-04
+         3               0  8.545e-04
+    ---------------------------------
+    Total:              24  2.984e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          1.443e-04 seconds
+        β          8.730e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         4.318e-04 seconds
+        ββ         4.492e-04 seconds
+        αβ         8.372e-04 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.002882 s
+
+    PQ-space CI Energy Root   0        = -168.895857438796 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895857438796 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B1     1.974367  
+        2B2     1.932722      3B1     1.024560      7A1     1.000000  
+        3B2     0.068351  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895857438796 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895857438796 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0   0.603920 0.364718901          19 |22-222222+220>
+    1   0.603920 0.364718901           7 |22+222222-220>
+    2   0.216021 0.046664962           6 |22+222222-2+->
+    3   0.216021 0.046664962          15 |22-222222+2-+>
+    4   0.214737 0.046111858           5 |22+222222-2-+>
+    5   0.214737 0.046111858          18 |22-222222+2+->
+    6   0.198801 0.039521809           3 |22+22222-2220>
+    7   0.198801 0.039521809          17 |22-22222+2220>
+    8  -0.041000 0.001680967          14 |22-222222+202>
+    9  -0.041000 0.001680967           4 |22+222222-202>
+
+  Saving information for root: 0
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  9.133e-04
+         2              12  8.117e-04
+         3               0  8.238e-04
+    ---------------------------------
+    Total:              24  2.722e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          5.810e-05 seconds
+        β          5.400e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         3.087e-04 seconds
+        ββ         3.065e-04 seconds
+        αβ         5.285e-04 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.001939 s
+
+    PQ-space CI Energy Root   0        = -168.895857438797 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895857438797 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B2     1.974367  
+        2B1     1.932722      3B2     1.024560      7A1     1.000000  
+        3B1     0.068351  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895857438797 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895857438797 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0   0.603920 0.364718901          23 |22-222222022+>
+    1   0.603920 0.364718901           7 |22+222222022->
+    2   0.216021 0.046664962          19 |22-22222-+22+>
+    3   0.216021 0.046664962           6 |22+22222+-22->
+    4   0.214737 0.046111858          21 |22-22222+-22+>
+    5   0.214737 0.046111858           3 |22+22222-+22->
+    6   0.198801 0.039521809           5 |22+22222202-2>
+    7   0.198801 0.039521809          22 |22-22222202+2>
+    8  -0.041000 0.001680967           2 |22+222220222->
+    9  -0.041000 0.001680967          17 |22-222220222+>
+
+  Saving information for root: 0
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    B1     0     -168.895857438796   0.000000
+    --------------------------------------------------------
+       1  (  0)    B2     0     -168.895857438797   0.000000
+    --------------------------------------------------------
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          6.100e-06 seconds
+        β          6.100e-06 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         6.000e-06 seconds
+        ββ         6.000e-06 seconds
+        αβ         6.000e-06 seconds
+  1-RDM  took 0.000223 s (determinant)
+  2-RDMS took 0.001324 s (determinant)
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          6.400e-06 seconds
+        β          5.900e-06 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         6.000e-06 seconds
+        ββ         5.900e-06 seconds
+        αβ         6.000e-06 seconds
+  1-RDM  took 0.000231 s (determinant)
+  2-RDMS took 0.001383 s (determinant)
+
+  ==> Optimizing Orbitals for Current RDMs <==
+
+  L-BFGS Iter:  1; fx = -168.895863151079652; g_norm = 2.096823e-02; step = 1.000e+00
+  L-BFGS Iter:  2; fx = -168.895905345073004; g_norm = 6.335088e-03; step = 1.000e+00
+  L-BFGS Iter:  3; fx = -168.895931225462846; g_norm = 5.765335e-03; step = 1.000e+00
+  L-BFGS Iter:  4; fx = -168.895957673354275; g_norm = 7.261853e-03; step = 1.000e+00
+  L-BFGS Iter:  5; fx = -168.895963908494764; g_norm = 3.053693e-03; step = 1.000e+00
+  L-BFGS Iter:  6; fx = -168.895964928267801; g_norm = 6.868451e-04; step = 1.000e+00
+  L-BFGS Iter:  7; fx = -168.895965040536510; g_norm = 4.042034e-04; step = 1.000e+00
+  L-BFGS Iter:  8; fx = -168.895965058652308; g_norm = 1.440865e-04; step = 1.000e+00
+  L-BFGS Iter:  9; fx = -168.895965060107898; g_norm = 2.864361e-05; step = 1.000e+00
+  L-BFGS Iter: 10; fx = -168.895965060180231; g_norm = 8.036077e-06; step = 1.000e+00
+  L-BFGS Iter: 11; fx = -168.895965060189383; g_norm = 2.526967e-06; step = 1.000e+00
+  L-BFGS Iter: 12; fx = -168.895965060190093; g_norm = 7.180712e-07; step = 1.000e+00
+
+  ==> MCSCF Macro Iter. 5 <==
+
+             Energy CI (  Delta E  )         Energy Opt. (  Delta E  )  E_OPT - E_CI   Orbital RMS  Micro  DIIS
+     -168.895857438797 (-5.2628e-04)   -168.895965060190 (-3.0226e-04)   -1.0762e-04    9.2667e-08   12/Y   S/E
+
+  ==> Summary of Active Space Solver Input <==
+
+    Irrep.  Multi.(2ms)      N
+    --------------------------
+       B1      1  (  0)      1
+       B2      1  (  0)      1
+    --------------------------
+    N: number of roots
+    ms: spin z component
+    Total number of roots:   2
+    --------------------------
+
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  1.092e-03
+         2              12  1.118e-03
+         3               0  1.297e-03
+    ---------------------------------
+    Total:              24  3.795e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          2.236e-04 seconds
+        β          9.850e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         6.542e-04 seconds
+        ββ         6.096e-04 seconds
+        αβ         9.765e-04 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.004253 s
+
+    PQ-space CI Energy Root   0        = -168.895987409227 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895987409227 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B1     1.973972  
+        2B2     1.933165      3B1     1.025023      7A1     1.000000  
+        3B2     0.067840  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895987409227 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895987409227 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0   0.605948 0.367173455          19 |22-222222+220>
+    1   0.605948 0.367173455           7 |22+222222-220>
+    2   0.212456 0.045137718           5 |22+222222-2-+>
+    3   0.212456 0.045137718          18 |22-222222+2+->
+    4   0.208462 0.043456479           6 |22+222222-2+->
+    5   0.208462 0.043456479          15 |22-222222+2-+>
+    6   0.202401 0.040966084          17 |22-22222+2220>
+    7   0.202401 0.040966084           3 |22+22222-2220>
+    8  -0.042860 0.001836952          14 |22-222222+202>
+    9  -0.042860 0.001836952           4 |22+222222-202>
+
+  Saving information for root: 0
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  1.200e-03
+         2              12  1.199e-03
+         3               0  1.133e-03
+    ---------------------------------
+    Total:              24  3.776e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          9.340e-05 seconds
+        β          8.220e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         7.040e-04 seconds
+        ββ         4.946e-04 seconds
+        αβ         1.597e-03 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.005453 s
+
+    PQ-space CI Energy Root   0        = -168.895987409227 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895987409227 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B2     1.973972  
+        2B1     1.933165      3B2     1.025023      7A1     1.000000  
+        3B1     0.067840  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895987409227 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895987409227 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0  -0.605948 0.367173455          23 |22-222222022+>
+    1  -0.605948 0.367173455           7 |22+222222022->
+    2  -0.212456 0.045137718          21 |22-22222+-22+>
+    3  -0.212456 0.045137718           3 |22+22222-+22->
+    4  -0.208462 0.043456479          19 |22-22222-+22+>
+    5  -0.208462 0.043456479           6 |22+22222+-22->
+    6  -0.202401 0.040966084           5 |22+22222202-2>
+    7  -0.202401 0.040966084          22 |22-22222202+2>
+    8   0.042860 0.001836952          17 |22-222220222+>
+    9   0.042860 0.001836952           2 |22+222220222->
+
+  Saving information for root: 0
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    B1     0     -168.895987409227   0.000000
+    --------------------------------------------------------
+       1  (  0)    B2     0     -168.895987409227   0.000000
+    --------------------------------------------------------
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          7.800e-06 seconds
+        β          1.010e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         7.900e-06 seconds
+        ββ         8.100e-06 seconds
+        αβ         9.000e-06 seconds
+  1-RDM  took 0.000804 s (determinant)
+  2-RDMS took 0.002387 s (determinant)
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          7.600e-06 seconds
+        β          7.700e-06 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         7.300e-06 seconds
+        ββ         7.300e-06 seconds
+        αβ         7.200e-06 seconds
+  1-RDM  took 0.000344 s (determinant)
+  2-RDMS took 0.002161 s (determinant)
+
+  ==> Optimizing Orbitals for Current RDMs <==
+
+  L-BFGS Iter:  1; fx = -168.895989548001069; g_norm = 4.124631e-03; step = 1.000e+00
+  L-BFGS Iter:  2; fx = -168.895991223362302; g_norm = 3.307462e-03; step = 1.000e+00
+  L-BFGS Iter:  3; fx = -168.895992675652082; g_norm = 1.673628e-03; step = 1.000e+00
+  L-BFGS Iter:  4; fx = -168.895994165427737; g_norm = 1.509919e-03; step = 1.000e+00
+  L-BFGS Iter:  5; fx = -168.895994691987141; g_norm = 7.585071e-04; step = 1.000e+00
+  L-BFGS Iter:  6; fx = -168.895994763829862; g_norm = 2.721294e-04; step = 1.000e+00
+  L-BFGS Iter:  7; fx = -168.895994777714748; g_norm = 9.585194e-05; step = 1.000e+00
+  L-BFGS Iter:  8; fx = -168.895994778962603; g_norm = 3.752363e-05; step = 1.000e+00
+  L-BFGS Iter:  9; fx = -168.895994779068474; g_norm = 7.954396e-06; step = 1.000e+00
+  L-BFGS Iter: 10; fx = -168.895994779073362; g_norm = 5.965521e-06; step = 1.000e+00
+  L-BFGS Iter: 11; fx = -168.895994779075238; g_norm = 3.439608e-06; step = 1.000e+00
+  L-BFGS Iter: 12; fx = -168.895994779076005; g_norm = 4.288600e-07; step = 1.000e+00
+
+  ==> MCSCF Macro Iter. 6 <==
+
+             Energy CI (  Delta E  )         Energy Opt. (  Delta E  )  E_OPT - E_CI   Orbital RMS  Micro  DIIS
+     -168.895987409227 (-1.2997e-04)   -168.895994779076 (-2.9719e-05)   -7.3698e-06    8.9429e-08   12/Y   S/E
+
+  ==> Summary of Active Space Solver Input <==
+
+    Irrep.  Multi.(2ms)      N
+    --------------------------
+       B1      1  (  0)      1
+       B2      1  (  0)      1
+    --------------------------
+    N: number of roots
+    ms: spin z component
+    Total number of roots:   2
+    --------------------------
+
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  1.164e-03
+         2              12  1.412e-03
+         3               0  1.330e-03
+    ---------------------------------
+    Total:              24  4.262e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          6.000e-05 seconds
+        β          5.960e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         5.250e-04 seconds
+        ββ         4.756e-04 seconds
+        αβ         9.693e-04 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.003306 s
+
+    PQ-space CI Energy Root   0        = -168.895995535151 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895995535151 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B1     1.973951  
+        2B2     1.932987      3B1     1.025035      7A1     1.000000  
+        3B2     0.068026  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895995535151 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895995535151 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0   0.605573 0.366718686          19 |22-222222+220>
+    1   0.605573 0.366718686           7 |22+222222-220>
+    2   0.212865 0.045311677           5 |22+222222-2-+>
+    3   0.212865 0.045311677          18 |22-222222+2+->
+    4   0.209401 0.043848955           6 |22+222222-2+->
+    5   0.209401 0.043848955          15 |22-222222+2-+>
+    6   0.202203 0.040886214          17 |22-22222+2220>
+    7   0.202203 0.040886214           3 |22+22222-2220>
+    8  -0.042677 0.001821333          14 |22-222222+202>
+    9  -0.042677 0.001821333           4 |22+222222-202>
+
+  Saving information for root: 0
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  1.674e-03
+         2              12  1.182e-03
+         3               0  2.135e-03
+    ---------------------------------
+    Total:              24  5.302e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          9.640e-05 seconds
+        β          9.190e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         5.936e-04 seconds
+        ββ         6.651e-04 seconds
+        αβ         1.934e-03 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.005220 s
+
+    PQ-space CI Energy Root   0        = -168.895995535151 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895995535151 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B2     1.973951  
+        2B1     1.932987      3B2     1.025035      7A1     1.000000  
+        3B1     0.068026  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895995535151 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895995535151 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0  -0.605573 0.366718686          23 |22-222222022+>
+    1  -0.605573 0.366718686           7 |22+222222022->
+    2  -0.212865 0.045311677          21 |22-22222+-22+>
+    3  -0.212865 0.045311677           3 |22+22222-+22->
+    4  -0.209401 0.043848955          19 |22-22222-+22+>
+    5  -0.209401 0.043848955           6 |22+22222+-22->
+    6  -0.202203 0.040886214           5 |22+22222202-2>
+    7  -0.202203 0.040886214          22 |22-22222202+2>
+    8   0.042677 0.001821333          17 |22-222220222+>
+    9   0.042677 0.001821333           2 |22+222220222->
+
+  Saving information for root: 0
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    B1     0     -168.895995535151   0.000000
+    --------------------------------------------------------
+       1  (  0)    B2     0     -168.895995535151   0.000000
+    --------------------------------------------------------
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          1.076e-04 seconds
+        β          8.600e-06 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         5.470e-05 seconds
+        ββ         1.660e-05 seconds
+        αβ         7.500e-06 seconds
+  1-RDM  took 0.000513 s (determinant)
+  2-RDMS took 0.002232 s (determinant)
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          8.600e-06 seconds
+        β          8.100e-06 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         7.700e-06 seconds
+        ββ         8.100e-06 seconds
+        αβ         1.070e-05 seconds
+  1-RDM  took 0.000347 s (determinant)
+  2-RDMS took 0.002149 s (determinant)
+
+  ==> Optimizing Orbitals for Current RDMs <==
+
+  L-BFGS Iter:  1; fx = -168.895996192172845; g_norm = 2.150165e-03; step = 1.000e+00
+  L-BFGS Iter:  2; fx = -168.895996632903206; g_norm = 1.785472e-03; step = 1.000e+00
+  L-BFGS Iter:  3; fx = -168.895997041402183; g_norm = 8.663829e-04; step = 1.000e+00
+  L-BFGS Iter:  4; fx = -168.895997448682408; g_norm = 8.098685e-04; step = 1.000e+00
+  L-BFGS Iter:  5; fx = -168.895997609704182; g_norm = 4.212792e-04; step = 1.000e+00
+  L-BFGS Iter:  6; fx = -168.895997630422841; g_norm = 1.496886e-04; step = 1.000e+00
+  L-BFGS Iter:  7; fx = -168.895997634464521; g_norm = 5.093775e-05; step = 1.000e+00
+  L-BFGS Iter:  8; fx = -168.895997634834828; g_norm = 2.105059e-05; step = 1.000e+00
+  L-BFGS Iter:  9; fx = -168.895997634868536; g_norm = 4.526830e-06; step = 1.000e+00
+  L-BFGS Iter: 10; fx = -168.895997634870099; g_norm = 3.494664e-06; step = 1.000e+00
+  L-BFGS Iter: 11; fx = -168.895997634870639; g_norm = 1.844377e-06; step = 1.000e+00
+  L-BFGS Iter: 12; fx = -168.895997634870952; g_norm = 2.635370e-07; step = 1.000e+00
+
+  ==> MCSCF Macro Iter. 7 <==
+
+             Energy CI (  Delta E  )         Energy Opt. (  Delta E  )  E_OPT - E_CI   Orbital RMS  Micro  DIIS
+     -168.895995535151 (-8.1259e-06)   -168.895997634871 (-2.8558e-06)   -2.0997e-06    1.6406e-08   12/Y   S/E
+
+  ==> Summary of Active Space Solver Input <==
+
+    Irrep.  Multi.(2ms)      N
+    --------------------------
+       B1      1  (  0)      1
+       B2      1  (  0)      1
+    --------------------------
+    N: number of roots
+    ms: spin z component
+    Total number of roots:   2
+    --------------------------
+
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  1.109e-03
+         2              12  9.346e-04
+         3               0  1.391e-03
+    ---------------------------------
+    Total:              24  3.964e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          1.281e-04 seconds
+        β          7.460e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         1.070e-03 seconds
+        ββ         6.559e-04 seconds
+        αβ         9.121e-04 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.005040 s
+
+    PQ-space CI Energy Root   0        = -168.895998683643 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895998683643 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B1     1.973929  
+        2B2     1.932808      3B1     1.025049      7A1     1.000000  
+        3B2     0.068213  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895998683643 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895998683643 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0   0.605174 0.366235467          19 |22-222222+220>
+    1   0.605174 0.366235467           7 |22+222222-220>
+    2   0.213293 0.045493699           5 |22+222222-2-+>
+    3   0.213293 0.045493699          18 |22-222222+2+->
+    4   0.210302 0.044226858          15 |22-222222+2-+>
+    5   0.210302 0.044226858           6 |22+222222-2+->
+    6   0.202093 0.040841424           3 |22+22222-2220>
+    7   0.202093 0.040841424          17 |22-22222+2220>
+    8  -0.042491 0.001805482          14 |22-222222+202>
+    9  -0.042491 0.001805482           4 |22+222222-202>
+
+  Saving information for root: 0
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  9.246e-04
+         2              12  1.168e-03
+         3               0  6.803e-04
+    ---------------------------------
+    Total:              24  3.017e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          9.690e-05 seconds
+        β          5.520e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         4.819e-04 seconds
+        ββ         6.327e-04 seconds
+        αβ         1.230e-03 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.004324 s
+
+    PQ-space CI Energy Root   0        = -168.895998683644 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895998683644 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B2     1.973929  
+        2B1     1.932808      3B2     1.025049      7A1     1.000000  
+        3B1     0.068213  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895998683644 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895998683644 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0  -0.605174 0.366235467          23 |22-222222022+>
+    1  -0.605174 0.366235467           7 |22+222222022->
+    2  -0.213293 0.045493699          21 |22-22222+-22+>
+    3  -0.213293 0.045493699           3 |22+22222-+22->
+    4  -0.210302 0.044226858          19 |22-22222-+22+>
+    5  -0.210302 0.044226858           6 |22+22222+-22->
+    6  -0.202093 0.040841424           5 |22+22222202-2>
+    7  -0.202093 0.040841424          22 |22-22222202+2>
+    8   0.042491 0.001805482          17 |22-222220222+>
+    9   0.042491 0.001805482           2 |22+222220222->
+
+  Saving information for root: 0
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    B1     0     -168.895998683643   0.000000
+    --------------------------------------------------------
+       1  (  0)    B2     0     -168.895998683644   0.000000
+    --------------------------------------------------------
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          2.890e-05 seconds
+        β          8.400e-06 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         6.100e-06 seconds
+        ββ         6.100e-06 seconds
+        αβ         6.100e-06 seconds
+  1-RDM  took 0.000460 s (determinant)
+  2-RDMS took 0.002280 s (determinant)
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          8.900e-06 seconds
+        β          2.380e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         8.500e-06 seconds
+        ββ         8.000e-06 seconds
+        αβ         7.900e-06 seconds
+  1-RDM  took 0.000519 s (determinant)
+  2-RDMS took 0.002591 s (determinant)
+
+  ==> Optimizing Orbitals for Current RDMs <==
+
+  L-BFGS Iter:  1; fx = -168.895998692970153; g_norm = 4.747921e-04; step = 1.000e+00
+  L-BFGS Iter:  2; fx = -168.895998714851714; g_norm = 1.969533e-04; step = 1.000e+00
+  L-BFGS Iter:  3; fx = -168.895998726739492; g_norm = 1.460450e-04; step = 1.000e+00
+  L-BFGS Iter:  4; fx = -168.895998740601613; g_norm = 1.464821e-04; step = 1.000e+00
+  L-BFGS Iter:  5; fx = -168.895998744265370; g_norm = 6.745509e-05; step = 1.000e+00
+  L-BFGS Iter:  6; fx = -168.895998744977334; g_norm = 2.277867e-05; step = 1.000e+00
+  L-BFGS Iter:  7; fx = -168.895998745079254; g_norm = 1.014181e-05; step = 1.000e+00
+  L-BFGS Iter:  8; fx = -168.895998745090935; g_norm = 3.384763e-06; step = 1.000e+00
+  L-BFGS Iter:  9; fx = -168.895998745091759; g_norm = 8.968302e-07; step = 1.000e+00
+  L-BFGS Iter: 10; fx = -168.895998745091731; g_norm = 2.614494e-07; step = 1.000e+00
+
+  ==> MCSCF Macro Iter. 8 <==
+
+             Energy CI (  Delta E  )         Energy Opt. (  Delta E  )  E_OPT - E_CI   Orbital RMS  Micro  DIIS
+     -168.895998683644 (-3.1485e-06)   -168.895998745092 (-1.1102e-06)   -6.1448e-08    3.9101e-08   10/Y   S/E
+
+  ==> Summary of Active Space Solver Input <==
+
+    Irrep.  Multi.(2ms)      N
+    --------------------------
+       B1      1  (  0)      1
+       B2      1  (  0)      1
+    --------------------------
+    N: number of roots
+    ms: spin z component
+    Total number of roots:   2
+    --------------------------
+
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  1.361e-03
+         2              12  8.597e-04
+         3               0  1.363e-03
+    ---------------------------------
+    Total:              24  3.854e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          9.780e-05 seconds
+        β          9.740e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         4.441e-04 seconds
+        ββ         5.416e-04 seconds
+        αβ         1.173e-03 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.003728 s
+
+    PQ-space CI Energy Root   0        = -168.895998752554 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895998752554 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B1     1.973930  
+        2B2     1.932775      3B1     1.025046      7A1     1.000000  
+        3B2     0.068249  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895998752554 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895998752554 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0   0.605096 0.366141174          19 |22-222222+220>
+    1   0.605096 0.366141174           7 |22+222222-220>
+    2   0.213379 0.045530390           5 |22+222222-2-+>
+    3   0.213379 0.045530390          18 |22-222222+2+->
+    4   0.210535 0.044325094           6 |22+222222-2+->
+    5   0.210535 0.044325094          15 |22-222222+2-+>
+    6   0.202012 0.040808710          17 |22-22222+2220>
+    7   0.202012 0.040808710           3 |22+22222-2220>
+    8  -0.042443 0.001801427          14 |22-222222+202>
+    9  -0.042443 0.001801427           4 |22+222222-202>
+
+  Saving information for root: 0
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  1.132e-03
+         2              12  2.238e-03
+         3               0  2.354e-03
+    ---------------------------------
+    Total:              24  6.300e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          1.248e-04 seconds
+        β          1.945e-04 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         8.425e-04 seconds
+        ββ         1.091e-03 seconds
+        αβ         1.146e-03 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.006074 s
+
+    PQ-space CI Energy Root   0        = -168.895998752554 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895998752554 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B2     1.973930  
+        2B1     1.932775      3B2     1.025046      7A1     1.000000  
+        3B1     0.068249  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895998752554 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895998752554 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0  -0.605096 0.366141174          23 |22-222222022+>
+    1  -0.605096 0.366141174           7 |22+222222022->
+    2  -0.213379 0.045530390          21 |22-22222+-22+>
+    3  -0.213379 0.045530390           3 |22+22222-+22->
+    4  -0.210535 0.044325094          19 |22-22222-+22+>
+    5  -0.210535 0.044325094           6 |22+22222+-22->
+    6  -0.202012 0.040808710           5 |22+22222202-2>
+    7  -0.202012 0.040808710          22 |22-22222202+2>
+    8   0.042443 0.001801427           2 |22+222220222->
+    9   0.042443 0.001801427          17 |22-222220222+>
+
+  Saving information for root: 0
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    B1     0     -168.895998752554   0.000000
+    --------------------------------------------------------
+       1  (  0)    B2     0     -168.895998752554   0.000000
+    --------------------------------------------------------
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          7.800e-06 seconds
+        β          7.900e-06 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         7.800e-06 seconds
+        ββ         1.050e-05 seconds
+        αβ         7.700e-06 seconds
+  1-RDM  took 0.000579 s (determinant)
+  2-RDMS took 0.004373 s (determinant)
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          3.500e-05 seconds
+        β          8.200e-06 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         8.200e-06 seconds
+        ββ         8.300e-06 seconds
+        αβ         8.300e-06 seconds
+  1-RDM  took 0.000476 s (determinant)
+  2-RDMS took 0.002415 s (determinant)
+
+  ==> Optimizing Orbitals for Current RDMs <==
+
+  L-BFGS Iter:  1; fx = -168.895998754629460; g_norm = 2.072677e-04; step = 1.000e+00
+  L-BFGS Iter:  2; fx = -168.895998758833684; g_norm = 9.689569e-05; step = 1.000e+00
+  L-BFGS Iter:  3; fx = -168.895998761252514; g_norm = 6.659289e-05; step = 1.000e+00
+  L-BFGS Iter:  4; fx = -168.895998764029684; g_norm = 6.520253e-05; step = 1.000e+00
+  L-BFGS Iter:  5; fx = -168.895998764799600; g_norm = 2.909717e-05; step = 1.000e+00
+  L-BFGS Iter:  6; fx = -168.895998764932273; g_norm = 1.026017e-05; step = 1.000e+00
+  L-BFGS Iter:  7; fx = -168.895998764953390; g_norm = 4.442170e-06; step = 1.000e+00
+  L-BFGS Iter:  8; fx = -168.895998764955721; g_norm = 1.494709e-06; step = 1.000e+00
+  L-BFGS Iter:  9; fx = -168.895998764955806; g_norm = 3.746809e-07; step = 1.000e+00
+  L-BFGS Iter: 10; fx = -168.895998764955777; g_norm = 1.269639e-07; step = 1.000e+00
+  L-BFGS Iter: 11; fx = -168.895998764955806; g_norm = 7.894571e-08; step = 1.000e+00
+
+  ==> MCSCF Macro Iter. 9 <==
+
+             Energy CI (  Delta E  )         Energy Opt. (  Delta E  )  E_OPT - E_CI   Orbital RMS  Micro  DIIS
+     -168.895998752554 (-6.8910e-08)   -168.895998764956 (-1.9864e-08)   -1.2402e-08    2.4513e-08   11/Y   S/E
+
+  ==> Summary of Active Space Solver Input <==
+
+    Irrep.  Multi.(2ms)      N
+    --------------------------
+       B1      1  (  0)      1
+       B2      1  (  0)      1
+    --------------------------
+    N: number of roots
+    ms: spin z component
+    Total number of roots:   2
+    --------------------------
+
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  7.829e-04
+         2              12  7.198e-04
+         3               0  8.196e-04
+    ---------------------------------
+    Total:              24  2.580e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          5.730e-05 seconds
+        β          1.068e-04 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         5.063e-04 seconds
+        ββ         4.371e-04 seconds
+        αβ         7.112e-04 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.002732 s
+
+    PQ-space CI Energy Root   0        = -168.895998770209 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895998770209 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B1     1.973930  
+        2B2     1.932786      3B1     1.025047      7A1     1.000000  
+        3B2     0.068237  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895998770209 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895998770209 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0   0.605122 0.366172808          19 |22-222222+220>
+    1   0.605122 0.366172808           7 |22+222222-220>
+    2   0.213350 0.045518133           5 |22+222222-2-+>
+    3   0.213350 0.045518133          18 |22-222222+2+->
+    4   0.210459 0.044293077           6 |22+222222-2+->
+    5   0.210459 0.044293077          15 |22-222222+2-+>
+    6   0.202036 0.040818746          17 |22-22222+2220>
+    7   0.202036 0.040818746           3 |22+22222-2220>
+    8  -0.042459 0.001802761          14 |22-222222+202>
+    9  -0.042459 0.001802761           4 |22+222222-202>
+
+  Saving information for root: 0
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  7.168e-04
+         2              12  7.190e-04
+         3               0  6.949e-04
+    ---------------------------------
+    Total:              24  2.270e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          7.400e-05 seconds
+        β          1.318e-04 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         3.230e-04 seconds
+        ββ         3.721e-04 seconds
+        αβ         6.132e-04 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.002381 s
+
+    PQ-space CI Energy Root   0        = -168.895998770209 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895998770209 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B2     1.973930  
+        2B1     1.932786      3B2     1.025047      7A1     1.000000  
+        3B1     0.068237  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895998770209 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895998770209 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0  -0.605122 0.366172808          23 |22-222222022+>
+    1  -0.605122 0.366172808           7 |22+222222022->
+    2  -0.213350 0.045518133          21 |22-22222+-22+>
+    3  -0.213350 0.045518133           3 |22+22222-+22->
+    4  -0.210459 0.044293077          19 |22-22222-+22+>
+    5  -0.210459 0.044293077           6 |22+22222+-22->
+    6  -0.202036 0.040818746           5 |22+22222202-2>
+    7  -0.202036 0.040818746          22 |22-22222202+2>
+    8   0.042459 0.001802761           2 |22+222220222->
+    9   0.042459 0.001802761          17 |22-222220222+>
+
+  Saving information for root: 0
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    B1     0     -168.895998770209   0.000000
+    --------------------------------------------------------
+       1  (  0)    B2     0     -168.895998770209   0.000000
+    --------------------------------------------------------
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          6.100e-06 seconds
+        β          1.100e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         2.400e-05 seconds
+        ββ         5.800e-06 seconds
+        αβ         5.800e-06 seconds
+  1-RDM  took 0.000360 s (determinant)
+  2-RDMS took 0.001558 s (determinant)
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          6.200e-06 seconds
+        β          6.200e-06 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         7.600e-06 seconds
+        ββ         5.900e-06 seconds
+        αβ         6.000e-06 seconds
+  1-RDM  took 0.000204 s (determinant)
+  2-RDMS took 0.001827 s (determinant)
+
+  ==> Optimizing Orbitals for Current RDMs <==
+
+  L-BFGS Iter:  1; fx = -168.895998770211236; g_norm = 8.029296e-06; step = 1.000e+00
+  L-BFGS Iter:  2; fx = -168.895998770217489; g_norm = 3.235830e-06; step = 1.000e+00
+  L-BFGS Iter:  3; fx = -168.895998770220899; g_norm = 2.483630e-06; step = 1.000e+00
+  L-BFGS Iter:  4; fx = -168.895998770224850; g_norm = 2.522329e-06; step = 1.000e+00
+  L-BFGS Iter:  5; fx = -168.895998770225873; g_norm = 1.146004e-06; step = 1.000e+00
+  L-BFGS Iter:  6; fx = -168.895998770226100; g_norm = 3.783917e-07; step = 1.000e+00
+  L-BFGS Iter:  7; fx = -168.895998770226072; g_norm = 1.731668e-07; step = 1.000e+00
+  L-BFGS Iter:  8; fx = -168.895998770226214; g_norm = 5.696263e-08; step = 1.000e+00
+
+  ==> MCSCF Macro Iter. 10 <==
+
+             Energy CI (  Delta E  )         Energy Opt. (  Delta E  )  E_OPT - E_CI   Orbital RMS  Micro  DIIS
+     -168.895998770209 (-1.7655e-08)   -168.895998770226 (-5.2704e-09)   -1.7536e-11    7.9460e-09    8/Y   S/E
+
+  ==> Summary of Active Space Solver Input <==
+
+    Irrep.  Multi.(2ms)      N
+    --------------------------
+       B1      1  (  0)      1
+       B2      1  (  0)      1
+    --------------------------
+    N: number of roots
+    ms: spin z component
+    Total number of roots:   2
+    --------------------------
+
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  1.602e-03
+         2              12  1.613e-03
+         3               0  1.596e-03
+    ---------------------------------
+    Total:              24  5.132e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          1.479e-04 seconds
+        β          1.389e-04 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         1.204e-03 seconds
+        ββ         7.682e-04 seconds
+        αβ         1.296e-03 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.005337 s
+
+    PQ-space CI Energy Root   0        = -168.895998770233 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895998770233 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B1     1.973930  
+        2B2     1.932785      3B1     1.025047      7A1     1.000000  
+        3B2     0.068237  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895998770233 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895998770233 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0   0.605121 0.366171756          19 |22-222222+220>
+    1   0.605121 0.366171756           7 |22+222222-220>
+    2   0.213351 0.045518544           5 |22+222222-2-+>
+    3   0.213351 0.045518544          18 |22-222222+2+->
+    4   0.210462 0.044294214           6 |22+222222-2+->
+    5   0.210462 0.044294214          15 |22-222222+2-+>
+    6   0.202035 0.040818341           3 |22+22222-2220>
+    7   0.202035 0.040818341          17 |22-22222+2220>
+    8  -0.042458 0.001802714          14 |22-222222+202>
+    9  -0.042458 0.001802714           4 |22+222222-202>
+
+  Saving information for root: 0
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  1.628e-03
+         2              12  8.141e-04
+         3               0  8.225e-04
+    ---------------------------------
+    Total:              24  3.527e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          7.920e-05 seconds
+        β          8.610e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         4.260e-04 seconds
+        ββ         4.391e-04 seconds
+        αβ         7.173e-04 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.002726 s
+
+    PQ-space CI Energy Root   0        = -168.895998770233 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895998770233 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B2     1.973930  
+        2B1     1.932785      3B2     1.025047      7A1     1.000000  
+        3B1     0.068237  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895998770233 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895998770233 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0  -0.605121 0.366171756          23 |22-222222022+>
+    1  -0.605121 0.366171756           7 |22+222222022->
+    2  -0.213351 0.045518544          21 |22-22222+-22+>
+    3  -0.213351 0.045518544           3 |22+22222-+22->
+    4  -0.210462 0.044294214          19 |22-22222-+22+>
+    5  -0.210462 0.044294214           6 |22+22222+-22->
+    6  -0.202035 0.040818341           5 |22+22222202-2>
+    7  -0.202035 0.040818341          22 |22-22222202+2>
+    8   0.042458 0.001802714          17 |22-222220222+>
+    9   0.042458 0.001802714           2 |22+222220222->
+
+  Saving information for root: 0
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    B1     0     -168.895998770233   0.000000
+    --------------------------------------------------------
+       1  (  0)    B2     0     -168.895998770233   0.000000
+    --------------------------------------------------------
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          8.300e-06 seconds
+        β          8.100e-06 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         1.240e-05 seconds
+        ββ         1.000e-05 seconds
+        αβ         8.200e-06 seconds
+  1-RDM  took 0.000280 s (determinant)
+  2-RDMS took 0.001792 s (determinant)
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          8.100e-06 seconds
+        β          8.000e-06 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         8.000e-06 seconds
+        ββ         8.100e-06 seconds
+        αβ         8.100e-06 seconds
+  1-RDM  took 0.000278 s (determinant)
+  2-RDMS took 0.001746 s (determinant)
+
+  ==> Optimizing Orbitals for Current RDMs <==
+
+
+  ==> MCSCF Macro Iter. 11 <==
+
+             Energy CI (  Delta E  )         Energy Opt. (  Delta E  )  E_OPT - E_CI   Orbital RMS  Micro  DIIS
+     -168.895998770233 (-2.4158e-11)   -168.895998770233 (-6.9065e-12)   -2.8422e-13    1.6518e-09    0/Y
+
+  A miracle has come to pass: MCSCF iterations have converged!
+
+  ==> MCSCF Iteration Summary <==
+
+                      Energy CI                    Energy Orbital
+           ------------------------------  ------------------------------
+    Iter.        Total Energy       Delta        Total Energy       Delta  Orb. Grad.  Micro
+    ----------------------------------------------------------------------------------------
+       1    -168.616670654420  0.0000e+00   -168.888783337078  0.0000e+00  3.6950e-06    15
+       2    -168.892747738622 -2.7608e-01   -168.893697378755 -4.9140e-03  3.6553e-06    15
+       3    -168.894295631079 -1.5479e-03   -168.894836244495 -1.1389e-03  1.4994e-07    13
+       4    -168.895331156330 -1.0355e-03   -168.895662805026 -8.2656e-04  4.7932e-08    13
+       5    -168.895857438797 -5.2628e-04   -168.895965060190 -3.0226e-04  9.2667e-08    12
+       6    -168.895987409227 -1.2997e-04   -168.895994779076 -2.9719e-05  8.9429e-08    12
+       7    -168.895995535151 -8.1259e-06   -168.895997634871 -2.8558e-06  1.6406e-08    12
+       8    -168.895998683644 -3.1485e-06   -168.895998745092 -1.1102e-06  3.9101e-08    10
+       9    -168.895998752554 -6.8910e-08   -168.895998764956 -1.9864e-08  2.4513e-08    11
+      10    -168.895998770209 -1.7655e-08   -168.895998770226 -5.2704e-09  7.9460e-09     8
+      11    -168.895998770233 -2.4158e-11   -168.895998770233 -6.9065e-12  1.6518e-09     0
+    ----------------------------------------------------------------------------------------
+
+       -----------------------------------------------------------------
+                            Semi-Canonical Orbitals
+         Chenyang Li, Jeffrey B. Schriber and Francesco A. Evangelista
+       -----------------------------------------------------------------
+
+
+  ==> Checking Fock Matrix Diagonal Blocks <==
+
+    Off-Diag. Elements       Max           2-Norm
+    ------------------------------------------------
+    FROZEN_DOCC          0.0000000000   0.0000000000
+    FROZEN_UOCC          0.0000000000   0.0000000000
+    GAS1                 0.0000000000   0.0000000000
+    GAS2                 0.0000000000   0.0000000000
+    GAS3                 0.0000000000   0.0000000000
+    GAS4                 0.0250147685   0.0533136370
+    GAS5                 0.1283886972   0.2567773945
+    GAS6                 0.0000000000   0.0000000000
+    RESTRICTED_DOCC      0.0000000000   0.0000000000
+    RESTRICTED_UOCC      0.0551291923   0.2820036941
+    ------------------------------------------------
+  Timing for semi-canonicalization:                           0.001 s.
+
+  ==> Summary of Active Space Solver Input <==
+
+    Irrep.  Multi.(2ms)      N
+    --------------------------
+       B1      1  (  0)      1
+       B2      1  (  0)      1
+    --------------------------
+    N: number of roots
+    ms: spin z component
+    Total number of roots:   2
+    --------------------------
+
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 2    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  8.053e-04
+         2              12  9.147e-04
+         3               0  9.375e-04
+    ---------------------------------
+    Total:              24  2.846e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          1.101e-04 seconds
+        β          1.563e-04 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         4.211e-04 seconds
+        ββ         3.738e-04 seconds
+        αβ         1.165e-03 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.003319 s
+
+    PQ-space CI Energy Root   0        = -168.895998770233 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895998770233 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B1     1.973930  
+        2B2     1.932785      3B1     1.025047      7A1     1.000000  
+        3B2     0.068237  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895998770233 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895998770233 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0  -0.687231 0.472286835          19 |22-222222+220>
+    1  -0.687231 0.472286835           7 |22+222222-220>
+    2   0.097399 0.009486472          14 |22-222222+202>
+    3   0.097399 0.009486472           4 |22+222222-202>
+    4   0.078277 0.006127271           2 |22+22222-22+->
+    5   0.078277 0.006127271          13 |22-22222+22-+>
+    6   0.069295 0.004801810           1 |22+22222-22-+>
+    7   0.069295 0.004801810          16 |22-22222+22+->
+    8  -0.049676 0.002467674           5 |22+222222-2-+>
+    9  -0.049676 0.002467674          18 |22-222222+2+->
+
+  Saving information for root: 0
+
+--------------------------------------------------------------------------------
+               Selected Configuration Interaction Excited States
+  written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista
+--------------------------------------------------------------------------------
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Ms                                       0
+    Excited Algorithm                        NONE
+  -----------------------------------------------------------------
+  Using 1 thread(s)
+  Computing wavefunction for root 0
+
+        ---------------------------------------------------------------
+                      Adaptive Configuration Interaction
+          written by Jeffrey B. Schriber and Francesco A. Evangelista
+        ---------------------------------------------------------------
+
+  ==> Reference Information <==
+
+  There are 0 frozen orbitals.
+  There are 13 active orbitals.
+
+  ==> Calculation Information <==
+
+  -----------------------------------------------------------------
+    Multiplicity                             1    
+    Symmetry                                 3    
+    Number of roots                          1    
+    Root used for properties                 0    
+    Roots used for averaging                 1    
+    Root averaging offset                    0    
+    Sigma (Eh)                               1.00e-02
+    Gamma (Eh^(-1))                          1.00e+00
+    Convergence threshold                    1.00e-09
+    Ms                                       0
+    Diagonalization algorithm                SPARSE
+    Excited Algorithm                        NONE
+    Project out spin contaminants            True
+    Enforce spin completeness of basis       True
+    Enforce complete aimed selection         True
+    Multiroot averaging                      Average
+  -----------------------------------------------------------------
+  Number of active orbitals: 13
+  Number of active alpha electrons: 11
+  Number of active beta electrons: 11
+
+  ==> GAS Orbital Energies from SCF <==
+
+    GAS        Energy  Index
+    ------------------------
+     1   -20.66106075      0
+     2   -15.85184378      1
+     3   -15.70414633      2
+     4    -1.61962645      3
+     4    -1.41247386      4
+     4    -0.83347966      5
+     4    -0.69166888      6
+     4    -0.75805474      7
+     4    -0.75805474     10
+     5    -0.48191403      8
+     5     0.15247332      9
+     5    -0.48191403     11
+     5     0.15247332     12
+    ------------------------
+
+  ==> Number of Electrons in GAS <==
+
+    GAS  MAX  MIN
+    -------------
+      1    2    2
+      2    2    2
+      3    1    0
+      4   12   12
+      5    8    0
+    -------------
+
+  ==> Possible Electron Occupations in GAS <==
+
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B
+    ---------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3
+         2     1    1    1    1    0    1    6    6    3    2
+         3     1    1    1    1    0    0    6    6    3    3
+    ---------------------------------------------------------
+    n_A/B: # of alpha/beta electrons in GASn
+
+  ==> Building GAS Determinants <==
+
+    Config.  #Determinants     Time/s
+    ---------------------------------
+         1              12  9.601e-04
+         2              12  7.955e-04
+         3               0  1.030e-03
+    ---------------------------------
+    Total:              24  3.095e-03
+    ---------------------------------
+
+  ==> Diagonalizing the Hamiltonian in the P + Q space <==
+
+  Number of reference roots: 1
+
+  ==> Computing 1 Coupling Lists <==
+
+        α          8.980e-05 seconds
+        β          6.480e-05 seconds
+
+  ==> Computing 2 Coupling Lists <==
+
+        αα         4.530e-04 seconds
+        ββ         3.970e-04 seconds
+        αβ         7.864e-04 seconds
+
+  Davidson-Liu solver algorithm using SigmaVectorSparseList sigma algorithm
+
+  Performing diagonalization of the H matrix
+  Found 10 roots with 2S+1 = 1 *
+  Found 12 roots with 2S+1 = 3
+  Found 2 roots with 2S+1 = 5
+  Total time spent diagonalizing H:   0.002737 s
+
+    PQ-space CI Energy Root   0        = -168.895998770233 Eh =   0.0000 eV, S^2 = 0.000000
+    PQ-space CI Energy + EPT2 Root   0 = -168.895998770233 Eh =   0.0000 eV
+
+
+  ==> GAS Contribution Analysis <==
+
+  Root 0:
+    Config.  1_A  1_B  2_A  2_B  3_A  3_B  4_A  4_B  5_A  5_B  Contribution
+    -----------------------------------------------------------------------
+         1     1    1    1    1    1    0    6    6    2    3  50.00000000%
+         2     1    1    1    1    0    1    6    6    3    2  50.00000000%
+         3     1    1    1    1    0    0    6    6    3    3   0.00000000%
+    -----------------------------------------------------------------------
+               GAS1      GAS2      GAS3      GAS4      GAS5    Contribution
+    -----------------------------------------------------------------------
+                  2         2         0        12         6     0.00000000%
+                  2         2         1        12         5   100.00000000%
+    -----------------------------------------------------------------------
+
+  ==> ACI Natural Orbitals <==
+
+        1B2     2.000000      1B1     2.000000      6A1     2.000000  
+        5A1     2.000000      4A1     2.000000      3A1     2.000000  
+        2A1     2.000000      1A1     2.000000      2B2     1.973930  
+        2B1     1.932785      3B2     1.025047      7A1     1.000000  
+        3B1     0.068237  
+
+  ==> Excited state solver summary <==
+
+  Iterations required:                         0
+  Dimension of optimized determinant space:    24
+
+  * Selected-CI Energy Root   0        = -168.895998770233 Eh =   0.0000 eV
+  * Selected-CI Energy Root   0 + EPT2 = -168.895998770233 Eh =   0.0000 eV
+
+  ==> Wavefunction Information <==
+
+  Most important contributions to root   0:
+    0   0.687231 0.472286835          23 |22-222222022+>
+    1   0.687231 0.472286835           7 |22+222222022->
+    2  -0.097399 0.009486472          17 |22-222220222+>
+    3  -0.097399 0.009486472           2 |22+222220222->
+    4  -0.078277 0.006127271          18 |22-22222-+2+2>
+    5  -0.078277 0.006127271           4 |22+22222+-2-2>
+    6  -0.069295 0.004801810           1 |22+22222-+2-2>
+    7  -0.069295 0.004801810          20 |22-22222+-2+2>
+    8   0.049676 0.002467674          21 |22-22222+-22+>
+    9   0.049676 0.002467674           3 |22+22222-+22->
+
+  Saving information for root: 0
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    B1     0     -168.895998770233   0.000000
+    --------------------------------------------------------
+       1  (  0)    B2     0     -168.895998770233   0.000000
+    --------------------------------------------------------
+
+  Time to prepare integrals:        0.204 seconds
+  Time to run job          :       26.115 seconds
+  Total                    :       26.319 seconds
+    GASSCF energy.........................................................................PASSED
+
+    Psi4 stopped on: Wednesday, 28 July 2021 05:39PM
+    Psi4 wall time for execution: 0:00:27.17
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/methods/tests.yaml
+++ b/tests/methods/tests.yaml
@@ -246,6 +246,7 @@ gasscf:
       - gasscf-2
       - gasscf-dsrg-mrpt2-1
       - sa-gasscf-3
+      - sa-gasscf-4
 integrals:
    short:
       - integrals-3


### PR DESCRIPTION
## Description
This code now enables rotations between orbitals within the list CASSCF_ACTIVE_FROZEN_ORBITALS instead of completely freezing rotations of all the orbitals within the list.

## User Notes
- Added test sa-gasscf-4 to check this implementation is correct.
## Checklist
- [x] Added/updated tests of new features and included a reference `output.ref` file
- [x] Removed comments in code and input files
- [x] Documented source code
- [x] Checked for consistency in the formatting of the output file

