### PR TITLE
Add code to export spin orbital quantities

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,6 +136,9 @@ jobs:
       cd build
       echo "Now at directory: $PWD"
       git clone https://github.com/psi4/psi4.git psi4
+      cd psi4
+      git checkout 2feab68a2ce052ed74b75fa6749090cc467cd1d9
+      cd ..
     displayName: 'Clone Psi4 Source'
 
   - bash: |

--- a/docs/notebooks/nb_07_soints.ipynb
+++ b/docs/notebooks/nb_07_soints.ipynb
@@ -1,0 +1,264 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "47e14a67-ad61-4cc2-9427-0a215cad43fa",
+   "metadata": {},
+   "source": [
+    "# Reading integrals in a spin orbital basis\n",
+    "\n",
+    "In this tutorial, you will learn how to read access integrals in a spin orbital basis from python.\n",
+    "These integrals can be used in pilot implementations of quantum chemistry methods.\n",
+    "By the end of this tutorial you will know how to read the integrals and compute the Hartree-Fock energy.\n",
+    "For an implementation of MP2 based on the spin orbital integrals see the file `tests/pytest/helpers/test_spinorbital.py` in the forte directory.\n",
+    "\n",
+    "Forte assumes that the spin orbital basis $\\{ \\psi_{p} \\}$ is organized as follows\n",
+    "\\begin{equation}\n",
+    "\\underbrace{\\phi_{0,\\alpha}}_{\\psi_0},\n",
+    "\\underbrace{\\phi_{0,\\beta}}_{\\psi_1},\n",
+    "\\underbrace{\\phi_{1,\\alpha}}_{\\psi_2},\n",
+    "\\underbrace{\\phi_{1,\\beta}}_{\\psi_3},\n",
+    "\\ldots\n",
+    "\\end{equation}\n",
+    "\n",
+    "To read the one-electron integrals $h_{pq} = \\langle \\psi_p | \\hat{h} | \\psi_q \\rangle$ we use the function `spinorbital_oei`. This function takes as arguments a `ForteIntegrals` object and two lists of integers, `p` and `q`, that specify the indices of the bra and ket **spatial orbitals**.\n",
+    "For example, if we want the integrals over the bra functions $\\psi_0,\\psi_1,\\psi_3$ and ket functions $\\psi_5,\\psi_6$ we can write the following code\n",
+    "```python\n",
+    "    p = [0,1,3]\n",
+    "    q = [5,6]\n",
+    "    h = forte.spinorbital_oei(ints, p, q)\n",
+    "```\n",
+    "\n",
+    "To read the two-electron antisymmetrized integrals in physicist notation $\\langle pq \\| rs \\rangle$ we use the function `spinorbital_tei`, passing four list that corresponds to the range of the indices `p`, `q`, `r`, and `s`.\n",
+    "\n",
+    "\n",
+    "```python\n",
+    "    p = [0,1]\n",
+    "    q = [0,1]\n",
+    "    r = [2,3]\n",
+    "    s = [2,3]    \n",
+    "    v = forte.spinorbital_tei(ints, p, q, r, s)\n",
+    "```\n",
+    "\n",
+    "To compute the SCF energy we evaluate the expression\n",
+    "$$\n",
+    "E = V_\\mathrm{NN} + \\sum_{i}^\\mathrm{docc} h_{ii} + \\frac{1}{2} \\sum_{ij}^\\mathrm{docc} \\langle ij \\| ij \\rangle\n",
+    "$$\n",
+    "where $V_\\mathrm{NN}$ is the nuclear repulsion energy. To evaluate this expression we only need the one- and two-electron integral blocks that corresponds to the doubly occupied orbitals.\n",
+    "\n",
+    "## Preparing the orbitals via the `utils.psi4_scf` helper function\n",
+    "\n",
+    "To prepare an integral object it is necessary to first run a HF or CASSCF computation.\n",
+    "\n",
+    "Forte provides helper functions to run these computations using psi4. By default **this function uses conventional integrals**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "26de2205",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The SCF energy is -75.98015792193442 [Eh]\n",
+      "SCF doubly occupied orbitals per irrep: (3, 0, 1, 1)\n",
+      "SCF singly occupied orbitals per irrep: (0, 0, 0, 0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import math\n",
+    "import numpy as np\n",
+    "import forte\n",
+    "import forte.utils\n",
+    "\n",
+    "geom = \"\"\"\n",
+    "O\n",
+    "H 1 1.0\n",
+    "H 1 1.0 2 104.5\n",
+    "\"\"\"\n",
+    "\n",
+    "escf_psi4, wfn = forte.utils.psi4_scf(geom=geom, basis='6-31G', reference='RHF')\n",
+    "\n",
+    "# grab the orbital occupation\n",
+    "doccpi = wfn.doccpi().to_tuple()\n",
+    "soccpi = wfn.soccpi().to_tuple()\n",
+    "\n",
+    "print(f'The SCF energy is {escf_psi4} [Eh]')\n",
+    "print(f'SCF doubly occupied orbitals per irrep: {doccpi}')\n",
+    "print(f'SCF singly occupied orbitals per irrep: {soccpi}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e0a8cdd",
+   "metadata": {},
+   "source": [
+    "## Preparing the integral object\n",
+    "\n",
+    "To prepare the integrals, we use the helper function `utils.prepare_forte_objects`. We pass the psi4 wave function object (`wfn`) and specify the number of doubly occupied orbitals using the SCF occupation from psi4. Virtual orbitals are automatically determined."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "43d6fa26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mo_spaces={'RESTRICTED_DOCC' : doccpi, 'ACTIVE' : soccpi}\n",
+    "forte_objects = forte.utils.prepare_forte_objects(wfn,mo_spaces)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ecc14f93",
+   "metadata": {},
+   "source": [
+    "The `forte_objects` returned is a dictionary, and we can access the `ForteIntegral` object using the key `ints`. We store this object in the variable `ints`. We will also use the `MOSpaceInfo` object, which is stored with the key `mo_space_info`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ac9158c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ints = forte_objects['ints']\n",
+    "mo_space_info = forte_objects['mo_space_info']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc5bbd4b",
+   "metadata": {},
+   "source": [
+    "## Preparing list of doubly occupied orbitals\n",
+    "\n",
+    "From the `MOSpaceInfo` object we can find the list of doubly occupied orbitals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2f735184",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "List of doubly occupied orbitals: [0, 1, 2, 7, 9]\n"
+     ]
+    }
+   ],
+   "source": [
+    "rdocc = mo_space_info.corr_absolute_mo('RESTRICTED_DOCC')\n",
+    "print(f'List of doubly occupied orbitals: {rdocc}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a25c355",
+   "metadata": {},
+   "source": [
+    "## Preparing the core blocks of the Hamiltonian\n",
+    "\n",
+    "Here we call the functions that return the integrals in the spin orbital basis. We store those in two variables, `h` and `v`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "f16a0815",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[-32.98   0.    -0.58   0.    -0.19   0.     0.     0.     0.     0.  ]\n",
+      " [  0.   -32.98   0.    -0.58   0.    -0.19   0.     0.     0.     0.  ]\n",
+      " [ -0.58   0.    -7.78   0.    -0.3    0.     0.     0.     0.     0.  ]\n",
+      " [  0.    -0.58   0.    -7.78   0.    -0.3    0.     0.     0.     0.  ]\n",
+      " [ -0.19   0.    -0.3    0.    -6.8    0.     0.     0.     0.     0.  ]\n",
+      " [  0.    -0.19   0.    -0.3    0.    -6.8    0.     0.     0.     0.  ]\n",
+      " [  0.     0.     0.     0.     0.     0.    -7.07   0.     0.     0.  ]\n",
+      " [  0.     0.     0.     0.     0.     0.     0.    -7.07   0.     0.  ]\n",
+      " [  0.     0.     0.     0.     0.     0.     0.     0.    -6.5    0.  ]\n",
+      " [  0.     0.     0.     0.     0.     0.     0.     0.     0.    -6.5 ]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "h = forte.spinorbital_oei(ints, rdocc, rdocc)\n",
+    "v = forte.spinorbital_tei(ints, rdocc, rdocc, rdocc, rdocc)\n",
+    "\n",
+    "with np.printoptions(precision=2, suppress=True):\n",
+    "    print(h)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb3fa6a3",
+   "metadata": {},
+   "source": [
+    "## Evaluating the energy expression\n",
+    "\n",
+    "Here we add the three contributions to the energy and check the SCF energy computed with psi4 and the one recomputed here"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "65b3f97c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The SCF energy is -75.98015792193442 [Eh] (psi4)\n",
+      "The SCF energy is -75.98015792193439 [Eh] (spin orbital integrals)\n",
+      "The difference is -2.842170943040401e-14 [Eh]\n"
+     ]
+    }
+   ],
+   "source": [
+    "escf = ints.nuclear_repulsion_energy()\n",
+    "escf += np.einsum('ii->', h)\n",
+    "escf += 0.5 * np.einsum('ijij->', v)\n",
+    "\n",
+    "print(f'The SCF energy is {escf_psi4} [Eh] (psi4)')\n",
+    "print(f'The SCF energy is {escf} [Eh] (spin orbital integrals)')\n",
+    "print(f'The difference is {escf_psi4 - escf} [Eh]')\n",
+    "assert math.isclose(escf, escf_psi4)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/nb_03_wavefunction.rst
+++ b/docs/source/nb_03_wavefunction.rst
@@ -124,42 +124,24 @@ arranged according to Cotton’s book (*Chemical Applications of Group
 Theory*). This ordering is reproduced in the following table and is the
 same as used in Psi4:
 
-+-------+-------+-------+-------+-------+-------+-------+-------+-------+
-| Point | Irrep | Irrep | Irrep | Irrep | Irrep | Irrep | Irrep | Irrep |
-| group | 0     | 1     | 2     | 3     | 4     | 5     | 6     | 7     |
-+=======+=======+=======+=======+=======+=======+=======+=======+=======+
-| :     | :mat  |       |       |       |       |       |       |       |
-| math: | h:`A` |       |       |       |       |       |       |       |
-| `C_1` |       |       |       |       |       |       |       |       |
-+-------+-------+-------+-------+-------+-------+-------+-------+-------+
-| :     | :math | :     |       |       |       |       |       |       |
-| math: | :`A'` | math: |       |       |       |       |       |       |
-| `C_s` |       | `A''` |       |       |       |       |       |       |
-+-------+-------+-------+-------+-------+-------+-------+-------+-------+
-| :     | :ma   | :ma   |       |       |       |       |       |       |
-| math: | th:`A | th:`A |       |       |       |       |       |       |
-| `C_i` | _{g}` | _{u}` |       |       |       |       |       |       |
-+-------+-------+-------+-------+-------+-------+-------+-------+-------+
-| :     | :mat  | :mat  |       |       |       |       |       |       |
-| math: | h:`A` | h:`B` |       |       |       |       |       |       |
-| `C_2` |       |       |       |       |       |       |       |       |
-+-------+-------+-------+-------+-------+-------+-------+-------+-------+
-| :mat  | :ma   | :ma   | :ma   | :ma   |       |       |       |       |
-| h:`C_ | th:`A | th:`B | th:`A | th:`B |       |       |       |       |
-| {2h}` | _{g}` | _{g}` | _{u}` | _{u}` |       |       |       |       |
-+-------+-------+-------+-------+-------+-------+-------+-------+-------+
-| :mat  | :ma   | :ma   | :ma   | :ma   |       |       |       |       |
-| h:`C_ | th:`A | th:`B | th:`A | th:`B |       |       |       |       |
-| {2v}` | _{1}` | _{1}` | _{2}` | _{2}` |       |       |       |       |
-+-------+-------+-------+-------+-------+-------+-------+-------+-------+
-| :     | :mat  | :ma   | :ma   | :ma   |       |       |       |       |
-| math: | h:`A` | th:`B | th:`B | th:`B |       |       |       |       |
-| `D_2` |       | _{1}` | _{2}` | _{3}` |       |       |       |       |
-+-------+-------+-------+-------+-------+-------+-------+-------+-------+
-| :mat  | :ma   | :mat  | :mat  | :mat  | :ma   | :mat  | :mat  | :mat  |
-| h:`D_ | th:`A | h:`B_ | h:`B_ | h:`B_ | th:`A | h:`B_ | h:`B_ | h:`B_ |
-| {2h}` | _{g}` | {1g}` | {2g}` | {3g}` | _{u}` | {1u}` | {2u}` | {3u}` |
-+-------+-------+-------+-------+-------+-------+-------+-------+-------+
+============== ============= ============== ==============
+============== ============= ============== ==============
+==============
+Point group    Irrep 0       Irrep 1        Irrep 2        Irrep 3        Irrep 4       Irrep 5        Irrep 6        Irrep 7
+============== ============= ============== ==============
+============== ============= ============== ==============
+==============
+:math:`C_1`    :math:`A`                                                                                             
+:math:`C_s`    :math:`A'`    :math:`A''`                                                                             
+:math:`C_i`    :math:`A_{g}` :math:`A_{u}`                                                                           
+:math:`C_2`    :math:`A`     :math:`B`                                                                               
+:math:`C_{2h}` :math:`A_{g}` :math:`B_{g}`  :math:`A_{u}`  :math:`B_{u}`                                             
+:math:`C_{2v}` :math:`A_{1}` :math:`B_{1}`  :math:`A_{2}`  :math:`B_{2}`                                             
+:math:`D_2`    :math:`A`     :math:`B_{1}`  :math:`B_{2}`  :math:`B_{3}`                                             
+:math:`D_{2h}` :math:`A_{g}` :math:`B_{1g}` :math:`B_{2g}` :math:`B_{3g}` :math:`A_{u}` :math:`B_{1u}` :math:`B_{2u}` :math:`B_{3u}`
+============== ============= ============== ==============
+============== ============= ============== ==============
+==============
 
 By default, Forte targets a total symmetric state (e.g., :math:`A_1`,
 :math:`A_{g}`, …). To specify a state with a different irreducible
@@ -198,31 +180,18 @@ spaces:
 
 The following table summarizes the properties of these orbital spaces:
 
-+----------------+----------------+----------------+----------------+
-| Space          | Occupation in  | Occupation in  | Description    |
-|                | CAS/GAS        | correlated     |                |
-|                |                | methods        |                |
-+================+================+================+================+
-| `              | 2              | 2              | Frozen doubly  |
-| `FROZEN_DOCC`` |                |                | occupied       |
-|                |                |                | orbitals       |
-+----------------+----------------+----------------+----------------+
-| ``RES          | 2              | 0-2            | Restricted     |
-| TRICTED_DOCC`` |                |                | doubly         |
-|                |                |                | occupied       |
-|                |                |                | orbitals       |
-+----------------+----------------+----------------+----------------+
-| ``GAS1``,      | 0-2            | 0-2            | Generalized    |
-| ``GAS2``, …    |                |                | active spaces  |
-+----------------+----------------+----------------+----------------+
-| ``RES          | 0              | 0-2            | Restricted     |
-| TRICTED_UOCC`` |                |                | unoccupied     |
-|                |                |                | orbitals       |
-+----------------+----------------+----------------+----------------+
-| `              | 0              | 0              | Frozen         |
-| `FROZEN_UOCC`` |                |                | unoccupied     |
-|                |                |                | orbitals       |
-+----------------+----------------+----------------+----------------+
+===================== =====================
+================================ ===================================
+Space                 Occupation in CAS/GAS Occupation in correlated methods Description
+===================== =====================
+================================ ===================================
+``FROZEN_DOCC``       2                     2                                Frozen doubly occupied orbitals
+``RESTRICTED_DOCC``   2                     0-2                              Restricted doubly occupied orbitals
+``GAS1``, ``GAS2``, … 0-2                   0-2                              Generalized active spaces
+``RESTRICTED_UOCC``   0                     0-2                              Restricted unoccupied orbitals
+``FROZEN_UOCC``       0                     0                                Frozen unoccupied orbitals
+===================== =====================
+================================ ===================================
 
 **Note**: Forte makes a distinction between elementary and ``composite``
 orbital spaces. The spaces defined above are all elementary, except for
@@ -251,7 +220,7 @@ Theory*).
 The following is an example of a computation on BeH\ :math:`_2`. This
 system has 6 electrons. We freeze the Be 1s-like orbital, which has
 A\ :math:`_1` symmetry. The 2a\ :math:`_1` orbital is restricted doubly
-occupied and the 3a\ :math:`_1`/1b\ :math:`_2` orbitals belong to the
+occupied and the 3a\ :math:`_1`/1b:math:`_2` orbitals belong to the
 active space. The remaining orbitals belong to the ``RESTRICTED_UOCC``
 set and no virtual orbitals are frozen:
 

--- a/docs/source/nb_07_soints.rst
+++ b/docs/source/nb_07_soints.rst
@@ -1,0 +1,192 @@
+Reading integrals in a spin orbital basis
+=========================================
+
+In this tutorial, you will learn how to read access integrals in a spin
+orbital basis from python. These integrals can be used in pilot
+implementations of quantum chemistry methods. By the end of this
+tutorial you will know how to read the integrals and compute the
+Hartree-Fock energy. For an implementation of MP2 based on the spin
+orbital integrals see the file
+``tests/pytest/helpers/test_spinorbital.py`` in the forte directory.
+
+Forte assumes that the spin orbital basis :math:`\{ \psi_{p} \}` is
+organized as follows :raw-latex:`\begin{equation}
+\underbrace{\phi_{0,\alpha}}_{\psi_0},
+\underbrace{\phi_{0,\beta}}_{\psi_1},
+\underbrace{\phi_{1,\alpha}}_{\psi_2},
+\underbrace{\phi_{1,\beta}}_{\psi_3},
+\ldots
+\end{equation}`
+
+To read the one-electron integrals
+:math:`h_{pq} = \langle \psi_p | \hat{h} | \psi_q \rangle` we use the
+function ``spinorbital_oei``. This function takes as arguments a
+``ForteIntegrals`` object and two lists of integers, ``p`` and ``q``,
+that specify the indices of the bra and ket **spatial orbitals**. For
+example, if we want the integrals over the bra functions
+:math:`\psi_0,\psi_1,\psi_3` and ket functions :math:`\psi_5,\psi_6` we
+can write the following code
+
+.. code:: python
+
+       p = [0,1,3]
+       q = [5,6]
+       h = forte.spinorbital_oei(ints, p, q)
+
+To read the two-electron antisymmetrized integrals in physicist notation
+:math:`\langle pq \| rs \rangle` we use the function
+``spinorbital_tei``, passing four list that corresponds to the range of
+the indices ``p``, ``q``, ``r``, and ``s``.
+
+.. code:: python
+
+       p = [0,1]
+       q = [0,1]
+       r = [2,3]
+       s = [2,3]    
+       v = forte.spinorbital_tei(ints, p, q, r, s)
+
+To compute the SCF energy we evaluate the expression
+
+.. math::
+
+
+   E = V_\mathrm{NN} + \sum_{i}^\mathrm{docc} h_{ii} + \frac{1}{2} \sum_{ij}^\mathrm{docc} \langle ij \| ij \rangle
+
+where :math:`V_\mathrm{NN}` is the nuclear repulsion energy. To evaluate
+this expression we only need the one- and two-electron integral blocks
+that corresponds to the doubly occupied orbitals.
+
+Preparing the orbitals via the ``utils.psi4_scf`` helper function
+-----------------------------------------------------------------
+
+To prepare an integral object it is necessary to first run a HF or
+CASSCF computation.
+
+Forte provides helper functions to run these computations using psi4. By
+default **this function uses conventional integrals**.
+
+.. code:: ipython3
+
+    import math
+    import numpy as np
+    import forte
+    import forte.utils
+    
+    geom = """
+    O
+    H 1 1.0
+    H 1 1.0 2 104.5
+    """
+    
+    escf_psi4, wfn = forte.utils.psi4_scf(geom=geom, basis='6-31G', reference='RHF')
+    
+    # grab the orbital occupation
+    doccpi = wfn.doccpi().to_tuple()
+    soccpi = wfn.soccpi().to_tuple()
+    
+    print(f'The SCF energy is {escf_psi4} [Eh]')
+    print(f'SCF doubly occupied orbitals per irrep: {doccpi}')
+    print(f'SCF singly occupied orbitals per irrep: {soccpi}')
+
+
+.. parsed-literal::
+
+    The SCF energy is -75.98015792193442 [Eh]
+    SCF doubly occupied orbitals per irrep: (3, 0, 1, 1)
+    SCF singly occupied orbitals per irrep: (0, 0, 0, 0)
+
+
+Preparing the integral object
+-----------------------------
+
+To prepare the integrals, we use the helper function
+``utils.prepare_forte_objects``. We pass the psi4 wave function object
+(``wfn``) and specify the number of doubly occupied orbitals using the
+SCF occupation from psi4. Virtual orbitals are automatically determined.
+
+.. code:: ipython3
+
+    mo_spaces={'RESTRICTED_DOCC' : doccpi, 'ACTIVE' : soccpi}
+    forte_objects = forte.utils.prepare_forte_objects(wfn,mo_spaces)
+
+The ``forte_objects`` returned is a dictionary, and we can access the
+``ForteIntegral`` object using the key ``ints``. We store this object in
+the variable ``ints``. We will also use the ``MOSpaceInfo`` object,
+which is stored with the key ``mo_space_info``.
+
+.. code:: ipython3
+
+    ints = forte_objects['ints']
+    mo_space_info = forte_objects['mo_space_info']
+
+Preparing list of doubly occupied orbitals
+------------------------------------------
+
+From the ``MOSpaceInfo`` object we can find the list of doubly occupied
+orbitals
+
+.. code:: ipython3
+
+    rdocc = mo_space_info.corr_absolute_mo('RESTRICTED_DOCC')
+    print(f'List of doubly occupied orbitals: {rdocc}')
+
+
+.. parsed-literal::
+
+    List of doubly occupied orbitals: [0, 1, 2, 7, 9]
+
+
+Preparing the core blocks of the Hamiltonian
+--------------------------------------------
+
+Here we call the functions that return the integrals in the spin orbital
+basis. We store those in two variables, ``h`` and ``v``.
+
+.. code:: ipython3
+
+    h = forte.spinorbital_oei(ints, rdocc, rdocc)
+    v = forte.spinorbital_tei(ints, rdocc, rdocc, rdocc, rdocc)
+    
+    with np.printoptions(precision=2, suppress=True):
+        print(h)
+
+
+.. parsed-literal::
+
+    [[-32.98   0.    -0.58   0.    -0.19   0.     0.     0.     0.     0.  ]
+     [  0.   -32.98   0.    -0.58   0.    -0.19   0.     0.     0.     0.  ]
+     [ -0.58   0.    -7.78   0.    -0.3    0.     0.     0.     0.     0.  ]
+     [  0.    -0.58   0.    -7.78   0.    -0.3    0.     0.     0.     0.  ]
+     [ -0.19   0.    -0.3    0.    -6.8    0.     0.     0.     0.     0.  ]
+     [  0.    -0.19   0.    -0.3    0.    -6.8    0.     0.     0.     0.  ]
+     [  0.     0.     0.     0.     0.     0.    -7.07   0.     0.     0.  ]
+     [  0.     0.     0.     0.     0.     0.     0.    -7.07   0.     0.  ]
+     [  0.     0.     0.     0.     0.     0.     0.     0.    -6.5    0.  ]
+     [  0.     0.     0.     0.     0.     0.     0.     0.     0.    -6.5 ]]
+
+
+Evaluating the energy expression
+--------------------------------
+
+Here we add the three contributions to the energy and check the SCF
+energy computed with psi4 and the one recomputed here
+
+.. code:: ipython3
+
+    escf = ints.nuclear_repulsion_energy()
+    escf += np.einsum('ii->', h)
+    escf += 0.5 * np.einsum('ijij->', v)
+    
+    print(f'The SCF energy is {escf_psi4} [Eh] (psi4)')
+    print(f'The SCF energy is {escf} [Eh] (spin orbital integrals)')
+    print(f'The difference is {escf_psi4 - escf} [Eh]')
+    assert math.isclose(escf, escf_psi4)
+
+
+.. parsed-literal::
+
+    The SCF energy is -75.98015792193442 [Eh] (psi4)
+    The SCF energy is -75.98015792193439 [Eh] (spin orbital integrals)
+    The difference is -2.842170943040401e-14 [Eh]
+

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -10,3 +10,4 @@ Tutorials
    nb_04_multistate
    nb_05_examples
    nb_06_integrals
+   nb_07_soints

--- a/forte/CMakeLists.txt
+++ b/forte/CMakeLists.txt
@@ -132,6 +132,7 @@ helpers/lbfgs/lbfgs.cc
 helpers/lbfgs/lbfgs_param.cc
 helpers/lbfgs/rosenbrock.cc
 helpers/printing.cc
+helpers/spinorbital_helpers.cc
 helpers/string_algorithms.cc
 integrals/active_space_integrals.cc
 integrals/cholesky_integrals.cc

--- a/forte/api/forte_python_module.cc
+++ b/forte/api/forte_python_module.cc
@@ -33,9 +33,11 @@
 #include "psi4/libpsi4util/process.h"
 #include "psi4/libmints/wavefunction.h"
 
+#include "helpers/helpers.h"
 #include "helpers/printing.h"
 #include "helpers/lbfgs/rosenbrock.h"
 #include "helpers/symmetry.h"
+#include "helpers/spinorbital_helpers.h"
 
 #include "base_classes/active_space_solver.h"
 #include "base_classes/orbital_transform.h"
@@ -193,6 +195,52 @@ PYBIND11_MODULE(forte, m) {
     m.def("make_casscf", &make_casscf, "Make a CASSCF object");
     m.def("make_mcscf_two_step", &make_mcscf_two_step, "Make a 2-step MCSCF object");
     m.def("test_lbfgs_rosenbrock", &test_lbfgs_rosenbrock, "Test L-BFGS on Rosenbrock function");
+
+    m.def(
+        "spinorbital_oei",
+        [](const std::shared_ptr<ForteIntegrals> ints, const std::vector<size_t>& p,
+           const std::vector<size_t>& q) { return ambit_to_np(spinorbital_oei(ints, p, q)); },
+        "Compute the one-electron integrals in a spinorbital basis. Spinorbitals follow the "
+        "ordering abab...");
+    m.def(
+        "spinorbital_tei",
+        [](const std::shared_ptr<ForteIntegrals> ints, const std::vector<size_t>& p,
+           const std::vector<size_t>& q, const std::vector<size_t>& r,
+           const std::vector<size_t>& s) { return ambit_to_np(spinorbital_tei(ints, p, q, r, s)); },
+        "Compute the two-electron integrals in a spinorbital basis. Spinorbitals follow the "
+        "ordering abab...");
+    m.def(
+        "spinorbital_fock",
+        [](const std::shared_ptr<ForteIntegrals> ints, const std::vector<size_t>& p,
+           const std::vector<size_t>& q, const std::vector<size_t>& occ) {
+            return ambit_to_np(spinorbital_fock(ints, p, q, occ));
+        },
+        "Compute the fock matrix in a spinorbital basis. Spinorbitals follow the ordering abab...");
+
+    m.def(
+        "spinorbital_rdms",
+        [](RDMs& rdms) {
+            auto sordms = spinorbital_rdms(rdms);
+            std::vector<py::array_t<double>> pysordms;
+            for (const auto& sordm : sordms) {
+                pysordms.push_back(ambit_to_np(sordm));
+            }
+            return pysordms;
+        },
+        "Return the RDMs in a spinorbital basis. Spinorbitals follow the ordering abab...");
+
+    m.def(
+        "spinorbital_cumulants",
+        [](RDMs& rdms) {
+            auto sordms = spinorbital_cumulants(rdms);
+            std::vector<py::array_t<double>> pysordms;
+            for (const auto& sordm : sordms) {
+                pysordms.push_back(ambit_to_np(sordm));
+            }
+            return pysordms;
+        },
+        "Return the cumulants of the RDMs in a spinorbital basis. Spinorbitals follow the ordering "
+        "abab...");
 
     export_ambit(m);
 

--- a/forte/api/integrals_api.cc
+++ b/forte/api/integrals_api.cc
@@ -42,6 +42,12 @@ void export_ForteIntegrals(py::module& m) {
         .def("rotate_orbitals", &ForteIntegrals::rotate_orbitals, "Rotate MOs during contructor")
         .def("nmo", &ForteIntegrals::nmo, "Return the total number of moleuclar orbitals")
         .def("ncmo", &ForteIntegrals::ncmo, "Return the number of correlated orbitals")
+        .def("frozen_core_energy", &ForteIntegrals::frozen_core_energy,
+             "Return the frozen core energy")
+        .def("nuclear_repulsion_energy", &ForteIntegrals::nuclear_repulsion_energy,
+             "Return the nuclear repulsion energy")
+        .def("scalar", &ForteIntegrals::scalar, "Return the scalar component of the Hamiltonian")
+        .def("ncmo", &ForteIntegrals::ncmo, "Return the number of correlated orbitals")
         .def(
             "oei_a_block",
             [](ForteIntegrals& ints, const std::vector<size_t>& p, const std::vector<size_t>& q) {

--- a/forte/base_classes/active_space_method.cc
+++ b/forte/base_classes/active_space_method.cc
@@ -265,7 +265,11 @@ std::unique_ptr<ActiveSpaceMethod> make_active_space_method(
             state, nroot, mo_space_info, as_ints,
             std::make_unique<ProjectorCI>(state, nroot, scf_info, options, mo_space_info, as_ints));
     } else {
-        throw psi::PSIEXCEPTION("make_active_space_method: type = " + type + " was not recognized");
+        std::string msg = "make_active_space_method: type = " + type + " was not recognized";
+        if (type == "") {
+            msg += "\nPlease specify the active space method via the appropriate option.";
+        }
+        throw psi::PSIEXCEPTION(msg);
     }
 
     // read options

--- a/forte/base_classes/rdms.h
+++ b/forte/base_classes/rdms.h
@@ -146,9 +146,9 @@ class RDMs {
 
     // class variables
 
-    size_t max_rdm_level() { return max_rdm_; }
+    size_t max_rdm_level() const { return max_rdm_; }
 
-    bool ms_avg() { return ms_avg_; }
+    bool ms_avg() const { return ms_avg_; }
 
   protected:
     // ==> Class Data <==
@@ -354,6 +354,7 @@ void make_cumulant_L3bbb_in_place(const ambit::Tensor& g1b, const ambit::Tensor&
  */
 double compute_Eref_from_rdms(RDMs& ref, std::shared_ptr<ForteIntegrals> ints,
                               std::shared_ptr<MOSpaceInfo> mo_space_info);
+
 } // namespace forte
 
 #endif // _reference_h_

--- a/forte/helpers/spinorbital_helpers.cc
+++ b/forte/helpers/spinorbital_helpers.cc
@@ -1,0 +1,344 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Forte: an open-source plugin to Psi4 (https://github.com/psi4/psi4)
+ * that implements a variety of quantum chemistry methods for strongly
+ * correlated electrons.
+ *
+ * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ * @END LICENSE
+ */
+
+#include "helpers/helpers.h"
+#include "integrals/integrals.h"
+#include "base_classes/rdms.h"
+#include "ambit/tensor.h"
+
+#include "spinorbital_helpers.h"
+
+namespace forte {
+
+ambit::Tensor spinorbital_oei(const std::shared_ptr<ForteIntegrals> ints,
+                              const std::vector<size_t>& p, const std::vector<size_t>& q) {
+    ambit::Tensor t = ambit::Tensor::build(ambit::CoreTensor, "oei", {2 * p.size(), 2 * q.size()});
+    t.iterate([&](const std::vector<size_t>& i, double& value) {
+        if ((i[0] % 2 == 0) and (i[1] % 2 == 0)) {
+            value = ints->oei_a(p[i[0] / 2], q[i[1] / 2]);
+        }
+        if ((i[0] % 2 == 1) and (i[1] % 2 == 1)) {
+            value = ints->oei_b(p[i[0] / 2], q[i[1] / 2]);
+        }
+    });
+    return t;
+}
+
+ambit::Tensor spinorbital_tei(const std::shared_ptr<ForteIntegrals> ints,
+                              const std::vector<size_t>& p, const std::vector<size_t>& q,
+                              const std::vector<size_t>& r, const std::vector<size_t>& s) {
+    ambit::Tensor t = ambit::Tensor::build(
+        ambit::CoreTensor, "tei", {2 * p.size(), 2 * q.size(), 2 * r.size(), 2 * s.size()});
+
+    auto tei_aa = ints->aptei_aa_block(p, q, r, s);
+    auto tei_ab = ints->aptei_ab_block(p, q, r, s);
+    auto tei_ab2 = ints->aptei_ab_block(p, q, s, r);
+    auto tei_ba = ints->aptei_ab_block(q, p, s, r);
+    auto tei_ba2 = ints->aptei_ab_block(q, p, r, s);
+    auto tei_bb = ints->aptei_bb_block(p, q, r, s);
+
+    // fill in the tensor
+    t.iterate([&](const std::vector<size_t>& i, double& value) {
+        const size_t a = i[0] / 2;
+        const size_t b = i[1] / 2;
+        const size_t c = i[2] / 2;
+        const size_t d = i[3] / 2;
+        const bool sa = i[0] % 2;
+        const bool sb = i[1] % 2;
+        const bool sc = i[2] % 2;
+        const bool sd = i[3] % 2;
+        value = 0.0;
+        if ((sa == sb) and (sb == sc) and (sc == sd)) {
+            if (!sa)
+                value = tei_aa.at({a, b, c, d});
+            else
+                value = tei_bb.at({a, b, c, d});
+        }
+        if ((sa == sc) and (sb == sd) and (sa != sb)) {
+            if (!sa)
+                value = tei_ab.at({a, b, c, d});
+            else
+                value = tei_ba.at({b, a, d, c});
+        }
+        if ((sa == sd) and (sb == sc) and (sa != sb)) {
+            if (!sa)
+                value = -tei_ab2.at({a, b, d, c});
+            else
+                value = -tei_ba2.at({b, a, c, d});
+        }
+    });
+    return t;
+}
+
+ambit::Tensor spinorbital_fock(const std::shared_ptr<ForteIntegrals> ints,
+                               const std::vector<size_t>& p, const std::vector<size_t>& q,
+                               const std::vector<size_t>& docc) {
+    ambit::Tensor t = ambit::Tensor::build(ambit::CoreTensor, "tei", {2 * p.size(), 2 * q.size()});
+
+    auto h = spinorbital_oei(ints, p, q);
+    auto v = spinorbital_tei(ints, p, docc, q, docc);
+    for (size_t i = 0, maxi = 2 * p.size(); i < maxi; i++) {
+        for (size_t j = 0, maxj = 2 * q.size(); j < maxj; j++) {
+            double f = 0.0;
+            for (auto k : docc) {
+                f += v.at({i, 2 * k, j, 2 * k});
+                f += v.at({i, 2 * k + 1, j, 2 * k + 1});
+            }
+            h.at({i, j}) += f;
+        }
+    }
+    return h;
+}
+
+std::vector<ambit::Tensor> spinorbital_rdms(RDMs& rdms) {
+    auto max_rdm_level = rdms.max_rdm_level();
+
+    std::vector<ambit::Tensor> sordms;
+    if (max_rdm_level < 1)
+        return sordms;
+
+    ambit::Tensor g1a = rdms.g1a();
+    ambit::Tensor g1b = rdms.g1b();
+    size_t nso_actv = 2 * g1a.dim(0);
+
+    ambit::Tensor g1 = ambit::Tensor::build(ambit::CoreTensor, "g1", {nso_actv, nso_actv});
+
+    g1a.iterate([&](const std::vector<size_t>& i, double& value) {
+        g1.at({2 * i[0], 2 * i[1]}) = value;
+    });
+    g1b.iterate([&](const std::vector<size_t>& i, double& value) {
+        g1.at({2 * i[0] + 1, 2 * i[1] + 1}) = value;
+    });
+    sordms.push_back(g1);
+
+    if (max_rdm_level < 2)
+        return sordms;
+
+    ambit::Tensor g2aa = rdms.g2aa();
+    ambit::Tensor g2ab = rdms.g2ab();
+    ambit::Tensor g2bb = rdms.g2bb();
+
+    ambit::Tensor g2 =
+        ambit::Tensor::build(ambit::CoreTensor, "g2", {nso_actv, nso_actv, nso_actv, nso_actv});
+
+    g2aa.iterate([&](const std::vector<size_t>& i, double& value) {
+        g2.at({2 * i[0], 2 * i[1], 2 * i[2], 2 * i[3]}) = value;
+    });
+
+    g2bb.iterate([&](const std::vector<size_t>& i, double& value) {
+        g2.at({2 * i[0] + 1, 2 * i[1] + 1, 2 * i[2] + 1, 2 * i[3] + 1}) = value;
+    });
+
+    g2ab.iterate([&](const std::vector<size_t>& i, double& value) {
+        const auto a = 2 * i[0];
+        const auto B = 2 * i[1] + 1;
+        const auto r = 2 * i[2];
+        const auto S = 2 * i[3] + 1;
+        g2.at({a, B, r, S}) = value;
+        g2.at({a, B, S, r}) = -value;
+        g2.at({B, a, r, S}) = -value;
+        g2.at({B, a, S, r}) = value;
+    });
+
+    sordms.push_back(g2);
+
+    if (max_rdm_level < 3)
+        return sordms;
+
+    ambit::Tensor g3aaa = rdms.g3aaa();
+    ambit::Tensor g3aab = rdms.g3aab();
+    ambit::Tensor g3abb = rdms.g3abb();
+    ambit::Tensor g3bbb = rdms.g3bbb();
+
+    ambit::Tensor g3 = ambit::Tensor::build(
+        ambit::CoreTensor, "g3", {nso_actv, nso_actv, nso_actv, nso_actv, nso_actv, nso_actv});
+
+    g3aaa.iterate([&](const std::vector<size_t>& i, double& value) {
+        g3.at({2 * i[0], 2 * i[1], 2 * i[2], 2 * i[3], 2 * i[4], 2 * i[5]}) = value;
+    });
+
+    g3bbb.iterate([&](const std::vector<size_t>& i, double& value) {
+        g3.at({2 * i[0] + 1, 2 * i[1] + 1, 2 * i[2] + 1, 2 * i[3] + 1, 2 * i[4] + 1,
+               2 * i[5] + 1}) = value;
+    });
+
+    g3aab.iterate([&](const std::vector<size_t>& i, double& value) {
+        const auto a = 2 * i[0];
+        const auto b = 2 * i[1];
+        const auto C = 2 * i[2] + 1;
+        const auto r = 2 * i[3];
+        const auto s = 2 * i[4];
+        const auto T = 2 * i[5] + 1;
+        g3.at({a, b, C, r, s, T}) = +value;
+        g3.at({a, C, b, r, s, T}) = -value;
+        g3.at({C, b, a, r, s, T}) = -value;
+        g3.at({a, b, C, r, T, s}) = -value;
+        g3.at({a, C, b, r, T, s}) = +value;
+        g3.at({C, b, a, r, T, s}) = +value;
+        g3.at({a, b, C, T, s, r}) = -value;
+        g3.at({a, C, b, T, s, r}) = +value;
+        g3.at({C, b, a, T, s, r}) = +value;
+    });
+
+    g3abb.iterate([&](const std::vector<size_t>& i, double& value) {
+        const auto a = 2 * i[0];
+        const auto B = 2 * i[1] + 1;
+        const auto C = 2 * i[2] + 1;
+        const auto r = 2 * i[3];
+        const auto S = 2 * i[4] + 1;
+        const auto T = 2 * i[5] + 1;
+        g3.at({a, B, C, r, S, T}) = +value;
+        g3.at({B, a, C, r, S, T}) = -value;
+        g3.at({C, B, a, r, S, T}) = -value;
+        g3.at({a, B, C, S, r, T}) = -value;
+        g3.at({B, a, C, S, r, T}) = +value;
+        g3.at({C, B, a, S, r, T}) = +value;
+        g3.at({a, B, C, T, S, r}) = -value;
+        g3.at({B, a, C, T, S, r}) = +value;
+        g3.at({C, B, a, T, S, r}) = +value;
+    });
+
+    sordms.push_back(g3);
+
+    return sordms;
+}
+
+std::vector<ambit::Tensor> spinorbital_cumulants(RDMs& rdms) {
+    auto max_rdm_level = rdms.max_rdm_level();
+
+    std::vector<ambit::Tensor> sordms;
+    if (max_rdm_level < 1)
+        return sordms;
+
+    ambit::Tensor l1a = rdms.l1a();
+    ambit::Tensor l1b = rdms.l1b();
+    size_t nso_actv = 2 * l1a.dim(0);
+
+    ambit::Tensor l1 = ambit::Tensor::build(ambit::CoreTensor, "l1", {nso_actv, nso_actv});
+
+    l1a.iterate([&](const std::vector<size_t>& i, double& value) {
+        l1.at({2 * i[0], 2 * i[1]}) = value;
+    });
+    l1b.iterate([&](const std::vector<size_t>& i, double& value) {
+        l1.at({2 * i[0] + 1, 2 * i[1] + 1}) = value;
+    });
+    sordms.push_back(l1);
+
+    if (max_rdm_level < 2)
+        return sordms;
+
+    ambit::Tensor l2aa = rdms.L2aa();
+    ambit::Tensor l2ab = rdms.L2ab();
+    ambit::Tensor l2bb = rdms.L2bb();
+
+    ambit::Tensor l2 =
+        ambit::Tensor::build(ambit::CoreTensor, "l2", {nso_actv, nso_actv, nso_actv, nso_actv});
+
+    l2aa.iterate([&](const std::vector<size_t>& i, double& value) {
+        l2.at({2 * i[0], 2 * i[1], 2 * i[2], 2 * i[3]}) = value;
+    });
+
+    l2bb.iterate([&](const std::vector<size_t>& i, double& value) {
+        l2.at({2 * i[0] + 1, 2 * i[1] + 1, 2 * i[2] + 1, 2 * i[3] + 1}) = value;
+    });
+
+    l2ab.iterate([&](const std::vector<size_t>& i, double& value) {
+        const auto a = 2 * i[0];
+        const auto B = 2 * i[1] + 1;
+        const auto r = 2 * i[2];
+        const auto S = 2 * i[3] + 1;
+        l2.at({a, B, r, S}) = value;
+        l2.at({a, B, S, r}) = -value;
+        l2.at({B, a, r, S}) = -value;
+        l2.at({B, a, S, r}) = value;
+    });
+
+    sordms.push_back(l2);
+
+    if (max_rdm_level < 3)
+        return sordms;
+
+    ambit::Tensor l3aaa = rdms.L3aaa();
+    ambit::Tensor l3aab = rdms.L3aab();
+    ambit::Tensor l3abb = rdms.L3abb();
+    ambit::Tensor l3bbb = rdms.L3bbb();
+
+    ambit::Tensor l3 = ambit::Tensor::build(
+        ambit::CoreTensor, "l3", {nso_actv, nso_actv, nso_actv, nso_actv, nso_actv, nso_actv});
+
+    l3aaa.iterate([&](const std::vector<size_t>& i, double& value) {
+        l3.at({2 * i[0], 2 * i[1], 2 * i[2], 2 * i[3], 2 * i[4], 2 * i[5]}) = value;
+    });
+
+    l3bbb.iterate([&](const std::vector<size_t>& i, double& value) {
+        l3.at({2 * i[0] + 1, 2 * i[1] + 1, 2 * i[2] + 1, 2 * i[3] + 1, 2 * i[4] + 1,
+               2 * i[5] + 1}) = value;
+    });
+
+    l3aab.iterate([&](const std::vector<size_t>& i, double& value) {
+        const auto a = 2 * i[0];
+        const auto b = 2 * i[1];
+        const auto C = 2 * i[2] + 1;
+        const auto r = 2 * i[3];
+        const auto s = 2 * i[4];
+        const auto T = 2 * i[5] + 1;
+        l3.at({a, b, C, r, s, T}) = +value;
+        l3.at({a, C, b, r, s, T}) = -value;
+        l3.at({C, b, a, r, s, T}) = -value;
+        l3.at({a, b, C, r, T, s}) = -value;
+        l3.at({a, C, b, r, T, s}) = +value;
+        l3.at({C, b, a, r, T, s}) = +value;
+        l3.at({a, b, C, T, s, r}) = -value;
+        l3.at({a, C, b, T, s, r}) = +value;
+        l3.at({C, b, a, T, s, r}) = +value;
+    });
+
+    l3abb.iterate([&](const std::vector<size_t>& i, double& value) {
+        const auto a = 2 * i[0];
+        const auto B = 2 * i[1] + 1;
+        const auto C = 2 * i[2] + 1;
+        const auto r = 2 * i[3];
+        const auto S = 2 * i[4] + 1;
+        const auto T = 2 * i[5] + 1;
+        l3.at({a, B, C, r, S, T}) = +value;
+        l3.at({B, a, C, r, S, T}) = -value;
+        l3.at({C, B, a, r, S, T}) = -value;
+        l3.at({a, B, C, S, r, T}) = -value;
+        l3.at({B, a, C, S, r, T}) = +value;
+        l3.at({C, B, a, S, r, T}) = +value;
+        l3.at({a, B, C, T, S, r}) = -value;
+        l3.at({B, a, C, T, S, r}) = +value;
+        l3.at({C, B, a, T, S, r}) = +value;
+    });
+
+    sordms.push_back(l3);
+
+    return sordms;
+}
+
+} // namespace forte

--- a/forte/helpers/spinorbital_helpers.cc
+++ b/forte/helpers/spinorbital_helpers.cc
@@ -235,8 +235,8 @@ std::vector<ambit::Tensor> spinorbital_cumulants(RDMs& rdms) {
     if (max_rdm_level < 1)
         return sordms;
 
-    ambit::Tensor l1a = rdms.l1a();
-    ambit::Tensor l1b = rdms.l1b();
+    ambit::Tensor l1a = rdms.L1a();
+    ambit::Tensor l1b = rdms.L1b();
     size_t nso_actv = 2 * l1a.dim(0);
 
     ambit::Tensor l1 = ambit::Tensor::build(ambit::CoreTensor, "l1", {nso_actv, nso_actv});

--- a/forte/helpers/spinorbital_helpers.cc
+++ b/forte/helpers/spinorbital_helpers.cc
@@ -235,8 +235,8 @@ std::vector<ambit::Tensor> spinorbital_cumulants(RDMs& rdms) {
     if (max_rdm_level < 1)
         return sordms;
 
-    ambit::Tensor l1a = rdms.L1a();
-    ambit::Tensor l1b = rdms.L1b();
+    ambit::Tensor l1a = rdms.g1a();
+    ambit::Tensor l1b = rdms.g1b();
     size_t nso_actv = 2 * l1a.dim(0);
 
     ambit::Tensor l1 = ambit::Tensor::build(ambit::CoreTensor, "l1", {nso_actv, nso_actv});

--- a/forte/helpers/spinorbital_helpers.h
+++ b/forte/helpers/spinorbital_helpers.h
@@ -1,0 +1,98 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Forte: an open-source plugin to Psi4 (https://github.com/psi4/psi4)
+ * that implements a variety of quantum chemistry methods for strongly
+ * correlated electrons.
+ *
+ * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ * @END LICENSE
+ */
+
+#ifndef _spinorbital_helpers_h_
+#define _spinorbital_helpers_h_
+
+#include <vector>
+#include "base_classes/rdms.h"
+
+namespace ambit {
+class Tensor;
+} // namespace ambit
+
+namespace forte {
+class ForteIntegrals;
+
+/**
+ * @brief spinorbital_oei A helper function to return the one-electron integrals
+ *        in a spin orbital basis of the form <p|h|q>. This function will compute
+ *        a block of integrals at a time.
+ * @param ints the ForteIntegrals object
+ * @param p a vector of MO indices that define the block of integrals to generate
+ * @param q a vector of MO indices that define the block of integrals to generate
+ * @return a vector of RDMs up to the max rank stored in the RDMs object
+ */
+ambit::Tensor spinorbital_oei(const std::shared_ptr<ForteIntegrals> ints,
+                              const std::vector<size_t>& p, const std::vector<size_t>& q);
+
+/**
+ * @brief spinorbital_tei A helper function to return the two-electron integrals
+ *        in a spin orbital basis of the form <pq||rs>. This function will compute
+ *        a block of integrals at a time.
+ * @param ints the ForteIntegrals object
+ * @param p a vector of MO indices that define the block of integrals to generate
+ * @param q a vector of MO indices that define the block of integrals to generate
+ * @param r a vector of MO indices that define the block of integrals to generate
+ * @param s a vector of MO indices that define the block of integrals to generate*
+ * @return a vector of RDMs up to the max rank stored in the RDMs object
+ */
+ambit::Tensor spinorbital_tei(const std::shared_ptr<ForteIntegrals> ints,
+                              const std::vector<size_t>& p, const std::vector<size_t>& q,
+                              const std::vector<size_t>& r, const std::vector<size_t>& s);
+
+/**
+ * @brief spinorbital_fock A helper function to return the fock matrix elements <p|f|q>
+ *        in a spin orbital basis. This function will compute a block of integrals at a time.
+ * @param ints the ForteIntegrals object
+ * @param p a vector of MO indices that define the block of integrals to generate
+ * @param q a vector of MO indices that define the block of integrals to generate
+ * @param docc a vector of doubly occupied MOs
+ * @return a vector of RDMs up to the max rank stored in the RDMs object
+ */
+ambit::Tensor spinorbital_fock(const std::shared_ptr<ForteIntegrals> ints,
+                               const std::vector<size_t>& p, const std::vector<size_t>& q,
+                               const std::vector<size_t>& docc);
+
+/**
+ * @brief spinorbital_rdms A helper function to return RDMs in a spin orbital basis
+ * @param rdms the RDMs object
+ * @return a vector of RDMs up to the max rank stored in the RDMs object
+ */
+std::vector<ambit::Tensor> spinorbital_rdms(RDMs& rdms);
+
+/**
+ * @brief spinorbital_rdms A helper function to return density cumulants in a spin orbital basis
+ * @param rdms the RDMs object
+ * @return a vector of cumulants up to the max rank stored in the RDMs object
+ */
+std::vector<ambit::Tensor> spinorbital_cumulants(RDMs& rdms);
+
+} // namespace forte
+
+#endif // _spinorbital_helpers_h_

--- a/forte/integrals/integrals.cc
+++ b/forte/integrals/integrals.cc
@@ -547,4 +547,5 @@ void ForteIntegrals::_undefined_function(const std::string& method) const {
     throw std::runtime_error("ForteIntegrals::" + method + " not supported for integral type " +
                              std::to_string(integral_type()));
 }
+
 } // namespace forte

--- a/forte/integrals/integrals.h
+++ b/forte/integrals/integrals.h
@@ -594,7 +594,7 @@ class Psi4Integrals : public ForteIntegrals {
 
   protected:
     void freeze_core_orbitals() override;
-}; // namespace forte
+};
 
 } // namespace forte
 

--- a/forte/proc/scc/scc.py
+++ b/forte/proc/scc/scc.py
@@ -6,9 +6,9 @@ import copy
 
 import numpy as np
 
-import psi4
 import forte
 import forte.utils
+
 
 def run_cc(
     as_ints,
@@ -67,7 +67,6 @@ def run_cc(
     if cc_type == None:
         raise ValueError('No type of CC computation was selected. Specify a valid value for the cc_type option.')
 
-
     nmo = mo_space_info.size("CORRELATED")
     nmopi = mo_space_info.dimension("CORRELATED").to_tuple()
     nfrzdocc = mo_space_info.dimension("FROZEN_DOCC").to_tuple()
@@ -82,15 +81,13 @@ def run_cc(
     print(f"Number of beta electrons per irrep:      {nbelpi}")
 
     # if not provided, define the maximum excitation level to be FCI
-    if max_exc == None:
+    if max_exc is None:
         max_exc = min(naelpi + nbelpi, nmo - naelpi + nbelpi)
 
     antihermitian = (cc_type != 'cc') and (cc_type != 'dcc')
 
     # create the operator pool
-    op, denominators = make_cluster_operator(
-        antihermitian, max_exc, naelpi, mo_space_info, scf_info
-    )
+    op, denominators = make_cluster_operator(antihermitian, max_exc, naelpi, mo_space_info, scf_info)
     selected_op = forte.SparseOperator(antihermitian)
 
     # the list of operators selected from the full list
@@ -109,11 +106,11 @@ def run_cc(
     start = time.time()
 
     hfref = make_hfref(naelpi, nbelpi, nmopi)
-    eref = as_ints.slater_rules(hfref,hfref) + as_ints.nuclear_repulsion_energy()
+    eref = as_ints.slater_rules(hfref, hfref) + as_ints.nuclear_repulsion_energy()
     print(f"Reference determinant: {hfref.str(nmo)}")
     print(f"Energy of the reference determinant: {eref}")
 
-    ref = forte.StateVector({hfref : 1.0})
+    ref = forte.StateVector({hfref: 1.0})
 
     nops_old = 0
 
@@ -130,21 +127,8 @@ def run_cc(
 
         # solve the cc equations and update the amplitudes
         t, e, e_proj, micro_iter, timing = solve_cc_equations(
-            cc_type,
-            t,
-            op,
-            op,
-            op_pool,
-            denominators,
-            ref,
-            as_ints,
-            compute_threshold,
-            e_convergence,
-            r_convergence,
-            on_the_fly,
-            linked,
-            maxk,
-            diis_start
+            cc_type, t, op, op, op_pool, denominators, ref, as_ints, compute_threshold, e_convergence, r_convergence,
+            on_the_fly, linked, maxk, diis_start
         )
 
         print(
@@ -205,9 +189,7 @@ def make_hfref(naelpi, nbelpi, nmopi):
     return hfref
 
 
-def make_cluster_operator(
-    antihermitian, max_exc, naelpi, mo_space_info, psi4_wfn
-):
+def make_cluster_operator(antihermitian, max_exc, naelpi, mo_space_info, psi4_wfn):
     """Make the full cluster operator truncated to a given maximum excitation level (closed-shell case)
 
     Parameters
@@ -263,18 +245,10 @@ def make_cluster_operator(
                 for av in itertools.combinations(vir_orbs, na):
                     for bo in itertools.combinations(occ_orbs, nb):
                         for bv in itertools.combinations(vir_orbs, nb):
-                            aocc_sym = functools.reduce(
-                                lambda x, y: x ^ symmetry[y], ao, 0
-                            )
-                            avir_sym = functools.reduce(
-                                lambda x, y: x ^ symmetry[y], av, 0
-                            )
-                            bocc_sym = functools.reduce(
-                                lambda x, y: x ^ symmetry[y], bo, 0
-                            )
-                            bvir_sym = functools.reduce(
-                                lambda x, y: x ^ symmetry[y], bv, 0
-                            )
+                            aocc_sym = functools.reduce(lambda x, y: x ^ symmetry[y], ao, 0)
+                            avir_sym = functools.reduce(lambda x, y: x ^ symmetry[y], av, 0)
+                            bocc_sym = functools.reduce(lambda x, y: x ^ symmetry[y], bo, 0)
+                            bvir_sym = functools.reduce(lambda x, y: x ^ symmetry[y], bv, 0)
                             # make sure the operators are total symmetric
                             if (aocc_sym ^ avir_sym) ^ (bocc_sym ^ bvir_sym) == 0:
                                 # Create a list of tuples (creation, alpha, orb) where
@@ -293,23 +267,16 @@ def make_cluster_operator(
 
                                 sop.add_term(op, 0.0)
 
-                                e_aocc = functools.reduce(
-                                    lambda x, y: x + ea[y], ao, 0.0
-                                )
-                                e_avir = functools.reduce(
-                                    lambda x, y: x + ea[y], av, 0.0
-                                )
-                                e_bocc = functools.reduce(
-                                    lambda x, y: x + eb[y], bo, 0.0
-                                )
-                                e_bvir = functools.reduce(
-                                    lambda x, y: x + eb[y], bv, 0.0
-                                )
+                                e_aocc = functools.reduce(lambda x, y: x + ea[y], ao, 0.0)
+                                e_avir = functools.reduce(lambda x, y: x + ea[y], av, 0.0)
+                                e_bocc = functools.reduce(lambda x, y: x + eb[y], bo, 0.0)
+                                e_bvir = functools.reduce(lambda x, y: x + eb[y], bv, 0.0)
                                 den = e_bvir + e_avir - e_aocc - e_bocc
                                 denominators.append(den)
 
     print(f"Number of amplitudes: {sop.size()}")
     return (sop, denominators)
+
 
 def solve_cc_equations(
     cc_type,
@@ -364,7 +331,7 @@ def solve_cc_equations(
         Returns the a tuple containign the converged amplitudes, the energy, the projective energy,
         the number of iterations, and timings information
     """
-    diis = DIIS(t,diis_start)
+    diis = DIIS(t, diis_start)
     ham = forte.SparseHamiltonian(as_ints)
     if cc_type == "cc" or cc_type == "ucc":
         exp = forte.SparseExp()
@@ -377,13 +344,13 @@ def solve_cc_equations(
         micro_start = time.time()
         t_old = copy.deepcopy(t)
         residual, e, e_proj = residual_equations(
-            cc_type, t, op, selected_op, ref, ham, exp, compute_threshold,on_the_fly,linked,maxk
+            cc_type, t, op, selected_op, ref, ham, exp, compute_threshold, on_the_fly, linked, maxk
         )
 
         residual_norm = 0.0
         for l in range(selected_op.size()):
             t[l] -= residual[op_pool[l]] / denominators[op_pool[l]]
-            residual_norm += residual[op_pool[l]] ** 2
+            residual_norm += residual[op_pool[l]]**2
 
         residual_norm = math.sqrt(residual_norm)
 
@@ -396,20 +363,15 @@ def solve_cc_equations(
             flush=True,
         )
 
-        if (
-            micro_iter > 2
-            and (abs(delta_e_micro) < e_convergence)
-            and (residual_norm < r_convergence)
-        ):
+        if (micro_iter > 2 and (abs(delta_e_micro) < e_convergence) and (residual_norm < r_convergence)):
             break
 
         old_e_micro = e
 
     return (t, e, e_proj, micro_iter + 1, exp.timings())
 
-def residual_equations(
-    cc_type, t, op, sop, ref, ham, exp, compute_threshold, on_the_fly=False, linked=True,maxk=19
-):
+
+def residual_equations(cc_type, t, op, sop, ref, ham, exp, compute_threshold, on_the_fly=False, linked=True, maxk=19):
     """Evaluate the residual equations
 
     Parameters
@@ -439,24 +401,26 @@ def residual_equations(
     c0 = 0.0
     if on_the_fly:
         if cc_type == "cc" or cc_type == "ucc":
-            wfn = exp.compute(sop, ref,algorithm='onthefly',screen_thresh=compute_threshold,maxk=maxk)
+            wfn = exp.compute(sop, ref, algorithm='onthefly', screen_thresh=compute_threshold, maxk=maxk)
             Hwfn = ham.compute_on_the_fly(wfn, compute_threshold)
-            R = exp.compute(sop, Hwfn, scaling_factor=-1.0,algorithm='onthefly',screen_thresh=compute_threshold,maxk=maxk)
+            R = exp.compute(
+                sop, Hwfn, scaling_factor=-1.0, algorithm='onthefly', screen_thresh=compute_threshold, maxk=maxk
+            )
         elif cc_type == "dcc" or cc_type == "ducc":
-            wfn = exp.compute(sop, ref,algorithm='onthefly',screen_thresh=compute_threshold)
+            wfn = exp.compute(sop, ref, algorithm='onthefly', screen_thresh=compute_threshold)
             Hwfn = ham.compute_on_the_fly(wfn, compute_threshold)
-            R = exp.compute(sop, Hwfn, inverse=True,algorithm='onthefly',screen_thresh=compute_threshold)
+            R = exp.compute(sop, Hwfn, inverse=True, algorithm='onthefly', screen_thresh=compute_threshold)
         else:
             raise ValueError("Incorrect value for cc_type")
     else:
         if cc_type == "cc" or cc_type == "ucc":
-            wfn = exp.compute(sop, ref,screen_thresh=compute_threshold,maxk=maxk)
+            wfn = exp.compute(sop, ref, screen_thresh=compute_threshold, maxk=maxk)
             Hwfn = ham.compute(wfn, compute_threshold)
-            R = exp.compute(sop, Hwfn, scaling_factor=-1.0,screen_thresh=compute_threshold,maxk=maxk)
+            R = exp.compute(sop, Hwfn, scaling_factor=-1.0, screen_thresh=compute_threshold, maxk=maxk)
         elif cc_type == "dcc" or cc_type == "ducc":
-            wfn = exp.compute(sop, ref,screen_thresh=compute_threshold)
+            wfn = exp.compute(sop, ref, screen_thresh=compute_threshold)
             Hwfn = ham.compute(wfn, compute_threshold)
-            R = exp.compute(sop, Hwfn, inverse=True,screen_thresh=compute_threshold)
+            R = exp.compute(sop, Hwfn, inverse=True, screen_thresh=compute_threshold)
         else:
             raise ValueError("Incorrect value for cc_type")
 
@@ -469,7 +433,7 @@ def residual_equations(
         # compute Eavg = <Psi|H|Psi> = <ref|U^+ H U|ref>
         for d, c in ref.items():
             energy += c * R[d]
-        # compute Eproj = <ref|H|Psi> / <ref|Psi> = <ref|H U|ref> / <ref|U|ref> 
+        # compute Eproj = <ref|H|Psi> / <ref|Psi> = <ref|H U|ref> / <ref|U|ref>
         for d, c in ref.items():
             energy_proj += c * Hwfn[d] / c0
         # compute R = <exc|U^+ H U|ref>
@@ -486,10 +450,11 @@ def residual_equations(
             energy_proj += c * Hwfn[d] / c0
         # compute R = <exc|H U|ref> - E_proj <exc|U|ref>
         for d, c in wfn.items():
-            Hwfn[d] -= c * energy_proj  
+            Hwfn[d] -= c * energy_proj
         residual = forte.get_projection(op, ref, Hwfn)
 
     return (residual, energy, energy_proj)
+
 
 class DIIS:
     """A class that implements DIIS for CC theory 
@@ -498,7 +463,7 @@ class DIIS:
     ----------
     diis_start : int
         Start the iterations when the DIIS dimension is greather than this parameter (default = 3)
-    """  
+    """
     def __init__(self, t, diis_start=3):
         self.t_diis = [t]
         self.e_diis = []

--- a/forte/utils/__init__.py
+++ b/forte/utils/__init__.py
@@ -1,3 +1,3 @@
 # utils/__init__.py
 
-from .helpers import psi4_scf, psi4_cubeprop, prepare_forte_objects
+from .helpers import psi4_scf, psi4_casscf, psi4_cubeprop, prepare_forte_objects, prepare_ints_rdms

--- a/forte/utils/helpers.py
+++ b/forte/utils/helpers.py
@@ -2,8 +2,7 @@ import psi4
 import forte
 
 
-def psi4_scf(geom, basis, reference, functional='hf',
-             options={}) -> (float, psi4.core.Wavefunction):
+def psi4_scf(geom, basis, reference, functional='hf', options={}) -> (float, psi4.core.Wavefunction):
     """Run a psi4 scf computation and return the energy and the Wavefunction object
 
     Parameters
@@ -26,11 +25,7 @@ def psi4_scf(geom, basis, reference, functional='hf',
     mol = psi4.geometry(geom)
 
     # add basis/reference/scf_type to options passed by the user
-    default_options = {
-        'SCF_TYPE': 'pk',
-        'E_CONVERGENCE': 1.0e-10,
-        'D_CONVERGENCE': 1.0e-6
-    }
+    default_options = {'SCF_TYPE': 'pk', 'E_CONVERGENCE': 1.0e-11, 'D_CONVERGENCE': 1.0e-6}
 
     # capitalize the options
     options = {k.upper(): v for k, v in options.items()}
@@ -49,19 +44,95 @@ def psi4_scf(geom, basis, reference, functional='hf',
     psi4.core.set_output_file('output.dat', True)
 
     # run scf and return the energy and a wavefunction object (will work only if pass return_wfn=True)
-    E_scf, wfn = psi4.energy(functional, return_wfn=True)
-
+    E_scf, wfn = psi4.energy(functional, molecule=mol, return_wfn=True)
+    #     psi4.core.clean()
     return (E_scf, wfn)
 
 
-def psi4_cubeprop(wfn,
-                  path='.',
-                  orbs=[],
-                  nocc=0,
-                  nvir=0,
-                  density=False,
-                  frontier_orbitals=False,
-                  load=False):
+def psi4_casscf(geom, basis, reference, restricted_docc, active, options={}) -> (float, psi4.core.Wavefunction):
+    """Run a psi4 casscf computation and return the energy and the Wavefunction object
+
+    Parameters
+    ----------
+    geom : str
+        The molecular geometry (in xyz or zmat)
+    basis : str
+        The computational basis set
+    reference : str
+        The type of reference (rhf, uhf, rohf)
+
+    Returns
+    -------
+    tuple(double, psi4::Wavefunction)
+        a tuple containing the energy and the Wavefunction object
+    """
+    # build the molecule object
+    mol = psi4.geometry(geom)
+
+    # add basis/reference/scf_type to options passed by the user
+    default_options = {'SCF_TYPE': 'pk', 'E_CONVERGENCE': 1.0e-10, 'D_CONVERGENCE': 1.0e-6}
+
+    # capitalize the options
+    options = {k.upper(): v for k, v in options.items()}
+    default_options = {k.upper(): v for k, v in default_options.items()}
+
+    # merge the two dictionaries. The user-provided options will overwrite the default ones
+    merged_options = {**default_options, **options}
+
+    # add the mandatory arguments
+    merged_options['BASIS'] = basis
+    merged_options['REFERENCE'] = reference
+    merged_options['RESTRICTED_DOCC'] = restricted_docc
+    merged_options['ACTIVE'] = active
+    merged_options['MCSCF_MAXITER'] = 100
+    merged_options['MCSCF_E_CONVERGENCE'] = 1.0e-10
+    merged_options['MCSCF_R_CONVERGENCE'] = 1.0e-6
+    merged_options['MCSCF_DIIS_START'] = 20
+
+    psi4.set_options(merged_options)
+
+    # pipe output to the file output.dat
+    psi4.core.set_output_file('output.dat', True)
+
+    # run scf and return the energy and a wavefunction object (will work only if pass return_wfn=True)
+    E_scf, wfn = psi4.energy('casscf', molecule=mol, return_wfn=True)
+    #     psi4.core.clean()
+    return (E_scf, wfn)
+
+
+def psi4_casscf(geom, basis, mo_spaces):
+    """
+    Run a Psi4 SCF.
+    :param geom: a string for molecular geometry
+    :param basis: a string for basis set
+    :param reference: a string for the type of reference
+    :return: a tuple of (scf energy, psi4 Wavefunction)
+    """
+    psi4.core.clean()
+    mol = psi4.geometry(geom)
+
+    psi4.set_options(
+        {
+            'basis': basis,
+            'scf_type': 'pk',
+            'e_convergence': 1e-13,
+            'd_convergence': 1e-6,
+            'restricted_docc': mo_spaces['RESTRICTED_DOCC'],
+            'active': mo_spaces['ACTIVE'],
+            'mcscf_maxiter': 100,
+            'mcscf_e_convergence': 1.0e-11,
+            'mcscf_r_convergence': 1.0e-6,
+            'mcscf_diis_start': 20
+        }
+    )
+    psi4.core.set_output_file('output.dat', False)
+
+    Escf, wfn = psi4.energy('casscf', return_wfn=True)
+    psi4.core.clean()
+    return Escf, wfn
+
+
+def psi4_cubeprop(wfn, path='.', orbs=[], nocc=0, nvir=0, density=False, frontier_orbitals=False, load=False):
     """
     Run a psi4 cubeprop computation to generate cube files from a given Wavefunction object
     By default this function plots from the HOMO -2 to the LUMO + 2
@@ -95,9 +166,7 @@ def psi4_cubeprop(wfn,
             min_orb = max(1, na + 1 - nocc)
             max_orb = min(nmo, na + nvir)
             orbs = [k for k in range(min_orb, max_orb + 1)]
-        print(
-            f'Preparing cube files for orbitals: {", ".join([str(orb) for orb in orbs])}'
-        )
+        print(f'Preparing cube files for orbitals: {", ".join([str(orb) for orb in orbs])}')
 
     if density:
         cubeprop_tasks.append('DENSITY')
@@ -105,17 +174,15 @@ def psi4_cubeprop(wfn,
     if not os.path.exists(path):
         os.makedirs(path)
 
-    psi4.set_options({
-        'CUBEPROP_TASKS': cubeprop_tasks,
-        'CUBEPROP_ORBITALS': orbs,
-        'CUBEPROP_FILEPATH': path
-    })
+    psi4.set_options({'CUBEPROP_TASKS': cubeprop_tasks, 'CUBEPROP_ORBITALS': orbs, 'CUBEPROP_FILEPATH': path})
     psi4.cubeprop(wfn)
     if load:
         return load_cubes(path)
 
 
-def prepare_forte_objects(wfn,mo_spaces = None, active_space = 'ACTIVE',core_spaces = ['RESTRICTED_DOCC'],localize = False,localize_spaces = []):
+def prepare_forte_objects(
+    wfn, mo_spaces=None, active_space='ACTIVE', core_spaces=['RESTRICTED_DOCC'], localize=False, localize_spaces=[]
+):
     """Take a psi4 wavefunction object and prepare the ForteIntegrals, SCFInfo, and MOSpaceInfo objects
 
     Parameters
@@ -145,29 +212,33 @@ def prepare_forte_objects(wfn,mo_spaces = None, active_space = 'ACTIVE',core_spa
 
     if ('DF' in options.get_str('INT_TYPE')):
         aux_basis = psi4.core.BasisSet.build(
-            wfn.molecule(), 'DF_BASIS_MP2',
-            psi4.core.get_global_option('DF_BASIS_MP2'), 'RIFIT',
-            psi4.core.get_global_option('BASIS'))
+            wfn.molecule(), 'DF_BASIS_MP2', psi4.core.get_global_option('DF_BASIS_MP2'), 'RIFIT',
+            psi4.core.get_global_option('BASIS')
+        )
         wfn.set_basisset('DF_BASIS_MP2', aux_basis)
 
     if (options.get_str('MINAO_BASIS')):
-        minao_basis = psi4.core.BasisSet.build(
-            wfn.molecule(), 'MINAO_BASIS', psi4_options.get_str('MINAO_BASIS'))
+        minao_basis = psi4.core.BasisSet.build(wfn.molecule(), 'MINAO_BASIS', psi4_options.get_str('MINAO_BASIS'))
         wfn.set_basisset('MINAO_BASIS', minao_basis)
 
     # Prepare base objects
     scf_info = forte.SCFInfo(wfn)
 
+    # Grab the number of MOs per irrep
     nmopi = wfn.nmopi()
+
+    # Grab the point group symbol (e.g. "C2V")
     point_group = wfn.molecule().point_group().symbol()
 
-    if mo_spaces == None:
+    # create a MOSpaceInfo object
+    if mo_spaces is None:
         mo_space_info = forte.make_mo_space_info(nmopi, point_group, options)
     else:
-        mo_space_info = forte.make_mo_space_info_from_map(nmopi,point_group,mo_spaces,[])
+        mo_space_info = forte.make_mo_space_info_from_map(nmopi, point_group, mo_spaces, [])
 
     state_weights_map = forte.make_state_weights_map(options, mo_space_info)
 
+    # make a ForteIntegral object
     ints = forte.make_ints_from_psi4(wfn, options, mo_space_info)
 
     if localize:
@@ -175,11 +246,50 @@ def prepare_forte_objects(wfn,mo_spaces = None, active_space = 'ACTIVE',core_spa
         localizer.set_orbital_space(localize_spaces)
         localizer.compute_transformation()
         Ua = localizer.get_Ua()
-        ints.rotate_orbitals(Ua,Ua)
+        ints.rotate_orbitals(Ua, Ua)
 
     # the space that defines the active orbitals. We select only the 'ACTIVE' part
     # the space(s) with non-active doubly occupied orbitals
 
+    # create active space integrals
     as_ints = forte.make_active_space_ints(mo_space_info, ints, active_space, core_spaces)
 
     return (ints, as_ints, scf_info, mo_space_info, state_weights_map)
+
+
+def prepare_ints_rdms(wfn, mo_spaces, rdm_level=3):
+    """
+    Preparation step for DSRG: compute a CAS and its RDMs.
+    :param wfn: reference wave function from psi4
+    :param mo_spaces: a dictionary {mo_space: occupation}, e.g., {'ACTIVE': [0,0,0,0]}
+    :param rdm_level: max RDM to be computed
+    :return: a tuple of (reference energy, MOSpaceInfo, ForteIntegrals, RDMs)
+    """
+
+    (ints, as_ints, scf_info, mo_space_info, state_weights_map) = prepare_forte_objects(wfn, mo_spaces)
+
+    # build a map {StateInfo: a list of weights} for multi-state computations
+    state_weights_map = forte.make_state_weights_map(forte.forte_options, mo_space_info)
+
+    # converts {StateInfo: weights} to {StateInfo: nroots}
+    state_map = forte.to_state_nroots_map(state_weights_map)
+
+    # create an active space solver object and compute the energy
+    as_solver_type = 'FCI'
+    as_solver = forte.make_active_space_solver(
+        as_solver_type, state_map, scf_info, mo_space_info, as_ints, forte.forte_options
+    )
+
+    state_energies_list = as_solver.compute_energy()  # a map {StateInfo: a list of energies}
+
+    # compute averaged energy --- reference energy for DSRG
+    Eref = forte.compute_average_state_energy(state_energies_list, state_weights_map)
+
+    # compute RDMs
+    rdms = as_solver.compute_average_rdms(state_weights_map, rdm_level)
+
+    # semicanonicalize orbitals
+    semi = forte.SemiCanonical(mo_space_info, ints, forte.forte_options)
+    semi.semicanonicalize(rdms, rdm_level)
+
+    return Eref, mo_space_info, ints, rdms

--- a/forte/utils/helpers.py
+++ b/forte/utils/helpers.py
@@ -206,8 +206,8 @@ def prepare_forte_objects(
         A list of spaces to localize (default: [])
     Returns
     -------
-    tuple(ForteIntegrals, ActiveSpaceIntegrals, SCFInfo, MOSpaceInfo, map(StateInfo : list)
-        a tuple containing the ForteIntegrals, SCFInfo, and MOSpaceInfo objects and a map of states and weights
+    dict(ForteIntegrals, ActiveSpaceIntegrals, SCFInfo, MOSpaceInfo, map(StateInfo : list))
+        a dictionary containing the ForteIntegrals, SCFInfo, and MOSpaceInfo objects and a map of states and weights
     """
     # fill in the options object
     options = forte.forte_options
@@ -256,7 +256,13 @@ def prepare_forte_objects(
     # create active space integrals
     as_ints = forte.make_active_space_ints(mo_space_info, ints, active_space, core_spaces)
 
-    return (ints, as_ints, scf_info, mo_space_info, state_weights_map)
+    return {
+        'ints': ints,
+        'as_ints': as_ints,
+        'scf_info': scf_info,
+        'mo_space_info': mo_space_info,
+        'state_weights_map': state_weights_map
+    }
 
 
 def prepare_ints_rdms(wfn, mo_spaces, rdm_level=3):

--- a/forte/utils/helpers.py
+++ b/forte/utils/helpers.py
@@ -21,11 +21,15 @@ def psi4_scf(geom, basis, reference, functional='hf', options={}) -> (float, psi
     tuple(double, psi4::Wavefunction)
         a tuple containing the energy and the Wavefunction object
     """
+
+    # clean psi4
+    psi4.core.clean()
+
     # build the molecule object
     mol = psi4.geometry(geom)
 
     # add basis/reference/scf_type to options passed by the user
-    default_options = {'SCF_TYPE': 'pk', 'E_CONVERGENCE': 1.0e-11, 'D_CONVERGENCE': 1.0e-6}
+    default_options = {'SCF_TYPE': 'PK', 'E_CONVERGENCE': 1.0e-11, 'D_CONVERGENCE': 1.0e-6}
 
     # capitalize the options
     options = {k.upper(): v for k, v in options.items()}
@@ -45,7 +49,7 @@ def psi4_scf(geom, basis, reference, functional='hf', options={}) -> (float, psi
 
     # run scf and return the energy and a wavefunction object (will work only if pass return_wfn=True)
     E_scf, wfn = psi4.energy(functional, molecule=mol, return_wfn=True)
-    #     psi4.core.clean()
+
     return (E_scf, wfn)
 
 
@@ -94,9 +98,10 @@ def psi4_casscf(geom, basis, reference, restricted_docc, active, options={}) -> 
     # pipe output to the file output.dat
     psi4.core.set_output_file('output.dat', True)
 
+    # psi4.core.clean()
+
     # run scf and return the energy and a wavefunction object (will work only if pass return_wfn=True)
     E_scf, wfn = psi4.energy('casscf', molecule=mol, return_wfn=True)
-    #     psi4.core.clean()
     return (E_scf, wfn)
 
 
@@ -205,10 +210,7 @@ def prepare_forte_objects(
         a tuple containing the ForteIntegrals, SCFInfo, and MOSpaceInfo objects and a map of states and weights
     """
     # fill in the options object
-    psi4_options = psi4.core.get_options()
-    psi4_options.set_current_module('FORTE')
     options = forte.forte_options
-    options.get_options_from_psi4(psi4_options)
 
     if ('DF' in options.get_str('INT_TYPE')):
         aux_basis = psi4.core.BasisSet.build(
@@ -218,7 +220,7 @@ def prepare_forte_objects(
         wfn.set_basisset('DF_BASIS_MP2', aux_basis)
 
     if (options.get_str('MINAO_BASIS')):
-        minao_basis = psi4.core.BasisSet.build(wfn.molecule(), 'MINAO_BASIS', psi4_options.get_str('MINAO_BASIS'))
+        minao_basis = psi4.core.BasisSet.build(wfn.molecule(), 'MINAO_BASIS', options.get_str('MINAO_BASIS'))
         wfn.set_basisset('MINAO_BASIS', minao_basis)
 
     # Prepare base objects

--- a/tests/pytest/determinant/test_dets.py
+++ b/tests/pytest/determinant/test_dets.py
@@ -1,22 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import math
 import forte
 import pytest
 
 
 def det(s):
     return forte.det(s)
-    # for k, c in enumerate(s):
-    #     if c == '+':
-    #         d.create_alfa_bit(k)
-    #     elif c == '-':
-    #         d.create_beta_bit(k)
-    #     elif c == '2':
-    #         d.create_alfa_bit(k)
-    #         d.create_beta_bit(k)
-    # return d
 
 
 def test_det_constructors():

--- a/tests/pytest/helpers/test_spinorbital.py
+++ b/tests/pytest/helpers/test_spinorbital.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import math
+import forte
+import pytest
+
+
+def test_spinorbital_mp2():
+    import forte
+    import forte.utils
+    from math import isclose
+    import numpy as np
+
+    geom = """0 1
+    H
+    F 1 1.0
+    symmetry c1
+    """
+
+    basis = '6-31g'
+    Escf, wfn = forte.utils.psi4_scf(geom, basis, 'rhf')
+    (ints, as_ints, scf_info, mo_space_info,
+     state_weights_map) = forte.utils.prepare_forte_objects(wfn, mo_spaces={
+         'RESTRICTED_DOCC': [5],
+         'ACTIVE': [0]
+     })
+    core = mo_space_info.corr_absolute_mo('RESTRICTED_DOCC')
+    virt = mo_space_info.corr_absolute_mo('RESTRICTED_UOCC')
+
+    H = {
+        'cc': forte.spinorbital_oei(ints, core, core),
+        'cccc': forte.spinorbital_tei(ints, core, core, core, core),
+        'ccvv': forte.spinorbital_tei(ints, core, core, virt, virt)
+    }
+
+    Eref_test = ints.nuclear_repulsion_energy()
+    Eref_test += np.einsum('mm->', H['cc'])
+    Eref_test += 0.5 * np.einsum('mnmn->', H['cccc'])
+    assert math.isclose(Eref_test, -99.97763667846159)
+
+    Fc = forte.spinorbital_fock(ints, core, core, core).diagonal()
+    Fv = forte.spinorbital_fock(ints, virt, virt, core).diagonal()
+    ncoreso = 2 * len(core)
+    nvirtso = 2 * len(virt)
+    d = np.zeros((ncoreso, ncoreso, nvirtso, nvirtso))
+    for i in range(ncoreso):
+        for j in range(ncoreso):
+            for a in range(nvirtso):
+                for b in range(nvirtso):
+                    d[i][j][a][b] = 1. / (Fc[i] + Fc[j] - Fv[a] - Fv[b])
+    T = {'ccvv': np.einsum("ijab,ijab->ijab", d, H['ccvv'])}
+    E = 0.25 * np.einsum("ijab,ijab->", T['ccvv'], H['ccvv'])
+    assert math.isclose(E, -0.13305567213152, rel_tol=1e-08)
+
+
+if __name__ == "__main__":
+    test_spinorbital_mp2()

--- a/tests/pytest/helpers/test_spinorbital.py
+++ b/tests/pytest/helpers/test_spinorbital.py
@@ -2,8 +2,9 @@
 # -*- coding: utf-8 -*-
 
 import math
-import forte
 import pytest
+import psi4
+import forte
 
 
 def test_spinorbital_mp2():
@@ -52,6 +53,8 @@ def test_spinorbital_mp2():
     T = {'ccvv': np.einsum("ijab,ijab->ijab", d, H['ccvv'])}
     E = 0.25 * np.einsum("ijab,ijab->", T['ccvv'], H['ccvv'])
     assert math.isclose(E, -0.13305567213152, abs_tol=1e-09)
+
+    psi4.core.clean()
 
 
 if __name__ == "__main__":

--- a/tests/pytest/helpers/test_spinorbital.py
+++ b/tests/pytest/helpers/test_spinorbital.py
@@ -51,7 +51,7 @@ def test_spinorbital_mp2():
                     d[i][j][a][b] = 1. / (Fc[i] + Fc[j] - Fv[a] - Fv[b])
     T = {'ccvv': np.einsum("ijab,ijab->ijab", d, H['ccvv'])}
     E = 0.25 * np.einsum("ijab,ijab->", T['ccvv'], H['ccvv'])
-    assert math.isclose(E, -0.13305567213152, rel_tol=1e-08)
+    assert math.isclose(E, -0.13305567213152, abs_tol=1e-09)
 
 
 if __name__ == "__main__":

--- a/tests/pytest/helpers/test_spinorbital.py
+++ b/tests/pytest/helpers/test_spinorbital.py
@@ -21,14 +21,13 @@ def test_spinorbital_mp2():
 
     basis = '6-31g'
     Escf, wfn = forte.utils.psi4_scf(geom, basis, 'rhf')
-    (ints, as_ints, scf_info, mo_space_info,
-     state_weights_map) = forte.utils.prepare_forte_objects(wfn, mo_spaces={
-         'RESTRICTED_DOCC': [5],
-         'ACTIVE': [0]
-     })
+    forte_objects = forte.utils.prepare_forte_objects(wfn, mo_spaces={'RESTRICTED_DOCC': [5], 'ACTIVE': [0]})
+
+    mo_space_info = forte_objects['mo_space_info']
     core = mo_space_info.corr_absolute_mo('RESTRICTED_DOCC')
     virt = mo_space_info.corr_absolute_mo('RESTRICTED_UOCC')
 
+    ints = forte_objects['ints']
     H = {
         'cc': forte.spinorbital_oei(ints, core, core),
         'cccc': forte.spinorbital_tei(ints, core, core, core, core),

--- a/tests/pytest/sparse_ci/srcc/test_uccsd.py
+++ b/tests/pytest/sparse_ci/srcc/test_uccsd.py
@@ -19,7 +19,7 @@ def test_uccsd():
 
     scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='DZ', reference='RHF')
     forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={})
-    calc_data = scc.run_cc(forte_objs[1], forte_objs[2], forte_objs[3], cc_type='cc', max_exc=2, e_convergence=1.0e-11)
+    calc_data = scc.run_cc(forte_objs[1], forte_objs[2], forte_objs[3], cc_type='ucc', max_exc=2, e_convergence=1.0e-11)
 
     psi4.core.clean()
 

--- a/tutorials/Tutorial_01.01_forte_api.ipynb
+++ b/tutorials/Tutorial_01.01_forte_api.ipynb
@@ -313,7 +313,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -327,7 +327,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/tutorials/Tutorial_01.03_forte_sparse.ipynb
+++ b/tutorials/Tutorial_01.03_forte_sparse.ipynb
@@ -801,7 +801,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -815,7 +815,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/tutorials/Tutorial_01.04_forte_cc.ipynb
+++ b/tutorials/Tutorial_01.04_forte_cc.ipynb
@@ -576,7 +576,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -590,7 +590,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/tutorials/Tutorial_02.02_mo_localization.ipynb
+++ b/tutorials/Tutorial_02.02_mo_localization.ipynb
@@ -177,7 +177,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -191,7 +191,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/tutorials/Tutorial_03.00_DSRG-PT2.ipynb
+++ b/tutorials/Tutorial_03.00_DSRG-PT2.ipynb
@@ -126,18 +126,24 @@
     "    :return: a tuple of (reference energy, MOSpaceInfo, ForteIntegrals, RDMs)\n",
     "    \"\"\"\n",
     "    \n",
-    "    forte.startup()\n",
+    "#     forte.startup()\n",
     "    \n",
     "    # pass Psi4 options to Forte\n",
     "    options = psi4.core.get_options()\n",
     "    options.set_current_module('FORTE')\n",
     "    forte_options.get_options_from_psi4(options)\n",
     "    \n",
+    "    # Grab the number of MOs per irrep\n",
+    "    nmopi = ref_wfn.nmopi()\n",
+    "    \n",
+    "    # Grab the point group symbol (e.g. \"C2V\")\n",
+    "    point_group = ref_wfn.molecule().point_group().symbol()\n",
+    "    \n",
     "    # create a MOSpaceInfo object\n",
-    "    mo_space_info = forte.make_mo_space_info_from_map(wfn, mo_spaces, [])\n",
+    "    mo_space_info = forte.make_mo_space_info_from_map(nmopi, point_group,mo_spaces, [])\n",
     "    \n",
     "    # make a ForteIntegral object\n",
-    "    ints = forte.make_forte_integrals(ref_wfn, options, mo_space_info)\n",
+    "    ints = forte.make_ints_from_psi4(ref_wfn, forte_options, mo_space_info)\n",
     "\n",
     "    # create active space integrals for CASCI\n",
     "    as_ints = forte.make_active_space_ints(mo_space_info, ints, \"ACTIVE\", [\"RESTRICTED_DOCC\"]);\n",
@@ -146,10 +152,10 @@
     "    scf_info = forte.SCFInfo(ref_wfn)\n",
     "    \n",
     "    # StateInfo: state irrep, multiplicity, nalpha electron, etc.\n",
-    "    state = forte.make_state_info_from_psi_wfn(ref_wfn)\n",
+    "    state = forte.make_state_info_from_psi(forte_options)\n",
     "    \n",
     "    # build a map {StateInfo: a list of weights} for multi-state computations\n",
-    "    state_weights_map = forte.make_state_weights_map(forte_options, ref_wfn)\n",
+    "    state_weights_map = forte.make_state_weights_map(forte_options, mo_space_info)\n",
     "    print(state_weights_map)\n",
     "    \n",
     "    # converts {StateInfo: weights} to {StateInfo: nroots}\n",
@@ -575,13 +581,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from math import isclose\n",
+    "\n",
+    "# reference value (s = 1.0)\n",
+    "Ept2_corr_ref = -0.148255452641\n",
+    "\n",
     "# compute DSRG-PT2 energy\n",
     "Ept2_corr = contraction(rVaa, rTaa, 0.25) + contraction(rVbb, rTbb, 0.25) \\\n",
     "          + contraction(rVab, rTab, 1.0)\n",
     "Ept2 = Eref + Ept2_corr\n",
     "print(f\"DSRG-PT2 correlation energy:     {Ept2_corr:18.12f}\")\n",
     "print(f\"DSRG-PT2 total energy tutorial:  {Ept2:18.12f}\")\n",
-    "print(f\"MP2 total energy from Psi4:      {Emp2_psi4:18.12f}\")"
+    "print(f\"MP2 total energy from Psi4:      {Emp2_psi4:18.12f}\")\n",
+    "\n",
+    "# test against the reference value\n",
+    "assert isclose(Ept2_corr, Ept2_corr_ref, rel_tol=1e-9, abs_tol=0.0)"
    ]
   },
   {
@@ -652,7 +666,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -666,7 +680,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description
This PR adds code to export 1- & 2-electron integrals, Fock matrix, RDMs, and cumulants to the python side as numpy arrays. This code can be used for prototyping new methods.

## User Notes
- [x] Added `spinorbital_x` functions in a new file under the `forte/helpers` folder
- [x] Fixed some minor issues.

## Checklist
- [x] Added/updated tests of new features and included a reference `output.ref` file
- [x] Removed comments in code and input files
- [x] Documented source code
- [x] Checked for redundant headers
- [x] Checked for consistency in the formatting of the output file
- [ ] Documented new features in the manual
- [ ] Ready to go!
