### PR TITLE
Adjoint for SQOperator and SparseOperator

### DIFF
--- a/forte/api/sci_api.cc
+++ b/forte/api/sci_api.cc
@@ -149,14 +149,17 @@ void export_Determinant(py::module& m) {
         .def("set_coefficient", &SparseOperator::set_coefficient)
         .def("op_list", &SparseOperator::op_list)
         .def("str", &SparseOperator::str)
-        .def("latex", &SparseOperator::latex);
+        .def("latex", &SparseOperator::latex)
+        .def("adjoint", &SparseOperator::adjoint);
 
     py::class_<SQOperator>(m, "SQOperator")
+        .def(py::init<double, const Determinant&, const Determinant&>())
         .def("coefficient", &SQOperator::coefficient)
         .def("cre", &SQOperator::cre)
         .def("ann", &SQOperator::ann)
         .def("str", &SQOperator::str)
-        .def("latex", &SQOperator::latex);
+        .def("latex", &SQOperator::latex)
+        .def("adjoint", &SQOperator::adjoint);
 
     py::class_<StateVector>(m, "StateVector")
         .def(py::init<const det_hash<double>&>())

--- a/forte/helpers/blockedtensorfactory.cc
+++ b/forte/helpers/blockedtensorfactory.cc
@@ -202,7 +202,7 @@ BlockedTensorFactory::spin_cases_avoid(const std::vector<std::string>& in_str_ve
 
     std::vector<std::string> out_str_vec;
     if (how_many_active == 1) {
-        for (const std::string spin : in_str_vec) {
+        for (const std::string& spin : in_str_vec) {
             size_t spin_ind = spin.find('a');
             size_t spin_ind2 = spin.find('A');
             if (spin_ind != std::string::npos || spin_ind2 != std::string::npos) {
@@ -210,7 +210,7 @@ BlockedTensorFactory::spin_cases_avoid(const std::vector<std::string>& in_str_ve
             }
         }
     } else if (how_many_active > 1) {
-        for (const std::string spin : in_str_vec) {
+        for (const std::string& spin : in_str_vec) {
             std::string spin_transform = spin;
             std::transform(spin_transform.begin(), spin_transform.end(), spin_transform.begin(),
                            ::tolower);

--- a/forte/sparse_ci/sparse_operator.cc
+++ b/forte/sparse_ci/sparse_operator.cc
@@ -139,4 +139,12 @@ std::string SparseOperator::latex() const {
     }
     return join(v, " ");
 }
+
+SparseOperator SparseOperator::adjoint() const {
+    auto adjoint_operator = SparseOperator(antihermitian_);
+    for (const SQOperator& sqop : op_list_) {
+        adjoint_operator.add_term(sqop.adjoint());
+    }
+    return adjoint_operator;
+}
 } // namespace forte

--- a/forte/sparse_ci/sparse_operator.h
+++ b/forte/sparse_ci/sparse_operator.h
@@ -119,6 +119,8 @@ class SparseOperator {
     std::vector<std::string> str() const;
     /// @return a latex representation of this operator
     std::string latex() const;
+    /// @return the sparse operator that is the adjoint of this operator
+    SparseOperator adjoint() const;
 
   private:
     /// is this an antihermitian operator?

--- a/forte/sparse_ci/sq_operator.cc
+++ b/forte/sparse_ci/sq_operator.cc
@@ -188,4 +188,8 @@ std::string SQOperator::latex() const {
     return s;
 }
 
+SQOperator SQOperator::adjoint() const {
+    return SQOperator(coefficient_, ann_, cre_);
+}
+
 } // namespace forte

--- a/forte/sparse_ci/sq_operator.h
+++ b/forte/sparse_ci/sq_operator.h
@@ -106,6 +106,8 @@ class SQOperator {
     std::string str() const;
     /// @return a latex representation of this operator
     std::string latex() const;
+    /// @return a sq_operator that is thea djoint of this operator
+    SQOperator adjoint() const;
 
   private:
     /// a numerical coefficient associated with this product of sq operators

--- a/tests/pytest/sparse_ci/test_sparse_operator.py
+++ b/tests/pytest/sparse_ci/test_sparse_operator.py
@@ -357,6 +357,28 @@ def test_sparse_operator():
     wfn = forte.apply_operator(sop, ref)
     assert wfn[det("+20-")] == pytest.approx(-1.0, abs=1e-9)
 
+    ### Adjoint tests
+    # test adjoint of SqOperator is idempotent
+    sqop = forte.SQOperator(1, det("2+0"), det("002"))
+    sqopd = sqop.adjoint()
+    sqopdd = sqopd.adjoint()
+    assert sqop.str() == sqopdd.str()
+    # test adjoint of SqOperator
+    ref = forte.SQOperator(1, det("002"), det("2+0"))
+    assert sqopd.str() == ref.str()
+    # test adjoint of SparseOperator is idempotent
+    sop = forte.SparseOperator()
+    sop.add_term_from_str('[3a+ 0a-]', 1.0)
+    sop.add_term_from_str('[2b+ 1b-]', 1.0)
+    sopd = sop.adjoint()
+    sopdd = sopd.adjoint()
+    assert sop.str() == sopdd.str()
+    # test adjoint of SparseOperator
+    ref = forte.SparseOperator()
+    ref.add_term_from_str('[0a+ 3a-]', 1.0)
+    ref.add_term_from_str('[1b+ 2b-]', 1.0)
+    assert sopd.str() == ref.str()
+
 
 if __name__ == "__main__":
     test_sparse_operator()


### PR DESCRIPTION
## Description
This PR adds an adjoint method to the `SQOperator` and `SparseOperator` classes, so that I can use the SparseOperator API to correctness-test truncated VCC.

## User Notes
- [x] `SQOperator` and `SparseOperator` now have a defined `adjoint` method

## Checklist
- [x] Added pytests, so no output files
- [x] Ready to go!
