### PR TITLE
Update Forte to work with development Psi4

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -137,9 +137,6 @@ jobs:
       cd build
       echo "Now at directory: $PWD"
       git clone https://github.com/psi4/psi4.git psi4
-      cd psi4
-      git checkout de731dbf19932092603c25a1e2a02cf813ab77ee
-      cd ..
     displayName: 'Clone Psi4 Source'
 
   - bash: |

--- a/forte/casscf/casscf.cc
+++ b/forte/casscf/casscf.cc
@@ -186,9 +186,9 @@ double CASSCF::compute_energy() {
 
     // Setup the DIIS manager
     auto diis_manager = std::make_shared<DIISManager>(
-        diis_max_vec, "MCSCF DIIS", DIISManager::OldestAdded, DIISManager::InCore);
-    diis_manager->set_error_vector_size(1, DIISEntry::Matrix, S.get());
-    diis_manager->set_vector_size(1, DIISEntry::Matrix, S.get());
+        diis_max_vec, "MCSCF DIIS", DIISManager::RemovalPolicy::OldestAdded, DIISManager::StoragePolicy::InCore);
+    diis_manager->set_error_vector_size(1, DIISEntry::InputType::Matrix, S.get());
+    diis_manager->set_vector_size(1, DIISEntry::InputType::Matrix, S.get());
 
     int diis_count = 0;
 

--- a/forte/casscf/mcscf_2step.cc
+++ b/forte/casscf/mcscf_2step.cc
@@ -168,11 +168,11 @@ double MCSCF_2STEP::compute_energy() {
 
     // DIIS extropolation for macro iteration
     psi::DIISManager diis_manager(do_diis_ ? diis_max_vec_ : 0, "MCSCF DIIS",
-                                  psi::DIISManager::OldestAdded, psi::DIISManager::OnDisk);
+                                  psi::DIISManager::RemovalPolicy::OldestAdded, psi::DIISManager::StoragePolicy::OnDisk);
     if (do_diis_) {
         dR = std::make_shared<psi::Vector>("dR", nrot);
-        diis_manager.set_error_vector_size(1, psi::DIISEntry::Vector, dR.get());
-        diis_manager.set_vector_size(1, psi::DIISEntry::Vector, R.get());
+        diis_manager.set_error_vector_size(1, psi::DIISEntry::InputType::Vector, dR.get());
+        diis_manager.set_vector_size(1, psi::DIISEntry::InputType::Vector, R.get());
     }
 
     // set up L-BFGS solver and its parameters for micro iteration

--- a/forte/integrals/integrals_psi4_interface.cc
+++ b/forte/integrals/integrals_psi4_interface.cc
@@ -340,35 +340,25 @@ void Psi4Integrals::rotate_mos() {
     std::shared_ptr<psi::Matrix> C_old = Ca_;
     std::shared_ptr<psi::Matrix> C_new(C_old->clone());
 
-    psi::Vector* eps_a = wfn_->epsilon_a()->clone();
-    psi::Vector* eps_b = wfn_->epsilon_b()->clone();
-    psi::Vector* epsilon_old = eps_a;
-    psi::Vector* epsilon_new(epsilon_old->clone());
+    const auto& eps_a_old = *wfn_->epsilon_a();
+    auto eps_a_new = *eps_a_old.clone();
 
     for (auto mo_group : rotate_mo_list) {
-        psi::SharedVector C_mo1 = C_old->get_column(mo_group[0], mo_group[1]);
-        psi::SharedVector C_mo2 = C_old->get_column(mo_group[0], mo_group[2]);
-        double epsilon_mo1 = epsilon_old->get(mo_group[0], mo_group[1]);
-        double epsilon_mo2 = epsilon_old->get(mo_group[0], mo_group[2]);
+        auto C_mo1 = C_old->get_column(mo_group[0], mo_group[1]);
+        auto C_mo2 = C_old->get_column(mo_group[0], mo_group[2]);
+        auto epsilon_mo1 = eps_a_old.get(mo_group[0], mo_group[1]);
+        auto epsilon_mo2 = eps_a_old.get(mo_group[0], mo_group[2]);
         C_new->set_column(mo_group[0], mo_group[2], C_mo1);
         C_new->set_column(mo_group[0], mo_group[1], C_mo2);
-        epsilon_new->set(mo_group[0], mo_group[2], epsilon_mo1);
-        epsilon_new->set(mo_group[0], mo_group[1], epsilon_mo2);
+        eps_a_new.set(mo_group[0], mo_group[2], epsilon_mo1);
+        eps_a_new.set(mo_group[0], mo_group[1], epsilon_mo2);
     }
-    C_old->copy(C_new);
-    epsilon_old->copy(epsilon_new);
 
-    // std::shared_ptr<psi::Matrix> Cb_old = wfn_->Cb();
-    std::shared_ptr<psi::Matrix> Cb_old = Cb_;
-    psi::Vector* epsilon_b_old = eps_b;
-    Cb_old->copy(C_new);
-    epsilon_b_old->copy(epsilon_new);
-
-    // Send a copy to psi::Wavefunction
-    wfn_->Ca()->copy(Ca_);
-    wfn_->Cb()->copy(Cb_);
-    wfn_->epsilon_a()->copy(eps_a);
-    wfn_->epsilon_b()->copy(eps_b);
+    // Copy to psi::Wavefunction
+    wfn_->Ca()->copy(C_new);
+    wfn_->Cb()->copy(C_new);
+    wfn_->epsilon_a()->copy(eps_a_new);
+    wfn_->epsilon_b()->copy(eps_a_new);
 }
 
 void Psi4Integrals::build_dipole_ints_ao() {

--- a/forte/integrals/integrals_psi4_interface.cc
+++ b/forte/integrals/integrals_psi4_interface.cc
@@ -336,7 +336,7 @@ void Psi4Integrals::rotate_mos() {
         outfile->Printf("   %d   %d   %d\n", rotate_mo_group[0], rotate_mo_group[1],
                         rotate_mo_group[2]);
     }
-    // std::shared_ptr<psi::Matrix> C_old = wfn_->Ca();
+
     std::shared_ptr<psi::Matrix> C_old = Ca_;
     std::shared_ptr<psi::Matrix> C_new(C_old->clone());
 
@@ -353,6 +353,9 @@ void Psi4Integrals::rotate_mos() {
         eps_a_new.set(mo_group[0], mo_group[2], epsilon_mo1);
         eps_a_new.set(mo_group[0], mo_group[1], epsilon_mo2);
     }
+    // Update local copy of the orbitals
+    Ca_->copy(C_new);
+    Cb_->copy(C_new);
 
     // Copy to psi::Wavefunction
     wfn_->Ca()->copy(C_new);

--- a/forte/mrdsrg-spin-adapted/sa_mrdsrg_diis.cc
+++ b/forte/mrdsrg-spin-adapted/sa_mrdsrg_diis.cc
@@ -36,7 +36,7 @@ namespace forte {
 
 void SA_MRDSRG::diis_manager_init() {
     diis_manager_ = std::make_shared<DIISManager>(diis_max_vec_, "SA_MRDSRG DIIS",
-                                                  DIISManager::LargestError, DIISManager::OnDisk);
+                                                  DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::OnDisk);
 
     amp_ptrs_.clear();
     res_ptrs_.clear();
@@ -60,21 +60,21 @@ void SA_MRDSRG::diis_manager_init() {
     }
 
     diis_manager_->set_error_vector_size(
-        18, DIISEntry::Pointer, sizes[0], DIISEntry::Pointer, sizes[1], DIISEntry::Pointer,
-        sizes[2], DIISEntry::Pointer, sizes[3], DIISEntry::Pointer, sizes[4], DIISEntry::Pointer,
-        sizes[5], DIISEntry::Pointer, sizes[6], DIISEntry::Pointer, sizes[7], DIISEntry::Pointer,
-        sizes[8], DIISEntry::Pointer, sizes[9], DIISEntry::Pointer, sizes[10], DIISEntry::Pointer,
-        sizes[11], DIISEntry::Pointer, sizes[12], DIISEntry::Pointer, sizes[13], DIISEntry::Pointer,
-        sizes[14], DIISEntry::Pointer, sizes[15], DIISEntry::Pointer, sizes[16], DIISEntry::Pointer,
+        18, DIISEntry::InputType::Pointer, sizes[0], DIISEntry::InputType::Pointer, sizes[1], DIISEntry::InputType::Pointer,
+        sizes[2], DIISEntry::InputType::Pointer, sizes[3], DIISEntry::InputType::Pointer, sizes[4], DIISEntry::InputType::Pointer,
+        sizes[5], DIISEntry::InputType::Pointer, sizes[6], DIISEntry::InputType::Pointer, sizes[7], DIISEntry::InputType::Pointer,
+        sizes[8], DIISEntry::InputType::Pointer, sizes[9], DIISEntry::InputType::Pointer, sizes[10], DIISEntry::InputType::Pointer,
+        sizes[11], DIISEntry::InputType::Pointer, sizes[12], DIISEntry::InputType::Pointer, sizes[13], DIISEntry::InputType::Pointer,
+        sizes[14], DIISEntry::InputType::Pointer, sizes[15], DIISEntry::InputType::Pointer, sizes[16], DIISEntry::InputType::Pointer,
         sizes[17]);
 
     diis_manager_->set_vector_size(
-        18, DIISEntry::Pointer, sizes[0], DIISEntry::Pointer, sizes[1], DIISEntry::Pointer,
-        sizes[2], DIISEntry::Pointer, sizes[3], DIISEntry::Pointer, sizes[4], DIISEntry::Pointer,
-        sizes[5], DIISEntry::Pointer, sizes[6], DIISEntry::Pointer, sizes[7], DIISEntry::Pointer,
-        sizes[8], DIISEntry::Pointer, sizes[9], DIISEntry::Pointer, sizes[10], DIISEntry::Pointer,
-        sizes[11], DIISEntry::Pointer, sizes[12], DIISEntry::Pointer, sizes[13], DIISEntry::Pointer,
-        sizes[14], DIISEntry::Pointer, sizes[15], DIISEntry::Pointer, sizes[16], DIISEntry::Pointer,
+        18, DIISEntry::InputType::Pointer, sizes[0], DIISEntry::InputType::Pointer, sizes[1], DIISEntry::InputType::Pointer,
+        sizes[2], DIISEntry::InputType::Pointer, sizes[3], DIISEntry::InputType::Pointer, sizes[4], DIISEntry::InputType::Pointer,
+        sizes[5], DIISEntry::InputType::Pointer, sizes[6], DIISEntry::InputType::Pointer, sizes[7], DIISEntry::InputType::Pointer,
+        sizes[8], DIISEntry::InputType::Pointer, sizes[9], DIISEntry::InputType::Pointer, sizes[10], DIISEntry::InputType::Pointer,
+        sizes[11], DIISEntry::InputType::Pointer, sizes[12], DIISEntry::InputType::Pointer, sizes[13], DIISEntry::InputType::Pointer,
+        sizes[14], DIISEntry::InputType::Pointer, sizes[15], DIISEntry::InputType::Pointer, sizes[16], DIISEntry::InputType::Pointer,
         sizes[17]);
 }
 

--- a/forte/mrdsrg-spin-integrated/mrdsrg_diis.cc
+++ b/forte/mrdsrg-spin-integrated/mrdsrg_diis.cc
@@ -101,7 +101,7 @@ void MRDSRG::return_amp_diis(BlockedTensor& T1, const std::vector<std::string>& 
 
 void MRDSRG::diis_manager_init() {
     diis_manager_ = std::make_shared<DIISManager>(diis_max_vec_, "MRDSRG DIIS",
-                                                  DIISManager::LargestError, DIISManager::OnDisk);
+                                                  DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::OnDisk);
 
     amp_ptrs_.clear();
     res_ptrs_.clear();
@@ -128,43 +128,43 @@ void MRDSRG::diis_manager_init() {
     }
 
     diis_manager_->set_error_vector_size(
-        51, DIISEntry::Pointer, sizes[0], DIISEntry::Pointer, sizes[1], DIISEntry::Pointer,
-        sizes[2], DIISEntry::Pointer, sizes[3], DIISEntry::Pointer, sizes[4], DIISEntry::Pointer,
-        sizes[5], DIISEntry::Pointer, sizes[6], DIISEntry::Pointer, sizes[7], DIISEntry::Pointer,
-        sizes[8], DIISEntry::Pointer, sizes[9], DIISEntry::Pointer, sizes[10], DIISEntry::Pointer,
-        sizes[11], DIISEntry::Pointer, sizes[12], DIISEntry::Pointer, sizes[13], DIISEntry::Pointer,
-        sizes[14], DIISEntry::Pointer, sizes[15], DIISEntry::Pointer, sizes[16], DIISEntry::Pointer,
-        sizes[17], DIISEntry::Pointer, sizes[18], DIISEntry::Pointer, sizes[19], DIISEntry::Pointer,
-        sizes[20], DIISEntry::Pointer, sizes[21], DIISEntry::Pointer, sizes[22], DIISEntry::Pointer,
-        sizes[23], DIISEntry::Pointer, sizes[24], DIISEntry::Pointer, sizes[25], DIISEntry::Pointer,
-        sizes[26], DIISEntry::Pointer, sizes[27], DIISEntry::Pointer, sizes[28], DIISEntry::Pointer,
-        sizes[29], DIISEntry::Pointer, sizes[30], DIISEntry::Pointer, sizes[31], DIISEntry::Pointer,
-        sizes[32], DIISEntry::Pointer, sizes[33], DIISEntry::Pointer, sizes[34], DIISEntry::Pointer,
-        sizes[35], DIISEntry::Pointer, sizes[36], DIISEntry::Pointer, sizes[37], DIISEntry::Pointer,
-        sizes[38], DIISEntry::Pointer, sizes[39], DIISEntry::Pointer, sizes[40], DIISEntry::Pointer,
-        sizes[41], DIISEntry::Pointer, sizes[42], DIISEntry::Pointer, sizes[43], DIISEntry::Pointer,
-        sizes[44], DIISEntry::Pointer, sizes[45], DIISEntry::Pointer, sizes[46], DIISEntry::Pointer,
-        sizes[47], DIISEntry::Pointer, sizes[48], DIISEntry::Pointer, sizes[49], DIISEntry::Pointer,
+        51, DIISEntry::InputType::Pointer, sizes[0], DIISEntry::InputType::Pointer, sizes[1], DIISEntry::InputType::Pointer,
+        sizes[2], DIISEntry::InputType::Pointer, sizes[3], DIISEntry::InputType::Pointer, sizes[4], DIISEntry::InputType::Pointer,
+        sizes[5], DIISEntry::InputType::Pointer, sizes[6], DIISEntry::InputType::Pointer, sizes[7], DIISEntry::InputType::Pointer,
+        sizes[8], DIISEntry::InputType::Pointer, sizes[9], DIISEntry::InputType::Pointer, sizes[10], DIISEntry::InputType::Pointer,
+        sizes[11], DIISEntry::InputType::Pointer, sizes[12], DIISEntry::InputType::Pointer, sizes[13], DIISEntry::InputType::Pointer,
+        sizes[14], DIISEntry::InputType::Pointer, sizes[15], DIISEntry::InputType::Pointer, sizes[16], DIISEntry::InputType::Pointer,
+        sizes[17], DIISEntry::InputType::Pointer, sizes[18], DIISEntry::InputType::Pointer, sizes[19], DIISEntry::InputType::Pointer,
+        sizes[20], DIISEntry::InputType::Pointer, sizes[21], DIISEntry::InputType::Pointer, sizes[22], DIISEntry::InputType::Pointer,
+        sizes[23], DIISEntry::InputType::Pointer, sizes[24], DIISEntry::InputType::Pointer, sizes[25], DIISEntry::InputType::Pointer,
+        sizes[26], DIISEntry::InputType::Pointer, sizes[27], DIISEntry::InputType::Pointer, sizes[28], DIISEntry::InputType::Pointer,
+        sizes[29], DIISEntry::InputType::Pointer, sizes[30], DIISEntry::InputType::Pointer, sizes[31], DIISEntry::InputType::Pointer,
+        sizes[32], DIISEntry::InputType::Pointer, sizes[33], DIISEntry::InputType::Pointer, sizes[34], DIISEntry::InputType::Pointer,
+        sizes[35], DIISEntry::InputType::Pointer, sizes[36], DIISEntry::InputType::Pointer, sizes[37], DIISEntry::InputType::Pointer,
+        sizes[38], DIISEntry::InputType::Pointer, sizes[39], DIISEntry::InputType::Pointer, sizes[40], DIISEntry::InputType::Pointer,
+        sizes[41], DIISEntry::InputType::Pointer, sizes[42], DIISEntry::InputType::Pointer, sizes[43], DIISEntry::InputType::Pointer,
+        sizes[44], DIISEntry::InputType::Pointer, sizes[45], DIISEntry::InputType::Pointer, sizes[46], DIISEntry::InputType::Pointer,
+        sizes[47], DIISEntry::InputType::Pointer, sizes[48], DIISEntry::InputType::Pointer, sizes[49], DIISEntry::InputType::Pointer,
         sizes[50]);
 
     diis_manager_->set_vector_size(
-        51, DIISEntry::Pointer, sizes[0], DIISEntry::Pointer, sizes[1], DIISEntry::Pointer,
-        sizes[2], DIISEntry::Pointer, sizes[3], DIISEntry::Pointer, sizes[4], DIISEntry::Pointer,
-        sizes[5], DIISEntry::Pointer, sizes[6], DIISEntry::Pointer, sizes[7], DIISEntry::Pointer,
-        sizes[8], DIISEntry::Pointer, sizes[9], DIISEntry::Pointer, sizes[10], DIISEntry::Pointer,
-        sizes[11], DIISEntry::Pointer, sizes[12], DIISEntry::Pointer, sizes[13], DIISEntry::Pointer,
-        sizes[14], DIISEntry::Pointer, sizes[15], DIISEntry::Pointer, sizes[16], DIISEntry::Pointer,
-        sizes[17], DIISEntry::Pointer, sizes[18], DIISEntry::Pointer, sizes[19], DIISEntry::Pointer,
-        sizes[20], DIISEntry::Pointer, sizes[21], DIISEntry::Pointer, sizes[22], DIISEntry::Pointer,
-        sizes[23], DIISEntry::Pointer, sizes[24], DIISEntry::Pointer, sizes[25], DIISEntry::Pointer,
-        sizes[26], DIISEntry::Pointer, sizes[27], DIISEntry::Pointer, sizes[28], DIISEntry::Pointer,
-        sizes[29], DIISEntry::Pointer, sizes[30], DIISEntry::Pointer, sizes[31], DIISEntry::Pointer,
-        sizes[32], DIISEntry::Pointer, sizes[33], DIISEntry::Pointer, sizes[34], DIISEntry::Pointer,
-        sizes[35], DIISEntry::Pointer, sizes[36], DIISEntry::Pointer, sizes[37], DIISEntry::Pointer,
-        sizes[38], DIISEntry::Pointer, sizes[39], DIISEntry::Pointer, sizes[40], DIISEntry::Pointer,
-        sizes[41], DIISEntry::Pointer, sizes[42], DIISEntry::Pointer, sizes[43], DIISEntry::Pointer,
-        sizes[44], DIISEntry::Pointer, sizes[45], DIISEntry::Pointer, sizes[46], DIISEntry::Pointer,
-        sizes[47], DIISEntry::Pointer, sizes[48], DIISEntry::Pointer, sizes[49], DIISEntry::Pointer,
+        51, DIISEntry::InputType::Pointer, sizes[0], DIISEntry::InputType::Pointer, sizes[1], DIISEntry::InputType::Pointer,
+        sizes[2], DIISEntry::InputType::Pointer, sizes[3], DIISEntry::InputType::Pointer, sizes[4], DIISEntry::InputType::Pointer,
+        sizes[5], DIISEntry::InputType::Pointer, sizes[6], DIISEntry::InputType::Pointer, sizes[7], DIISEntry::InputType::Pointer,
+        sizes[8], DIISEntry::InputType::Pointer, sizes[9], DIISEntry::InputType::Pointer, sizes[10], DIISEntry::InputType::Pointer,
+        sizes[11], DIISEntry::InputType::Pointer, sizes[12], DIISEntry::InputType::Pointer, sizes[13], DIISEntry::InputType::Pointer,
+        sizes[14], DIISEntry::InputType::Pointer, sizes[15], DIISEntry::InputType::Pointer, sizes[16], DIISEntry::InputType::Pointer,
+        sizes[17], DIISEntry::InputType::Pointer, sizes[18], DIISEntry::InputType::Pointer, sizes[19], DIISEntry::InputType::Pointer,
+        sizes[20], DIISEntry::InputType::Pointer, sizes[21], DIISEntry::InputType::Pointer, sizes[22], DIISEntry::InputType::Pointer,
+        sizes[23], DIISEntry::InputType::Pointer, sizes[24], DIISEntry::InputType::Pointer, sizes[25], DIISEntry::InputType::Pointer,
+        sizes[26], DIISEntry::InputType::Pointer, sizes[27], DIISEntry::InputType::Pointer, sizes[28], DIISEntry::InputType::Pointer,
+        sizes[29], DIISEntry::InputType::Pointer, sizes[30], DIISEntry::InputType::Pointer, sizes[31], DIISEntry::InputType::Pointer,
+        sizes[32], DIISEntry::InputType::Pointer, sizes[33], DIISEntry::InputType::Pointer, sizes[34], DIISEntry::InputType::Pointer,
+        sizes[35], DIISEntry::InputType::Pointer, sizes[36], DIISEntry::InputType::Pointer, sizes[37], DIISEntry::InputType::Pointer,
+        sizes[38], DIISEntry::InputType::Pointer, sizes[39], DIISEntry::InputType::Pointer, sizes[40], DIISEntry::InputType::Pointer,
+        sizes[41], DIISEntry::InputType::Pointer, sizes[42], DIISEntry::InputType::Pointer, sizes[43], DIISEntry::InputType::Pointer,
+        sizes[44], DIISEntry::InputType::Pointer, sizes[45], DIISEntry::InputType::Pointer, sizes[46], DIISEntry::InputType::Pointer,
+        sizes[47], DIISEntry::InputType::Pointer, sizes[48], DIISEntry::InputType::Pointer, sizes[49], DIISEntry::InputType::Pointer,
         sizes[50]);
 }
 


### PR DESCRIPTION
## Description
Updates Forte to work with newer version of Psi4. Some recent Psi PRs broke Forte due to:
* Switching to scoped namespaces for DIIS enums, which is the C++ standard
* Switching `Vector::clone` from returning raw pointers to unique pointers. This exposed a memory leak in Forte, as well as very clumsy code. Both are fixed.

The new code compiles, and if auto-tests pass, this should be good to go.

## Checklist
- [x] Ready to go!
