### PR TITLE
add header for size_t in combinatorial.h

### DIFF
--- a/forte/helpers/combinatorial.h
+++ b/forte/helpers/combinatorial.h
@@ -29,6 +29,7 @@
 #ifndef _combinatorial_h_
 #define _combinatorial_h_
 
+#include <cstddef>
 #include <vector>
 
 namespace forte {


### PR DESCRIPTION
## Description
Add the header for `size_t` in `helpers/combinatorial.h`. Somehow the machine I am using does not know where to find `size_t` in this file

## Checklist
- [x] Ready to go!
