### PR TITLE
fix the cannot open wfn problem for TRDM when doing spin averaging

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -149,7 +149,9 @@ jobs:
       PSI4BIN_DIR=$(Build.SourcesDirectory)/build/psi4bin
       echo "##vso[task.setvariable variable=PSI4BIN_DIR]${PSI4BIN_DIR}"
       echo "Psi4 bin directory: $PSI4BIN_DIR"
-      cmake -Spsi4 -Bpsi4obj \
+      mkdir psi4obj
+      cd psi4obj
+      cmake -H. -B$(Build.SourcesDirectory)/build/psi4obj \
         -DCMAKE_INSTALL_PREFIX=${PSI4BIN_DIR} \
         -DCMAKE_PREFIX_PATH=${CONDA_PREFIX} \
         -DCMAKE_CXX_COMPILER=${CXX_COMPILER} \
@@ -160,7 +162,8 @@ jobs:
         -DCMAKE_BUILD_TYPE=${PSI_BUILD_TYPE} \
         -Dpsi4_CXX_STANDARD=17 \
         -DCMAKE_CXX_FLAGS=-DPYBIND11_CPP17 \
-        -DCMAKE_CXX_STANDARD=17
+        -DCMAKE_CXX_STANDARD=17 \
+        $(Build.SourcesDirectory)/build/psi4
     displayName: 'Configure Psi4 Build'
 
   - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,7 +115,6 @@ jobs:
         adcc::adcc
       source activate p4env
       conda install -c conda-forge \
-        cmake \
         hdf5 \
         boost \
         mkl-devel \

--- a/forte/base_classes/active_space_solver.cc
+++ b/forte/base_classes/active_space_solver.cc
@@ -87,6 +87,7 @@ const std::map<StateInfo, std::vector<double>>& ActiveSpaceSolver::compute_energ
             psi::outfile->Printf("\n  Continue to the next symmetry block: No need to find the "
                                  "solution for ms = %d / 2 < 0.",
                                  twice_ms);
+            method->set_wfn_filename(""); // empty filename for ms < 0
             continue;
         }
 
@@ -206,6 +207,10 @@ void ActiveSpaceSolver::compute_fosc_same_orbs() {
             const auto& state2 = states[N];
             size_t nroot2 = state_nroots_map_[state2];
             const auto& method2 = state_method_map_[state2];
+
+            // skip negative ms if doing ms averaging
+            if (ms_avg_ and (state1.twice_ms() < 0 or state2.twice_ms() < 0))
+                continue;
 
             // skip different multiplicity (no spin-orbit coupling)
             if (state1.multiplicity() != state2.multiplicity()) {

--- a/forte/sci/detci.cc
+++ b/forte/sci/detci.cc
@@ -69,7 +69,7 @@ void DETCI::set_options(std::shared_ptr<ForteOptions> options) {
 DETCI::~DETCI() {
     // remove wave function file
     if (not dump_wfn_) {
-        if (std::remove(wfn_filename_.c_str()) != 0) {
+        if (wfn_filename_.size() != 0 and std::remove(wfn_filename_.c_str()) != 0) {
             outfile->Printf("\n  DETCI wave function %s not available.", state_.str().c_str());
             std::perror("Error when deleting DETCI wave function. See output file.");
         }


### PR DESCRIPTION
## Description
Fix the problem of failing to compute transition RDMs when doing Ms averaging for active space solver.

## Checklist
- [ ] Added/updated tests of new features and included a reference `output.ref` file
- [ ] Removed comments in code and input files
- [ ] Documented source code
- [ ] Checked for redundant headers
- [ ] Checked for consistency in the formatting of the output file
- [ ] Documented new features in the manual
- [x] Ready to go!
