### PR TITLE
Update copyright to 2022 and change name of c++ module to _forte

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,38 +1,22 @@
-# CMakeLists files in this project can
-# refer to the root source directory of the project as ${HELLO_SOURCE_DIR} and
-# to the root binary directory of the project as ${HELLO_BINARY_DIR}.
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
-# project(forte
-#         VERSION 0.1
-#         LANGUAGES CXX C)
-# set(forte_AUTHORS      "Francesco A. Evangelista and Group")
-# set(forte_DESCRIPTION  "Quantum Chemistry Methods for Strongly Correlated Electrons plugin to Psi4")
-# set(forte_URL          "https://github.com/evangelistalab/forte")
-# set(forte_LICENSE      "GPL-3.0+")
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-# set(TargetOpenMP_FIND_COMPONENTS "CXX")
+# set(CMAKE_CXX_STANDARD 17)
+# set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# set(CMAKE_CXX_EXTENSIONS OFF)
+# # set(TargetOpenMP_FIND_COMPONENTS "CXX")
 
-#
 # Add forte subdirectory
-#
 add_subdirectory (forte)
 
-#
 # Forte tests
-#
 option(ENABLE_ForteTests "Enable Forte tests." ON)
 
-# target_include_directories(forte PRIVATE .)
-
-## 64bit implementation
-if(MAX_DET_ORB)
-    add_definitions(-DMAX_DET_ORB=${MAX_DET_ORB})
-else()
-    add_definitions(-DMAX_DET_ORB=64)
-endif()
+# ## 64bit implementation
+# if(MAX_DET_ORB)
+#     add_definitions(-DMAX_DET_ORB=${MAX_DET_ORB})
+# else()
+#     add_definitions(-DMAX_DET_ORB=64)
+# endif()
 
 if (ENABLE_ForteTests)
   project (forte_tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,18 @@
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
-# set(CMAKE_CXX_STANDARD 17)
-# set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# set(CMAKE_CXX_EXTENSIONS OFF)
-# # set(TargetOpenMP_FIND_COMPONENTS "CXX")
-
-# Add forte subdirectory
-add_subdirectory (forte)
+ set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Forte tests
 option(ENABLE_ForteTests "Enable Forte tests." ON)
 
-# ## 64bit implementation
-# if(MAX_DET_ORB)
-#     add_definitions(-DMAX_DET_ORB=${MAX_DET_ORB})
-# else()
-#     add_definitions(-DMAX_DET_ORB=64)
-# endif()
+## 64bit implementation
+if(MAX_DET_ORB)
+    add_definitions(-DMAX_DET_ORB=${MAX_DET_ORB})
+else()
+    add_definitions(-DMAX_DET_ORB=64)
+endif()
 
 if (ENABLE_ForteTests)
   project (forte_tests)
@@ -31,3 +27,5 @@ if (ENABLE_ForteTests)
     tests/benchmark/determinant_benchmark.cc)
 endif (ENABLE_ForteTests)
 
+# Add forte subdirectory
+add_subdirectory (forte)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -239,9 +239,9 @@ jobs:
       source activate p4env
       cd build/forte
       make -j2 VERBOSE=1
-      file forte/forte*.so
-      ldd forte/forte*.so
-      readelf -d forte/forte*.so
+      file forte/_forte*.so
+      ldd forte/_forte*.so
+      readelf -d forte/_forte*.so
     displayName: 'Build Forte'
 
   - bash: |

--- a/forte/CMakeLists.txt
+++ b/forte/CMakeLists.txt
@@ -11,9 +11,6 @@ set(forte_AUTHORS      "Francesco A. Evangelista and Group")
 set(forte_DESCRIPTION  "Quantum Chemistry Methods for Strongly Correlated Electrons plugin to Psi4")
 set(forte_URL          "https://github.com/evangelistalab/forte")
 set(forte_LICENSE      "GPL-3.0+")
-#set(CMAKE_CXX_STANDARD 17)
-#set(CMAKE_CXX_STANDARD_REQUIRED ON)
-#set(CMAKE_CXX_EXTENSIONS OFF)
 set(TargetOpenMP_FIND_COMPONENTS "CXX")
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
@@ -234,13 +231,6 @@ if(TARGET CheMPS2::chemps2)
 endif()
 
 target_include_directories(_forte PRIVATE .)
-
-# 64bit implementation
-#if(MAX_DET_ORB)
-#    add_definitions(-DMAX_DET_ORB=${MAX_DET_ORB})
-#else()
-#    add_definitions(-DMAX_DET_ORB=64)
-#endif()
 
 if(ENABLE_MPI)
     target_link_libraries(_forte PRIVATE ${MPI_CXX_LIBRARIES})  # MPI option A

--- a/forte/CMakeLists.txt
+++ b/forte/CMakeLists.txt
@@ -11,9 +11,9 @@ set(forte_AUTHORS      "Francesco A. Evangelista and Group")
 set(forte_DESCRIPTION  "Quantum Chemistry Methods for Strongly Correlated Electrons plugin to Psi4")
 set(forte_URL          "https://github.com/evangelistalab/forte")
 set(forte_LICENSE      "GPL-3.0+")
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+#set(CMAKE_CXX_STANDARD 17)
+#set(CMAKE_CXX_STANDARD_REQUIRED ON)
+#set(CMAKE_CXX_EXTENSIONS OFF)
 set(TargetOpenMP_FIND_COMPONENTS "CXX")
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
@@ -224,30 +224,30 @@ sparse_ci/sparse_state_vector.cc
 v2rdm/v2rdm.cc
 )
 
-target_link_libraries(forte PRIVATE psi4::core)
-target_link_libraries(forte PRIVATE tgt::MathOpenMP)
+target_link_libraries(_forte PRIVATE psi4::core)
+target_link_libraries(_forte PRIVATE tgt::MathOpenMP)
 #set_target_properties(forte PROPERTIES PREFIX "")
-target_link_libraries(forte PRIVATE ambit::ambit)
+target_link_libraries(_forte PRIVATE ambit::ambit)
 if(TARGET CheMPS2::chemps2)
-    target_link_libraries(forte PRIVATE CheMPS2::chemps2)
+    target_link_libraries(_forte PRIVATE CheMPS2::chemps2)
     add_definitions(-DHAVE_CHEMPS2)
 endif()
 
-target_include_directories(forte PRIVATE .)
+target_include_directories(_forte PRIVATE .)
 
 # 64bit implementation
-if(MAX_DET_ORB)
-    add_definitions(-DMAX_DET_ORB=${MAX_DET_ORB})
-else()
-    add_definitions(-DMAX_DET_ORB=64)
-endif()
+#if(MAX_DET_ORB)
+#    add_definitions(-DMAX_DET_ORB=${MAX_DET_ORB})
+#else()
+#    add_definitions(-DMAX_DET_ORB=64)
+#endif()
 
 if(ENABLE_MPI)
-    target_link_libraries(forte PRIVATE ${MPI_CXX_LIBRARIES})  # MPI option A
+    target_link_libraries(_forte PRIVATE ${MPI_CXX_LIBRARIES})  # MPI option A
     #target_link_libraries(forte PRIVATE MPI::MPI_CXX)  # MPI option B
     #target_add_definitions(forte PRIVATE HAVE_MPI)  # MPI option B
 endif()
 
 if(ENABLE_GA)
-    target_link_libraries(forte PRIVATE GlobalArrays::ga)
+    target_link_libraries(_forte PRIVATE GlobalArrays::ga)
 endif()

--- a/forte/CMakeLists.txt
+++ b/forte/CMakeLists.txt
@@ -16,7 +16,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(TargetOpenMP_FIND_COMPONENTS "CXX")
 
-# cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 include(psi4OptionsTools)
@@ -74,7 +73,7 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++1z-extensions") # avoid warnings for C++17
 
 # List of CC files
-pybind11_add_module(forte
+pybind11_add_module(_forte
 api/ambit_api.cc
 api/cube_file_api.cc
 api/integrals_api.cc

--- a/forte/__init__.py
+++ b/forte/__init__.py
@@ -40,7 +40,7 @@ from .model import Model, MolecularModel
 from .pymodule import *
 from .register_forte_options import *
 from .core import ForteManager, clean_options
-from .forte import *
+from ._forte import *
 
 __version__ = '0.2.3'
 __author__ = 'Forte Developers'

--- a/forte/api/ambit_api.cc
+++ b/forte/api/ambit_api.cc
@@ -5,7 +5,7 @@
  * t    hat implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see LICENSE, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see LICENSE, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/api/cube_file_api.cc
+++ b/forte/api/cube_file_api.cc
@@ -5,7 +5,7 @@
  * t    hat implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see LICENSE, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see LICENSE, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/api/forte_python_module.cc
+++ b/forte/api/forte_python_module.cc
@@ -5,7 +5,7 @@
  * t    hat implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see LICENSE, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see LICENSE, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/api/forte_python_module.cc
+++ b/forte/api/forte_python_module.cc
@@ -152,7 +152,7 @@ void export_Symmetry(py::module& m) {
 }
 
 // TODO: export more classes using the function above
-PYBIND11_MODULE(forte, m) {
+PYBIND11_MODULE(_forte, m) {
     m.doc() = "pybind11 Forte module"; // module docstring
     m.def("startup", &startup);
     m.def("cleanup", &cleanup);

--- a/forte/api/integrals_api.cc
+++ b/forte/api/integrals_api.cc
@@ -5,7 +5,7 @@
  * t    hat implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see LICENSE, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see LICENSE, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/api/mospaceinfo_api.cc
+++ b/forte/api/mospaceinfo_api.cc
@@ -5,7 +5,7 @@
  * t    hat implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see LICENSE, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see LICENSE, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/api/options_api.cc
+++ b/forte/api/options_api.cc
@@ -5,7 +5,7 @@
  * t    hat implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see LICENSE, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see LICENSE, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/api/orbital_api.cc
+++ b/forte/api/orbital_api.cc
@@ -5,7 +5,7 @@
  * t    hat implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see LICENSE, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see LICENSE, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/api/rdms_api.cc
+++ b/forte/api/rdms_api.cc
@@ -5,7 +5,7 @@
  * t    hat implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see LICENSE, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see LICENSE, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/api/sci_api.cc
+++ b/forte/api/sci_api.cc
@@ -5,7 +5,7 @@
  * t    hat implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see LICENSE, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see LICENSE, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/api/state_info_api.cc
+++ b/forte/api/state_info_api.cc
@@ -5,7 +5,7 @@
  * t    hat implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see LICENSE, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see LICENSE, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/base_classes/active_space_method.cc
+++ b/forte/base_classes/active_space_method.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/base_classes/active_space_method.h
+++ b/forte/base_classes/active_space_method.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/base_classes/active_space_solver.cc
+++ b/forte/base_classes/active_space_solver.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/base_classes/active_space_solver.h
+++ b/forte/base_classes/active_space_solver.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/base_classes/forte_options.cc
+++ b/forte/base_classes/forte_options.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/base_classes/forte_options.h
+++ b/forte/base_classes/forte_options.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/base_classes/mo_space_info.cc
+++ b/forte/base_classes/mo_space_info.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in
@@ -188,7 +188,8 @@ std::vector<std::pair<size_t, size_t>> MOSpaceInfo::relative_mo(const std::strin
     return result;
 }
 
-bool MOSpaceInfo::contained_in_space(const std::string& space, const std::string& composite_space) const {
+bool MOSpaceInfo::contained_in_space(const std::string& space,
+                                     const std::string& composite_space) const {
     if (composite_spaces_.count(space) * composite_spaces_.count(composite_space) == 0) {
         std::string msg = "\n  MOSpaceInfo::contained_in_space - space " + space +
                           " or composite space " + composite_space + " is not defined.";

--- a/forte/base_classes/mo_space_info.h
+++ b/forte/base_classes/mo_space_info.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/base_classes/orbital_transform.cc
+++ b/forte/base_classes/orbital_transform.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/base_classes/rdms.cc
+++ b/forte/base_classes/rdms.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/base_classes/rdms.h
+++ b/forte/base_classes/rdms.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/base_classes/scf_info.h
+++ b/forte/base_classes/scf_info.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/base_classes/state_info.cc
+++ b/forte/base_classes/state_info.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/base_classes/state_info.h
+++ b/forte/base_classes/state_info.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/casscf/casscf.cc
+++ b/forte/casscf/casscf.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -185,8 +185,9 @@ double CASSCF::compute_energy() {
     psi::SharedMatrix Sstep;
 
     // Setup the DIIS manager
-    auto diis_manager = std::make_shared<DIISManager>(
-        diis_max_vec, "MCSCF DIIS", DIISManager::RemovalPolicy::OldestAdded, DIISManager::StoragePolicy::InCore);
+    auto diis_manager = std::make_shared<DIISManager>(diis_max_vec, "MCSCF DIIS",
+                                                      DIISManager::RemovalPolicy::OldestAdded,
+                                                      DIISManager::StoragePolicy::InCore);
     diis_manager->set_error_vector_size(1, DIISEntry::InputType::Matrix, S.get());
     diis_manager->set_vector_size(1, DIISEntry::InputType::Matrix, S.get());
 

--- a/forte/casscf/casscf.h
+++ b/forte/casscf/casscf.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/casscf/casscf_orb_grad.cc
+++ b/forte/casscf/casscf_orb_grad.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -705,7 +705,7 @@ bool CASSCF_ORB_GRAD::update_orbitals(psi::SharedVector x) {
     if (ortho_trans_algo_ == "PADE") {
         dU = dR->clone();
         dU->expm(3);
-    } else if(ortho_trans_algo_ == "POWER") {
+    } else if (ortho_trans_algo_ == "POWER") {
         dU = matrix_exponential(dR, 3);
     } else {
         dU = cayley_trans(dR);

--- a/forte/casscf/casscf_orb_grad.h
+++ b/forte/casscf/casscf_orb_grad.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -354,7 +354,7 @@ class CASSCF_ORB_GRAD {
     psi::SharedMatrix matrix_exponential(const psi::SharedMatrix& A, int n);
 
     /// Compute Cayley transformation from skew-symmetric matrix
-    psi::SharedMatrix  cayley_trans(const psi::SharedMatrix& A);
+    psi::SharedMatrix cayley_trans(const psi::SharedMatrix& A);
 
     /// Grab part of the orbital coefficients
     psi::SharedMatrix C_subset(const std::string& name, psi::SharedMatrix C,

--- a/forte/casscf/casscf_orb_grad_deriv.cc
+++ b/forte/casscf/casscf_orb_grad_deriv.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/casscf/cpscf.cc
+++ b/forte/casscf/cpscf.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/casscf/cpscf.h
+++ b/forte/casscf/cpscf.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/casscf/mcscf_2step.cc
+++ b/forte/casscf/mcscf_2step.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/casscf/mcscf_2step.h
+++ b/forte/casscf/mcscf_2step.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/ci_ex_states/excited_state_solver.cc
+++ b/forte/ci_ex_states/excited_state_solver.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/ci_ex_states/excited_state_solver.h
+++ b/forte/ci_ex_states/excited_state_solver.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/ci_rdm/ci_rdms.cc
+++ b/forte/ci_rdm/ci_rdms.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/ci_rdm/ci_rdms.h
+++ b/forte/ci_rdm/ci_rdms.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/ci_rdm/ci_rdms_dynamic.cc
+++ b/forte/ci_rdm/ci_rdms_dynamic.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/core.py
+++ b/forte/core.py
@@ -5,7 +5,7 @@
 # that implements a variety of quantum chemistry methods for strongly
 # correlated electrons.
 #
-# Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+# Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
 #
 # The copyrights for code used from other parties are included in
 # the corresponding files.

--- a/forte/dmrg/dmrgscf.cc
+++ b/forte/dmrg/dmrgscf.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/dmrg/dmrgscf.h
+++ b/forte/dmrg/dmrgscf.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/dmrg/dmrgsolver.cc
+++ b/forte/dmrg/dmrgsolver.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/dmrg/dmrgsolver.h
+++ b/forte/dmrg/dmrgsolver.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -29,7 +29,6 @@
 #ifndef DMRGSOLVER_H
 #define DMRGSOLVER_H
 
-
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libfock/jk.h"
 #include "base_classes/rdms.h"
@@ -45,18 +44,15 @@
 #include "chemps2/Initialize.h"
 #include "chemps2/EdmistonRuedenberg.h"
 
-
 namespace forte {
 
 class DMRGSolver {
   public:
-    DMRGSolver(StateInfo state,
-               std::shared_ptr<SCFInfo> scf_info,
-               std::shared_ptr<ForteOptions> options,
-               std::shared_ptr<ForteIntegrals> ints,
+    DMRGSolver(StateInfo state, std::shared_ptr<SCFInfo> scf_info,
+               std::shared_ptr<ForteOptions> options, std::shared_ptr<ForteIntegrals> ints,
                std::shared_ptr<MOSpaceInfo> mo_space_info);
-//    DMRGSolver(psi::SharedWavefunction ref_wfn, psi::Options& options,
-//               std::shared_ptr<MOSpaceInfo> mo_space_info);
+    //    DMRGSolver(psi::SharedWavefunction ref_wfn, psi::Options& options,
+    //               std::shared_ptr<MOSpaceInfo> mo_space_info);
     void compute_energy();
 
     RDMs rdms() { return dmrg_rdms_; }
@@ -98,5 +94,5 @@ class DMRGSolver {
     bool use_user_integrals_ = false;
     void print_natural_orbitals(double* one_rdm);
 };
-}
+} // namespace forte
 #endif // DMRG_H

--- a/forte/fci/binary_graph.cc
+++ b/forte/fci/binary_graph.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/fci/fci_solver.cc
+++ b/forte/fci/fci_solver.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/fci/fci_solver.h
+++ b/forte/fci/fci_solver.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/fci/fci_vector.cc
+++ b/forte/fci/fci_vector.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/fci/fci_vector.h
+++ b/forte/fci/fci_vector.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -201,27 +201,31 @@ class FCIVector {
     void H2_aaaa2(FCIVector& result, std::shared_ptr<ActiveSpaceIntegrals> fci_ints, bool alfa);
 
     // 1-RDM elements are stored in the format
-    // <a^+_{pa} a^+_{qb} a_{sb} a_ra> -> rdm[oei_index(p,q)]    
+    // <a^+_{pa} a^+_{qb} a_{sb} a_ra> -> rdm[oei_index(p,q)]
 
-    /// Compute the matrix elements of the same 1-RDM <a^+_{p} a_{q}>    
+    /// Compute the matrix elements of the same 1-RDM <a^+_{p} a_{q}>
     void compute_1rdm(std::vector<double>& rdm, bool alfa);
 
     // 2-RDM elements are stored in the format
     // <a^+_{p} a^+_{q} a_{s} a_r> -> rdm[tei_index(p,q,r,s)]
 
-    /// Compute the matrix elements of the same spin 2-RDM <a^+_p a^+_q a_s a_r> (with all indices alpha or beta)
+    /// Compute the matrix elements of the same spin 2-RDM <a^+_p a^+_q a_s a_r> (with all indices
+    /// alpha or beta)
     void compute_2rdm_aa(std::vector<double>& rdm, bool alfa);
     /// Compute the matrix elements of the alpha-beta 2-RDM <a^+_{pa} a^+_{qb} a_{sb} a_{ra}>
     void compute_2rdm_ab(std::vector<double>& rdm);
-    
+
     // 3-RDM elements are stored in the format
     // <a^+_p a^+_q a^+_r a_u a_t a_s> -> rdm[six_index(p,q,r,s,t,u)]
 
-    /// Compute the matrix elements of the same spin 3-RDM <a^+_p a^+_q a_s a_r> (with all indices alpha or beta)
+    /// Compute the matrix elements of the same spin 3-RDM <a^+_p a^+_q a_s a_r> (with all indices
+    /// alpha or beta)
     void compute_3rdm_aaa(std::vector<double>& rdm, bool alfa);
-    /// Compute the matrix elements of the alpha-alpha-beta 3-RDM <a^+_{pa} a^+_{qa} a^+_{rb} a_{ub} a_{ta} a_{sa}>
+    /// Compute the matrix elements of the alpha-alpha-beta 3-RDM <a^+_{pa} a^+_{qa} a^+_{rb} a_{ub}
+    /// a_{ta} a_{sa}>
     void compute_3rdm_aab(std::vector<double>& rdm);
-    /// Compute the matrix elements of the alpha-beta-beta 3-RDM <a^+_{pa} a^+_{qb} a^+_{rb} a_{ub} a_{tb} a_{sa}>
+    /// Compute the matrix elements of the alpha-beta-beta 3-RDM <a^+_{pa} a^+_{qb} a^+_{rb} a_{ub}
+    /// a_{tb} a_{sa}>
     void compute_3rdm_abb(std::vector<double>& rdm);
 };
 } // namespace forte

--- a/forte/fci/fci_vector_h_diag.cc
+++ b/forte/fci/fci_vector_h_diag.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/fci/fci_vector_hamiltonian.cc
+++ b/forte/fci/fci_vector_hamiltonian.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/fci/fci_vector_rdm.cc
+++ b/forte/fci/fci_vector_rdm.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -941,15 +941,13 @@ double FCIVector::compute_spin2() {
                 int s_sym = rs_sym ^ r_sym;
 
                 for (int r_rel = 0; r_rel < cmopi_[r_sym]; ++r_rel) {
-                        const int r_abs = r_rel + cmopi_offset_[r_sym];
+                    const int r_abs = r_rel + cmopi_offset_[r_sym];
                     for (int s_rel = 0; s_rel < cmopi_[s_sym]; ++s_rel) {
                         const int s_abs = s_rel + cmopi_offset_[s_sym];
 
                         // Grab list (r,s,Ib_sym)
-                        const auto& vo_alfa =
-                            lists_->get_alfa_vo_list(s_abs, r_abs, Ia_sym);
-                        const auto& vo_beta =
-                            lists_->get_beta_vo_list(r_abs, s_abs, Ib_sym);
+                        const auto& vo_alfa = lists_->get_alfa_vo_list(s_abs, r_abs, Ia_sym);
+                        const auto& vo_beta = lists_->get_beta_vo_list(r_abs, s_abs, Ib_sym);
 
                         const size_t maxSSa = vo_alfa.size();
                         const size_t maxSSb = vo_beta.size();
@@ -957,7 +955,8 @@ double FCIVector::compute_spin2() {
                         for (size_t SSa = 0; SSa < maxSSa; ++SSa) {
                             for (size_t SSb = 0; SSb < maxSSb; ++SSb) {
                                 spin2 += Y[vo_alfa[SSa].J][vo_beta[SSb].J] *
-                                         C[vo_alfa[SSa].I][vo_beta[SSb].I] * static_cast<double>(vo_alfa[SSa].sign * vo_beta[SSb].sign);
+                                         C[vo_alfa[SSa].I][vo_beta[SSb].I] *
+                                         static_cast<double>(vo_alfa[SSa].sign * vo_beta[SSb].sign);
                             }
                         }
                     }

--- a/forte/fci/string_hole_list.cc
+++ b/forte/fci/string_hole_list.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -40,7 +40,6 @@
 #include "psi4/psi4-dec.h"
 
 #include "string_lists.h"
-
 
 namespace forte {
 
@@ -166,11 +165,11 @@ std::vector<H3StringSubstitution>& StringLists::get_beta_3h_list(int h_I, size_t
 }
 
 /**
-                               * Generate all the pairs of strings I,J connected
+ * Generate all the pairs of strings I,J connected
  * by a^{+}_p a_q
-                               * that is: J = ± a^{+}_p a_q I. p and q are
+ * that is: J = ± a^{+}_p a_q I. p and q are
  * absolute indices and I belongs to the irrep h.
-                               */
+ */
 void StringLists::make_3h_list(GraphPtr graph, GraphPtr graph_3h, H3List& list) {
     int n = graph->nbits();
     int k = graph->nones();
@@ -230,4 +229,4 @@ void StringLists::make_3h_list(GraphPtr graph, GraphPtr graph_3h, H3List& list) 
     delete[] J;
     delete[] I;
 }
-}
+} // namespace forte

--- a/forte/fci/string_lists.cc
+++ b/forte/fci/string_lists.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -37,8 +37,9 @@ using namespace psi;
 
 namespace forte {
 
-StringLists::StringLists(RequiredLists required_lists, psi::Dimension cmopi, std::vector<size_t> core_mo,
-                         std::vector<size_t> cmo_to_mo, size_t na, size_t nb, int print)
+StringLists::StringLists(RequiredLists required_lists, psi::Dimension cmopi,
+                         std::vector<size_t> core_mo, std::vector<size_t> cmo_to_mo, size_t na,
+                         size_t nb, int print)
     : required_lists_(required_lists), cmopi_(cmopi), cmo_to_mo_(cmo_to_mo), fomo_to_mo_(core_mo),
       na_(na), nb_(nb), print_(print) {
     startup();
@@ -345,5 +346,4 @@ void StringLists::print_string(bool* I, size_t n) {
 //  delete[] I;
 //  delete[] b;
 //*/
-}
-
+} // namespace forte

--- a/forte/fci/string_lists.h
+++ b/forte/fci/string_lists.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/fci/string_oo_list.cc
+++ b/forte/fci/string_oo_list.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -29,7 +29,6 @@
 #include <algorithm>
 
 #include "string_lists.h"
-
 
 namespace forte {
 
@@ -128,4 +127,3 @@ void StringLists::make_oo(GraphPtr graph, OOList& list, int pq_sym, size_t pq) {
     }
 }
 } // namespace forte
-

--- a/forte/fci/string_vo_list.cc
+++ b/forte/fci/string_vo_list.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -41,7 +41,6 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 
 #include "string_lists.h"
-
 
 namespace forte {
 
@@ -142,7 +141,6 @@ void StringLists::make_vo(GraphPtr graph, VOList& list, int p, int q) {
     }
 }
 } // namespace forte
-
 
 ///**
 // * Generate all the pairs of strings I,J connected by a^{+}_p a_q

--- a/forte/fci/string_vvoo_list.cc
+++ b/forte/fci/string_vvoo_list.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -32,7 +32,6 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 
 #include "string_lists.h"
-
 
 namespace forte {
 
@@ -314,4 +313,3 @@ std::vector<StringSubstitution>& StringLists::get_beta_vovo_list(size_t p, size_
     return beta_vovo_list[pqrs_pair];
 }
 } // namespace forte
-

--- a/forte/finite_temperature/finite_temperature.cc
+++ b/forte/finite_temperature/finite_temperature.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -48,13 +48,10 @@
 
 namespace forte {
 
-FiniteTemperatureHF::FiniteTemperatureHF(psi::SharedWavefunction ref_wfn, std::shared_ptr<ForteOptions> options,
-                                         std::shared_ptr<MOSpaceInfo> mo_space)
-    : RHF(ref_wfn, std::make_shared<SuperFunctional>(), options, _default_psio_lib_),
-      mo_space_info_(mo_space), options_(options) {
-    shallow_copy(ref_wfn);
-    reference_wavefunction_ = ref_wfn;
-    startup();
+FiniteTemperatureHF::FiniteTemperatureHF(psi::SharedWavefunction ref_wfn,
+std::shared_ptr<ForteOptions> options, std::shared_ptr<MOSpaceInfo> mo_space) : RHF(ref_wfn,
+std::make_shared<SuperFunctional>(), options, _default_psio_lib_), mo_space_info_(mo_space),
+options_(options) { shallow_copy(ref_wfn); reference_wavefunction_ = ref_wfn; startup();
 }
 
 void FiniteTemperatureHF::startup() {
@@ -288,7 +285,8 @@ void FiniteTemperatureHF::form_G() {
     F_core->subtract(K_core);
     G_->copy(F_core);
 }
-void FiniteTemperatureHF::form_D() { D_ = psi::linalg::doublet(C_occ_folded_, C_occ_a_, false, true); }
+void FiniteTemperatureHF::form_D() { D_ = psi::linalg::doublet(C_occ_folded_, C_occ_a_, false,
+true); }
 }
 }
 */

--- a/forte/finite_temperature/finite_temperature.h
+++ b/forte/finite_temperature/finite_temperature.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/forte-def.h
+++ b/forte/forte-def.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/forte.cc
+++ b/forte/forte.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/forte.h
+++ b/forte/forte.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/blockedtensorfactory.cc
+++ b/forte/helpers/blockedtensorfactory.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/blockedtensorfactory.h
+++ b/forte/helpers/blockedtensorfactory.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -40,7 +40,6 @@
 #include "psi4/libmints/dimension.h"
 
 #include "integrals/integrals.h"
-
 
 namespace forte {
 
@@ -119,6 +118,6 @@ class BlockedTensorFactory {
                                               int how_many_active);
     std::map<std::string, std::vector<size_t>> get_mo_to_index() { return molabel_to_index_; }
 };
-}
+} // namespace forte
 
 #endif // BLOCKEDTENSORFACTORY_H

--- a/forte/helpers/combinatorial.cc
+++ b/forte/helpers/combinatorial.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/combinatorial.h
+++ b/forte/helpers/combinatorial.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/cube_file.cc
+++ b/forte/helpers/cube_file.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/cube_file.h
+++ b/forte/helpers/cube_file.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/disk_io.cc
+++ b/forte/helpers/disk_io.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -92,7 +92,7 @@ void read_disk_vector_double(const std::string& filename, std::vector<double>& d
     in.close();
 }
 
-//std::string write_disk_BT(ambit::BlockedTensor& BT, const std::string& name,
+// std::string write_disk_BT(ambit::BlockedTensor& BT, const std::string& name,
 //                          const std::string& file_prefix) {
 //    auto block_labels = BT.block_labels();
 //    std::vector<std::string> block_file_names;
@@ -133,7 +133,7 @@ void read_disk_vector_double(const std::string& filename, std::vector<double>& d
 //    return file_path;
 //}
 
-//void read_disk_BT(ambit::BlockedTensor& BT, const std::string& filename) {
+// void read_disk_BT(ambit::BlockedTensor& BT, const std::string& filename) {
 //    // read master file info for each block
 //    std::ifstream infile(filename);
 //    if (!infile.good()) {
@@ -163,7 +163,7 @@ void read_disk_vector_double(const std::string& filename, std::vector<double>& d
 //    infile.close();
 //}
 
-//void delete_disk_BT(const std::string& filename) {
+// void delete_disk_BT(const std::string& filename) {
 //    std::ifstream infile(filename);
 //    if (!infile.good()) {
 //        std::string error = "File " + filename + " does not exist.";

--- a/forte/helpers/disk_io.h
+++ b/forte/helpers/disk_io.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in
@@ -73,7 +73,7 @@ void read_disk_vector_double(const std::string& filename, std::vector<double>& d
 // * @param name The abbreviated name of the BlockedTensor BT
 // * @return The master file name (with absolute path) that handles all blocks
 // */
-//std::string write_disk_BT(ambit::BlockedTensor& BT, const std::string& name,
+// std::string write_disk_BT(ambit::BlockedTensor& BT, const std::string& name,
 //                          const std::string& file_prefix);
 
 ///**
@@ -81,13 +81,13 @@ void read_disk_vector_double(const std::string& filename, std::vector<double>& d
 // * @param BT The BlockedTensor to be filled
 // * @param filename The master file name (with absolute path) that stores file names for all blocks
 // */
-//void read_disk_BT(ambit::BlockedTensor& BT, const std::string& filename);
+// void read_disk_BT(ambit::BlockedTensor& BT, const std::string& filename);
 
 ///**
 // * @brief Delete all files written by write_disk_BT
 // * @param filename The master file name (with absolute path) that stores file names for all blocks
 // */
-//void delete_disk_BT(const std::string& filename);
+// void delete_disk_BT(const std::string& filename);
 
 } // namespace forte
 

--- a/forte/helpers/hash_vector.h
+++ b/forte/helpers/hash_vector.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -109,7 +109,7 @@ template <class Key, class Hash = std::hash<Key>> class HashVector {
 
     /*- Convertors -*/
     std::vector<Key> toVector() const;
-    std::vector<std::pair<Key,size_t>> toKeyIndex() const;
+    std::vector<std::pair<Key, size_t>> toKeyIndex() const;
     std::unordered_set<Key, Hash> toUnordered_set() const;
 
     class iterator : public std::vector<CINode<Key>>::const_iterator {
@@ -133,7 +133,7 @@ namespace std {
 template <class Key, class Hash> void swap(HashVector<Key, Hash>& a, HashVector<Key, Hash>& b) {
     a.swap(b);
 }
-}
+} // namespace std
 
 template <class Key, class Hash> HashVector<Key, Hash>::HashVector() { this->clear(); }
 
@@ -575,7 +575,8 @@ void HashVector<Key, Hash>::merge(const std::unordered_set<Key, Hash_2>& source)
 
 template <class Key, class Hash>
 void HashVector<Key, Hash>::map_order(const std::vector<size_t>& index_map) {
-    if (current_size == 0) return;
+    if (current_size == 0)
+        return;
     std::vector<CINode<Key>> new_vec;
     new_vec.reserve(this->vec.capacity());
     new_vec.resize(current_size, vec[0]);
@@ -690,12 +691,13 @@ template <class Key, class Hash> std::vector<Key> HashVector<Key, Hash>::toVecto
     return keys;
 }
 
-template <class Key, class Hash> std::vector<std::pair<Key,size_t>> HashVector<Key, Hash>::toKeyIndex() const {
-    std::vector<std::pair<Key,size_t>> key_index_pairs;
+template <class Key, class Hash>
+std::vector<std::pair<Key, size_t>> HashVector<Key, Hash>::toKeyIndex() const {
+    std::vector<std::pair<Key, size_t>> key_index_pairs;
     key_index_pairs.reserve(current_size);
     size_t n = 0;
     for (const Key& k : (*this)) {
-        key_index_pairs.push_back(std::make_pair(k,n));
+        key_index_pairs.push_back(std::make_pair(k, n));
         n++;
     }
     return key_index_pairs;

--- a/forte/helpers/helpers.cc
+++ b/forte/helpers/helpers.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/helpers.h
+++ b/forte/helpers/helpers.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/helpers/iterative_solvers.cc
+++ b/forte/helpers/iterative_solvers.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/iterative_solvers.h
+++ b/forte/helpers/iterative_solvers.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/lbfgs/lbfgs.cc
+++ b/forte/helpers/lbfgs/lbfgs.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/lbfgs/lbfgs.h
+++ b/forte/helpers/lbfgs/lbfgs.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/lbfgs/lbfgs_param.cc
+++ b/forte/helpers/lbfgs/lbfgs_param.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/lbfgs/lbfgs_param.h
+++ b/forte/helpers/lbfgs/lbfgs_param.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/lbfgs/rosenbrock.cc
+++ b/forte/helpers/lbfgs/rosenbrock.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/lbfgs/rosenbrock.h
+++ b/forte/helpers/lbfgs/rosenbrock.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/memory.h
+++ b/forte/helpers/memory.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -29,7 +29,6 @@
 #ifndef _memory_h_
 #define _memory_h_
 
-
 namespace forte {
 
 /**
@@ -38,8 +37,7 @@ namespace forte {
  * @param n The number of elements for storage
  * @return A pair (size, "unit") with the size given in appropriate unit (B, KB, MB, GB, TB, PB)
  */
-template <typename T>
-std::pair<double, std::string> to_xb2(size_t nele) {
+template <typename T> std::pair<double, std::string> to_xb2(size_t nele) {
     constexpr size_t type_size = sizeof(T);
     // map the size
     std::map<std::string, double> to_XB;
@@ -63,6 +61,6 @@ std::pair<double, std::string> to_xb2(size_t nele) {
     return out;
 }
 
-}
+} // namespace forte
 
 #endif // _memory_h_

--- a/forte/helpers/printing.cc
+++ b/forte/helpers/printing.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/printing.h
+++ b/forte/helpers/printing.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/spinorbital_helpers.cc
+++ b/forte/helpers/spinorbital_helpers.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/spinorbital_helpers.h
+++ b/forte/helpers/spinorbital_helpers.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/string_algorithms.cc
+++ b/forte/helpers/string_algorithms.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/string_algorithms.h
+++ b/forte/helpers/string_algorithms.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/symmetry.cc
+++ b/forte/helpers/symmetry.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/symmetry.h
+++ b/forte/helpers/symmetry.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/helpers/timer.h
+++ b/forte/helpers/timer.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/integrals/active_space_integrals.cc
+++ b/forte/integrals/active_space_integrals.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/integrals/active_space_integrals.h
+++ b/forte/integrals/active_space_integrals.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/integrals/cholesky_integrals.cc
+++ b/forte/integrals/cholesky_integrals.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/integrals/cholesky_integrals.h
+++ b/forte/integrals/cholesky_integrals.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/integrals/conventional_integrals.cc
+++ b/forte/integrals/conventional_integrals.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/integrals/conventional_integrals.h
+++ b/forte/integrals/conventional_integrals.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/integrals/custom_integrals.cc
+++ b/forte/integrals/custom_integrals.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/integrals/custom_integrals.h
+++ b/forte/integrals/custom_integrals.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/integrals/df_integrals.cc
+++ b/forte/integrals/df_integrals.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/integrals/df_integrals.h
+++ b/forte/integrals/df_integrals.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/integrals/diskdf_integrals.cc
+++ b/forte/integrals/diskdf_integrals.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/integrals/diskdf_integrals.h
+++ b/forte/integrals/diskdf_integrals.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/integrals/distribute_df_integrals.cc
+++ b/forte/integrals/distribute_df_integrals.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/integrals/distribute_df_integrals.h
+++ b/forte/integrals/distribute_df_integrals.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/integrals/integrals.cc
+++ b/forte/integrals/integrals.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -495,7 +495,8 @@ void ForteIntegrals::rotate_orbitals(std::shared_ptr<psi::Matrix> Ua,
 
 // The following functions throw an error by default
 
-void ForteIntegrals::update_orbitals(std::shared_ptr<psi::Matrix>, std::shared_ptr<psi::Matrix>, bool) {
+void ForteIntegrals::update_orbitals(std::shared_ptr<psi::Matrix>, std::shared_ptr<psi::Matrix>,
+                                     bool) {
     _undefined_function("update_orbitals");
 }
 

--- a/forte/integrals/integrals.h
+++ b/forte/integrals/integrals.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/integrals/integrals_psi4_interface.cc
+++ b/forte/integrals/integrals_psi4_interface.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/integrals/make_integrals.cc
+++ b/forte/integrals/make_integrals.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/integrals/make_integrals.h
+++ b/forte/integrals/make_integrals.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/integrals/parallel_ccvv_algorithms.cc
+++ b/forte/integrals/parallel_ccvv_algorithms.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -52,7 +52,6 @@
 #include "omp.h"
 #endif
 using namespace ambit;
-
 
 namespace forte {
 
@@ -154,7 +153,7 @@ double THREE_DSRG_MRPT2::E_VT2_2_batch_core_ga() {
         printf("\n Number of blocks can not be larger than core_ on P%d", my_proc);
         printf("\n num_block: %d core_: %d on P%d", num_block, core_, my_proc);
         throw psi::PSIEXCEPTION("Number of blocks is larger than core.  Fix "
-                           "num_block or check source code");
+                                "num_block or check source code");
     }
     if (num_block < num_proc) {
         outfile->Printf("\n Set number of processors larger");
@@ -643,7 +642,7 @@ double THREE_DSRG_MRPT2::E_VT2_2_batch_core_rep() {
         printf("\n P%d says that num_block is %d", my_proc, num_block);
         outfile->Printf("\n Number of blocks can not be larger than core_");
         throw psi::PSIEXCEPTION("Number of blocks is larger than core.  Fix "
-                           "num_block or check source code");
+                                "num_block or check source code");
     }
 
     if (num_block < num_proc) {
@@ -968,7 +967,7 @@ double THREE_DSRG_MRPT2::E_VT2_2_batch_virtual_ga() {
     if (num_block > virtual_) {
         outfile->Printf("\n Number of blocks can not be larger than core_");
         throw psi::PSIEXCEPTION("Number of blocks is larger than core.  Fix "
-                           "num_block or check source code");
+                                "num_block or check source code");
     }
 
     if (num_block >= 1) {
@@ -1150,6 +1149,5 @@ double THREE_DSRG_MRPT2::E_VT2_2_batch_virtual_ga() {
 }
 #endif
 } // namespace forte
-
 
 #endif

--- a/forte/integrals/paralleldfmo.cc
+++ b/forte/integrals/paralleldfmo.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -51,10 +51,10 @@
 #include <macdecls.h>
 #endif
 
-
 namespace forte {
 
-ParallelDFMO::ParallelDFMO(std::shared_ptr<psi::BasisSet> primary, std::shared_ptr<psi::BasisSet> auxiliary)
+ParallelDFMO::ParallelDFMO(std::shared_ptr<psi::BasisSet> primary,
+                           std::shared_ptr<psi::BasisSet> auxiliary)
     : primary_(primary), auxiliary_(auxiliary) {
     memory_ = psi::Process::environment.get_memory();
 }
@@ -201,8 +201,10 @@ void ParallelDFMO::transform_integrals() {
     // => Temporary Tensors <= //
 
     // > Three-index buffers < //
-    std::shared_ptr<psi::Matrix> Amn(new psi::Matrix("(A|mn)", max_rows, nso * (unsigned long int)nso));
-    std::shared_ptr<psi::Matrix> Ami(new psi::Matrix("(A|mi)", max_rows, nso * (unsigned long int)max1));
+    std::shared_ptr<psi::Matrix> Amn(
+        new psi::Matrix("(A|mn)", max_rows, nso * (unsigned long int)nso));
+    std::shared_ptr<psi::Matrix> Ami(
+        new psi::Matrix("(A|mi)", max_rows, nso * (unsigned long int)max1));
     std::shared_ptr<psi::Matrix> Aia(new psi::Matrix("(A|ia)", naux, max12));
     double** Amnp = Amn->pointer();
     double** Amip = Ami->pointer();
@@ -365,8 +367,9 @@ void ParallelDFMO::J_one_half() {
 
     // if(GA_Nodeid() == 0)
     {
-        std::shared_ptr<IntegralFactory> Jfactory(new IntegralFactory(
-            auxiliary_, psi::BasisSet::zero_ao_basis_set(), auxiliary_, psi::BasisSet::zero_ao_basis_set()));
+        std::shared_ptr<IntegralFactory> Jfactory(
+            new IntegralFactory(auxiliary_, psi::BasisSet::zero_ao_basis_set(), auxiliary_,
+                                psi::BasisSet::zero_ao_basis_set()));
         std::vector<std::shared_ptr<TwoBodyAOInt>> Jeri;
         for (int thread = 0; thread < nthread; thread++) {
             Jeri.push_back(std::shared_ptr<TwoBodyAOInt>(Jfactory->eri()));
@@ -425,6 +428,5 @@ void ParallelDFMO::J_one_half() {
     }
 }
 } // namespace forte
-
 
 #endif

--- a/forte/integrals/paralleldfmo.h
+++ b/forte/integrals/paralleldfmo.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/model.py
+++ b/forte/model.py
@@ -3,9 +3,9 @@ from abc import ABC, abstractmethod
 from forte.core import flog
 from forte.molecule import Molecule
 from forte.basis import Basis
-from forte.forte import StateInfo
-from forte.forte import Symmetry
-from forte.forte import make_ints_from_psi4
+from ._forte import StateInfo
+from ._forte import Symmetry
+from ._forte import make_ints_from_psi4
 
 
 class Model(ABC):

--- a/forte/mrdsrg-helper/dsrg_mem.cc
+++ b/forte/mrdsrg-helper/dsrg_mem.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -118,8 +118,8 @@ void DSRG_MEM::print(const std::string& name) {
         throw psi::PSIEXCEPTION(error);
     } else {
         auto avai_xb_pair = to_xb(mem_avai_, 1);
-        psi::outfile->Printf("\n    %-45s %7.2f %2s", "Memory currently available", avai_xb_pair.first,
-                             avai_xb_pair.second.c_str());
+        psi::outfile->Printf("\n    %-45s %7.2f %2s", "Memory currently available",
+                             avai_xb_pair.first, avai_xb_pair.second.c_str());
     }
     psi::outfile->Printf("\n");
 }

--- a/forte/mrdsrg-helper/dsrg_mem.h
+++ b/forte/mrdsrg-helper/dsrg_mem.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-helper/dsrg_source.cc
+++ b/forte/mrdsrg-helper/dsrg_source.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -40,4 +40,4 @@ LABS_SOURCE::LABS_SOURCE(double s, double taylor_threshold) : DSRG_SOURCE(s, tay
 DYSON_SOURCE::DYSON_SOURCE(double s, double taylor_threshold) : DSRG_SOURCE(s, taylor_threshold) {}
 
 MP2_SOURCE::MP2_SOURCE(double s, double taylor_threshold) : DSRG_SOURCE(s, taylor_threshold) {}
-}
+} // namespace forte

--- a/forte/mrdsrg-helper/dsrg_source.h
+++ b/forte/mrdsrg-helper/dsrg_source.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -30,7 +30,6 @@
 #define _dsrg_source_h_
 
 #include <cmath>
-
 
 namespace forte {
 
@@ -176,6 +175,6 @@ class MP2_SOURCE : public DSRG_SOURCE {
 
     virtual double compute_renormalized_denominator(const double& D) { return 1.0 / D; }
 };
-}
+} // namespace forte
 
 #endif // DSRG_SOURCE_H

--- a/forte/mrdsrg-helper/dsrg_time.cc
+++ b/forte/mrdsrg-helper/dsrg_time.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-helper/dsrg_time.h
+++ b/forte/mrdsrg-helper/dsrg_time.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -90,6 +90,6 @@ class DSRG_TIME {
     /// Test code
     bool test_code(const std::string& code);
 };
-}
+} // namespace forte
 
 #endif // DSRG_TIME_H

--- a/forte/mrdsrg-helper/run_dsrg.cc
+++ b/forte/mrdsrg-helper/run_dsrg.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/mrdsrg-so/mrdsrg_so.cc
+++ b/forte/mrdsrg-so/mrdsrg_so.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-so/mrdsrg_so.h
+++ b/forte/mrdsrg-so/mrdsrg_so.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -30,7 +30,6 @@
 #define _mrdsrg_so_h_
 
 #include <cmath>
-
 
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libpsio/psio.hpp"

--- a/forte/mrdsrg-so/so-mrdsrg.cc
+++ b/forte/mrdsrg-so/so-mrdsrg.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-so/so-mrdsrg.h
+++ b/forte/mrdsrg-so/so-mrdsrg.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -210,6 +210,6 @@ class SOMRDSRG : public DynamicCorrelationSolver {
     /// The frozen-core energy
     double frozen_core_energy;
 };
-}
+} // namespace forte
 
 #endif // _so_mrdsrg_h_

--- a/forte/mrdsrg-spin-adapted/dsrg_mrpt.cc
+++ b/forte/mrdsrg-spin-adapted/dsrg_mrpt.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-adapted/dsrg_mrpt.h
+++ b/forte/mrdsrg-spin-adapted/dsrg_mrpt.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -30,7 +30,6 @@
 #define _dsrg_mrpt_h_
 
 #include <cmath>
-
 
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libpsio/psio.hpp"

--- a/forte/mrdsrg-spin-adapted/dsrg_mrpt_2nd.cc
+++ b/forte/mrdsrg-spin-adapted/dsrg_mrpt_2nd.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -174,9 +174,8 @@ void DSRG_MRPT::BT_scaled_by_Rplus1(BlockedTensor& BT) {
     if (BT.rank() == 4) {
         BT.iterate([&](const std::vector<size_t>& i, const std::vector<SpinType>&, double& value) {
             if (std::fabs(value) > 1.0e-15) {
-                value *= 1.0 +
-                         dsrg_source_->compute_renormalized(Fdiag_[i[0]] + Fdiag_[i[1]] -
-                                                            Fdiag_[i[2]] - Fdiag_[i[3]]);
+                value *= 1.0 + dsrg_source_->compute_renormalized(Fdiag_[i[0]] + Fdiag_[i[1]] -
+                                                                  Fdiag_[i[2]] - Fdiag_[i[3]]);
             } else {
                 value = 0.0; // ignore all noise
             }
@@ -224,4 +223,3 @@ void DSRG_MRPT::BT_scaled_by_RD(BlockedTensor& BT) {
     }
 }
 } // namespace forte
-

--- a/forte/mrdsrg-spin-adapted/dsrg_mrpt_amp.cc
+++ b/forte/mrdsrg-spin-adapted/dsrg_mrpt_amp.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -34,7 +34,6 @@
 #include "dsrg_mrpt.h"
 #include "helpers/timer.h"
 #include "helpers/printing.h"
-
 
 using namespace psi;
 
@@ -356,9 +355,10 @@ void DSRG_MRPT::print_intruder(const std::string& name,
             double down = fi + fj - fa - fb;
             double v = datapair.second;
 
-            output += "\n" + indent + str(boost::format("[%3d %3d %3d %3d] %13.8f (%10.6f + "
-                                                        "%10.6f - %10.6f - %10.6f = %10.6f)") %
-                                          i % j % a % b % v % fi % fj % fa % fb % down);
+            output += "\n" + indent +
+                      str(boost::format("[%3d %3d %3d %3d] %13.8f (%10.6f + "
+                                        "%10.6f - %10.6f - %10.6f = %10.6f)") %
+                          i % j % a % b % v % fi % fj % fa % fb % down);
         }
     } else {
         outfile->Printf("\n    Printing of amplitude is implemented only for T1 and T2!");
@@ -373,4 +373,3 @@ void DSRG_MRPT::print_intruder(const std::string& name,
     outfile->Printf("\n%s", output.c_str());
 }
 } // namespace forte
-

--- a/forte/mrdsrg-spin-adapted/dsrg_mrpt_comm.cc
+++ b/forte/mrdsrg-spin-adapted/dsrg_mrpt_comm.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -427,4 +427,3 @@ void DSRG_MRPT::H2_T2_C0_L3(BlockedTensor& H2, BlockedTensor& T2, const double& 
     dsrg_time_.add("220", timer.get());
 }
 } // namespace forte
-

--- a/forte/mrdsrg-spin-adapted/sa_dsrgpt.cc
+++ b/forte/mrdsrg-spin-adapted/sa_dsrgpt.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/mrdsrg-spin-adapted/sa_dsrgpt.h
+++ b/forte/mrdsrg-spin-adapted/sa_dsrgpt.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-adapted/sa_ldsrg2.cc
+++ b/forte/mrdsrg-spin-adapted/sa_ldsrg2.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/mrdsrg-spin-adapted/sa_mrdsrg.cc
+++ b/forte/mrdsrg-spin-adapted/sa_mrdsrg.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-adapted/sa_mrdsrg.h
+++ b/forte/mrdsrg-spin-adapted/sa_mrdsrg.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-adapted/sa_mrdsrg_amps.cc
+++ b/forte/mrdsrg-spin-adapted/sa_mrdsrg_amps.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-adapted/sa_mrdsrg_diis.cc
+++ b/forte/mrdsrg-spin-adapted/sa_mrdsrg_diis.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -36,7 +36,8 @@ namespace forte {
 
 void SA_MRDSRG::diis_manager_init() {
     diis_manager_ = std::make_shared<DIISManager>(diis_max_vec_, "SA_MRDSRG DIIS",
-                                                  DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::OnDisk);
+                                                  DIISManager::RemovalPolicy::LargestError,
+                                                  DIISManager::StoragePolicy::OnDisk);
 
     amp_ptrs_.clear();
     res_ptrs_.clear();
@@ -60,22 +61,26 @@ void SA_MRDSRG::diis_manager_init() {
     }
 
     diis_manager_->set_error_vector_size(
-        18, DIISEntry::InputType::Pointer, sizes[0], DIISEntry::InputType::Pointer, sizes[1], DIISEntry::InputType::Pointer,
-        sizes[2], DIISEntry::InputType::Pointer, sizes[3], DIISEntry::InputType::Pointer, sizes[4], DIISEntry::InputType::Pointer,
-        sizes[5], DIISEntry::InputType::Pointer, sizes[6], DIISEntry::InputType::Pointer, sizes[7], DIISEntry::InputType::Pointer,
-        sizes[8], DIISEntry::InputType::Pointer, sizes[9], DIISEntry::InputType::Pointer, sizes[10], DIISEntry::InputType::Pointer,
-        sizes[11], DIISEntry::InputType::Pointer, sizes[12], DIISEntry::InputType::Pointer, sizes[13], DIISEntry::InputType::Pointer,
-        sizes[14], DIISEntry::InputType::Pointer, sizes[15], DIISEntry::InputType::Pointer, sizes[16], DIISEntry::InputType::Pointer,
-        sizes[17]);
+        18, DIISEntry::InputType::Pointer, sizes[0], DIISEntry::InputType::Pointer, sizes[1],
+        DIISEntry::InputType::Pointer, sizes[2], DIISEntry::InputType::Pointer, sizes[3],
+        DIISEntry::InputType::Pointer, sizes[4], DIISEntry::InputType::Pointer, sizes[5],
+        DIISEntry::InputType::Pointer, sizes[6], DIISEntry::InputType::Pointer, sizes[7],
+        DIISEntry::InputType::Pointer, sizes[8], DIISEntry::InputType::Pointer, sizes[9],
+        DIISEntry::InputType::Pointer, sizes[10], DIISEntry::InputType::Pointer, sizes[11],
+        DIISEntry::InputType::Pointer, sizes[12], DIISEntry::InputType::Pointer, sizes[13],
+        DIISEntry::InputType::Pointer, sizes[14], DIISEntry::InputType::Pointer, sizes[15],
+        DIISEntry::InputType::Pointer, sizes[16], DIISEntry::InputType::Pointer, sizes[17]);
 
     diis_manager_->set_vector_size(
-        18, DIISEntry::InputType::Pointer, sizes[0], DIISEntry::InputType::Pointer, sizes[1], DIISEntry::InputType::Pointer,
-        sizes[2], DIISEntry::InputType::Pointer, sizes[3], DIISEntry::InputType::Pointer, sizes[4], DIISEntry::InputType::Pointer,
-        sizes[5], DIISEntry::InputType::Pointer, sizes[6], DIISEntry::InputType::Pointer, sizes[7], DIISEntry::InputType::Pointer,
-        sizes[8], DIISEntry::InputType::Pointer, sizes[9], DIISEntry::InputType::Pointer, sizes[10], DIISEntry::InputType::Pointer,
-        sizes[11], DIISEntry::InputType::Pointer, sizes[12], DIISEntry::InputType::Pointer, sizes[13], DIISEntry::InputType::Pointer,
-        sizes[14], DIISEntry::InputType::Pointer, sizes[15], DIISEntry::InputType::Pointer, sizes[16], DIISEntry::InputType::Pointer,
-        sizes[17]);
+        18, DIISEntry::InputType::Pointer, sizes[0], DIISEntry::InputType::Pointer, sizes[1],
+        DIISEntry::InputType::Pointer, sizes[2], DIISEntry::InputType::Pointer, sizes[3],
+        DIISEntry::InputType::Pointer, sizes[4], DIISEntry::InputType::Pointer, sizes[5],
+        DIISEntry::InputType::Pointer, sizes[6], DIISEntry::InputType::Pointer, sizes[7],
+        DIISEntry::InputType::Pointer, sizes[8], DIISEntry::InputType::Pointer, sizes[9],
+        DIISEntry::InputType::Pointer, sizes[10], DIISEntry::InputType::Pointer, sizes[11],
+        DIISEntry::InputType::Pointer, sizes[12], DIISEntry::InputType::Pointer, sizes[13],
+        DIISEntry::InputType::Pointer, sizes[14], DIISEntry::InputType::Pointer, sizes[15],
+        DIISEntry::InputType::Pointer, sizes[16], DIISEntry::InputType::Pointer, sizes[17]);
 }
 
 void SA_MRDSRG::diis_manager_add_entry() {

--- a/forte/mrdsrg-spin-adapted/sa_mrpt2.cc
+++ b/forte/mrdsrg-spin-adapted/sa_mrpt2.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/mrdsrg-spin-adapted/sa_mrpt2.h
+++ b/forte/mrdsrg-spin-adapted/sa_mrpt2.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-adapted/sa_mrpt3.cc
+++ b/forte/mrdsrg-spin-adapted/sa_mrpt3.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in
@@ -96,7 +96,6 @@ void SA_MRPT3::build_ints() {
 
     print_done(t.stop());
 }
-
 
 void SA_MRPT3::init_amps() {
     timer t("Initialize T1 and T2");

--- a/forte/mrdsrg-spin-adapted/sa_mrpt3.h
+++ b/forte/mrdsrg-spin-adapted/sa_mrpt3.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-adapted/sadsrg.cc
+++ b/forte/mrdsrg-spin-adapted/sadsrg.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-adapted/sadsrg.h
+++ b/forte/mrdsrg-spin-adapted/sadsrg.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-adapted/sadsrg_amps_analysis.cc
+++ b/forte/mrdsrg-spin-adapted/sadsrg_amps_analysis.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-adapted/sadsrg_block_labels.cc
+++ b/forte/mrdsrg-spin-adapted/sadsrg_block_labels.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-adapted/sadsrg_comm.cc
+++ b/forte/mrdsrg-spin-adapted/sadsrg_comm.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-integrated/dsrg_mrpt2.cc
+++ b/forte/mrdsrg-spin-integrated/dsrg_mrpt2.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/mrdsrg-spin-integrated/dsrg_mrpt2.h
+++ b/forte/mrdsrg-spin-integrated/dsrg_mrpt2.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-integrated/dsrg_mrpt2_ms.cc
+++ b/forte/mrdsrg-spin-integrated/dsrg_mrpt2_ms.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-integrated/dsrg_mrpt3.cc
+++ b/forte/mrdsrg-spin-integrated/dsrg_mrpt3.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-integrated/dsrg_mrpt3.h
+++ b/forte/mrdsrg-spin-integrated/dsrg_mrpt3.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-integrated/dwms_mrpt2.cc
+++ b/forte/mrdsrg-spin-integrated/dwms_mrpt2.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-integrated/dwms_mrpt2.h
+++ b/forte/mrdsrg-spin-integrated/dwms_mrpt2.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -25,7 +25,6 @@
  *
  * @END LICENSE
  */
-
 
 #ifndef _dwms_mrpt2_h_
 #define _dwms_mrpt2_h_
@@ -123,12 +122,13 @@ class DWMS_DSRGPT2 {
 
     /// perform DSRG-PT2/3 computation and return the dressed integrals within active space
     std::shared_ptr<ActiveSpaceIntegrals> compute_dsrg_pt(std::shared_ptr<MASTER_DSRG>& dsrg_pt,
-                                                  RDMs& reference, std::string level = "PT2");
+                                                          RDMs& reference,
+                                                          std::string level = "PT2");
 
     /// perform a macro DSRG-PT2/3 computation
-    std::shared_ptr<ActiveSpaceIntegrals> compute_macro_dsrg_pt(std::shared_ptr<MASTER_DSRG>& dsrg_pt,
-                                                        std::shared_ptr<FCI_MO> fci_mo, int entry,
-                                                        int root);
+    std::shared_ptr<ActiveSpaceIntegrals>
+    compute_macro_dsrg_pt(std::shared_ptr<MASTER_DSRG>& dsrg_pt, std::shared_ptr<FCI_MO> fci_mo,
+                          int entry, int root);
 
     /// compute DWSA energies
     void compute_dwsa_energy(std::shared_ptr<FCI_MO>& fci_mo);
@@ -152,8 +152,7 @@ class DWMS_DSRGPT2 {
                    ambit::Tensor& H3bbb);
 
     /// contract H with transition densities
-    double contract_Heff_1TrDM(ambit::Tensor& H1a, ambit::Tensor& H1b, RDMs& TrD,
-                               bool transpose);
+    double contract_Heff_1TrDM(ambit::Tensor& H1a, ambit::Tensor& H1b, RDMs& TrD, bool transpose);
     double contract_Heff_2TrDM(ambit::Tensor& H2aa, ambit::Tensor& H2ab, ambit::Tensor& H2bb,
                                RDMs& TrD, bool transpose);
     double contract_Heff_3TrDM(ambit::Tensor& H3aaa, ambit::Tensor& H3aab, ambit::Tensor& H3abb,

--- a/forte/mrdsrg-spin-integrated/mcsrgpt2_mo.cc
+++ b/forte/mrdsrg-spin-integrated/mcsrgpt2_mo.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-integrated/mcsrgpt2_mo.h
+++ b/forte/mrdsrg-spin-integrated/mcsrgpt2_mo.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-integrated/mrdsrg.cc
+++ b/forte/mrdsrg-spin-integrated/mrdsrg.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-integrated/mrdsrg.h
+++ b/forte/mrdsrg-spin-integrated/mrdsrg.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-integrated/mrdsrg_amplitude.cc
+++ b/forte/mrdsrg-spin-integrated/mrdsrg_amplitude.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-integrated/mrdsrg_commutator.cc
+++ b/forte/mrdsrg-spin-integrated/mrdsrg_commutator.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/mrdsrg-spin-integrated/mrdsrg_diis.cc
+++ b/forte/mrdsrg-spin-integrated/mrdsrg_diis.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -101,7 +101,8 @@ void MRDSRG::return_amp_diis(BlockedTensor& T1, const std::vector<std::string>& 
 
 void MRDSRG::diis_manager_init() {
     diis_manager_ = std::make_shared<DIISManager>(diis_max_vec_, "MRDSRG DIIS",
-                                                  DIISManager::RemovalPolicy::LargestError, DIISManager::StoragePolicy::OnDisk);
+                                                  DIISManager::RemovalPolicy::LargestError,
+                                                  DIISManager::StoragePolicy::OnDisk);
 
     amp_ptrs_.clear();
     res_ptrs_.clear();
@@ -128,44 +129,60 @@ void MRDSRG::diis_manager_init() {
     }
 
     diis_manager_->set_error_vector_size(
-        51, DIISEntry::InputType::Pointer, sizes[0], DIISEntry::InputType::Pointer, sizes[1], DIISEntry::InputType::Pointer,
-        sizes[2], DIISEntry::InputType::Pointer, sizes[3], DIISEntry::InputType::Pointer, sizes[4], DIISEntry::InputType::Pointer,
-        sizes[5], DIISEntry::InputType::Pointer, sizes[6], DIISEntry::InputType::Pointer, sizes[7], DIISEntry::InputType::Pointer,
-        sizes[8], DIISEntry::InputType::Pointer, sizes[9], DIISEntry::InputType::Pointer, sizes[10], DIISEntry::InputType::Pointer,
-        sizes[11], DIISEntry::InputType::Pointer, sizes[12], DIISEntry::InputType::Pointer, sizes[13], DIISEntry::InputType::Pointer,
-        sizes[14], DIISEntry::InputType::Pointer, sizes[15], DIISEntry::InputType::Pointer, sizes[16], DIISEntry::InputType::Pointer,
-        sizes[17], DIISEntry::InputType::Pointer, sizes[18], DIISEntry::InputType::Pointer, sizes[19], DIISEntry::InputType::Pointer,
-        sizes[20], DIISEntry::InputType::Pointer, sizes[21], DIISEntry::InputType::Pointer, sizes[22], DIISEntry::InputType::Pointer,
-        sizes[23], DIISEntry::InputType::Pointer, sizes[24], DIISEntry::InputType::Pointer, sizes[25], DIISEntry::InputType::Pointer,
-        sizes[26], DIISEntry::InputType::Pointer, sizes[27], DIISEntry::InputType::Pointer, sizes[28], DIISEntry::InputType::Pointer,
-        sizes[29], DIISEntry::InputType::Pointer, sizes[30], DIISEntry::InputType::Pointer, sizes[31], DIISEntry::InputType::Pointer,
-        sizes[32], DIISEntry::InputType::Pointer, sizes[33], DIISEntry::InputType::Pointer, sizes[34], DIISEntry::InputType::Pointer,
-        sizes[35], DIISEntry::InputType::Pointer, sizes[36], DIISEntry::InputType::Pointer, sizes[37], DIISEntry::InputType::Pointer,
-        sizes[38], DIISEntry::InputType::Pointer, sizes[39], DIISEntry::InputType::Pointer, sizes[40], DIISEntry::InputType::Pointer,
-        sizes[41], DIISEntry::InputType::Pointer, sizes[42], DIISEntry::InputType::Pointer, sizes[43], DIISEntry::InputType::Pointer,
-        sizes[44], DIISEntry::InputType::Pointer, sizes[45], DIISEntry::InputType::Pointer, sizes[46], DIISEntry::InputType::Pointer,
-        sizes[47], DIISEntry::InputType::Pointer, sizes[48], DIISEntry::InputType::Pointer, sizes[49], DIISEntry::InputType::Pointer,
-        sizes[50]);
+        51, DIISEntry::InputType::Pointer, sizes[0], DIISEntry::InputType::Pointer, sizes[1],
+        DIISEntry::InputType::Pointer, sizes[2], DIISEntry::InputType::Pointer, sizes[3],
+        DIISEntry::InputType::Pointer, sizes[4], DIISEntry::InputType::Pointer, sizes[5],
+        DIISEntry::InputType::Pointer, sizes[6], DIISEntry::InputType::Pointer, sizes[7],
+        DIISEntry::InputType::Pointer, sizes[8], DIISEntry::InputType::Pointer, sizes[9],
+        DIISEntry::InputType::Pointer, sizes[10], DIISEntry::InputType::Pointer, sizes[11],
+        DIISEntry::InputType::Pointer, sizes[12], DIISEntry::InputType::Pointer, sizes[13],
+        DIISEntry::InputType::Pointer, sizes[14], DIISEntry::InputType::Pointer, sizes[15],
+        DIISEntry::InputType::Pointer, sizes[16], DIISEntry::InputType::Pointer, sizes[17],
+        DIISEntry::InputType::Pointer, sizes[18], DIISEntry::InputType::Pointer, sizes[19],
+        DIISEntry::InputType::Pointer, sizes[20], DIISEntry::InputType::Pointer, sizes[21],
+        DIISEntry::InputType::Pointer, sizes[22], DIISEntry::InputType::Pointer, sizes[23],
+        DIISEntry::InputType::Pointer, sizes[24], DIISEntry::InputType::Pointer, sizes[25],
+        DIISEntry::InputType::Pointer, sizes[26], DIISEntry::InputType::Pointer, sizes[27],
+        DIISEntry::InputType::Pointer, sizes[28], DIISEntry::InputType::Pointer, sizes[29],
+        DIISEntry::InputType::Pointer, sizes[30], DIISEntry::InputType::Pointer, sizes[31],
+        DIISEntry::InputType::Pointer, sizes[32], DIISEntry::InputType::Pointer, sizes[33],
+        DIISEntry::InputType::Pointer, sizes[34], DIISEntry::InputType::Pointer, sizes[35],
+        DIISEntry::InputType::Pointer, sizes[36], DIISEntry::InputType::Pointer, sizes[37],
+        DIISEntry::InputType::Pointer, sizes[38], DIISEntry::InputType::Pointer, sizes[39],
+        DIISEntry::InputType::Pointer, sizes[40], DIISEntry::InputType::Pointer, sizes[41],
+        DIISEntry::InputType::Pointer, sizes[42], DIISEntry::InputType::Pointer, sizes[43],
+        DIISEntry::InputType::Pointer, sizes[44], DIISEntry::InputType::Pointer, sizes[45],
+        DIISEntry::InputType::Pointer, sizes[46], DIISEntry::InputType::Pointer, sizes[47],
+        DIISEntry::InputType::Pointer, sizes[48], DIISEntry::InputType::Pointer, sizes[49],
+        DIISEntry::InputType::Pointer, sizes[50]);
 
     diis_manager_->set_vector_size(
-        51, DIISEntry::InputType::Pointer, sizes[0], DIISEntry::InputType::Pointer, sizes[1], DIISEntry::InputType::Pointer,
-        sizes[2], DIISEntry::InputType::Pointer, sizes[3], DIISEntry::InputType::Pointer, sizes[4], DIISEntry::InputType::Pointer,
-        sizes[5], DIISEntry::InputType::Pointer, sizes[6], DIISEntry::InputType::Pointer, sizes[7], DIISEntry::InputType::Pointer,
-        sizes[8], DIISEntry::InputType::Pointer, sizes[9], DIISEntry::InputType::Pointer, sizes[10], DIISEntry::InputType::Pointer,
-        sizes[11], DIISEntry::InputType::Pointer, sizes[12], DIISEntry::InputType::Pointer, sizes[13], DIISEntry::InputType::Pointer,
-        sizes[14], DIISEntry::InputType::Pointer, sizes[15], DIISEntry::InputType::Pointer, sizes[16], DIISEntry::InputType::Pointer,
-        sizes[17], DIISEntry::InputType::Pointer, sizes[18], DIISEntry::InputType::Pointer, sizes[19], DIISEntry::InputType::Pointer,
-        sizes[20], DIISEntry::InputType::Pointer, sizes[21], DIISEntry::InputType::Pointer, sizes[22], DIISEntry::InputType::Pointer,
-        sizes[23], DIISEntry::InputType::Pointer, sizes[24], DIISEntry::InputType::Pointer, sizes[25], DIISEntry::InputType::Pointer,
-        sizes[26], DIISEntry::InputType::Pointer, sizes[27], DIISEntry::InputType::Pointer, sizes[28], DIISEntry::InputType::Pointer,
-        sizes[29], DIISEntry::InputType::Pointer, sizes[30], DIISEntry::InputType::Pointer, sizes[31], DIISEntry::InputType::Pointer,
-        sizes[32], DIISEntry::InputType::Pointer, sizes[33], DIISEntry::InputType::Pointer, sizes[34], DIISEntry::InputType::Pointer,
-        sizes[35], DIISEntry::InputType::Pointer, sizes[36], DIISEntry::InputType::Pointer, sizes[37], DIISEntry::InputType::Pointer,
-        sizes[38], DIISEntry::InputType::Pointer, sizes[39], DIISEntry::InputType::Pointer, sizes[40], DIISEntry::InputType::Pointer,
-        sizes[41], DIISEntry::InputType::Pointer, sizes[42], DIISEntry::InputType::Pointer, sizes[43], DIISEntry::InputType::Pointer,
-        sizes[44], DIISEntry::InputType::Pointer, sizes[45], DIISEntry::InputType::Pointer, sizes[46], DIISEntry::InputType::Pointer,
-        sizes[47], DIISEntry::InputType::Pointer, sizes[48], DIISEntry::InputType::Pointer, sizes[49], DIISEntry::InputType::Pointer,
-        sizes[50]);
+        51, DIISEntry::InputType::Pointer, sizes[0], DIISEntry::InputType::Pointer, sizes[1],
+        DIISEntry::InputType::Pointer, sizes[2], DIISEntry::InputType::Pointer, sizes[3],
+        DIISEntry::InputType::Pointer, sizes[4], DIISEntry::InputType::Pointer, sizes[5],
+        DIISEntry::InputType::Pointer, sizes[6], DIISEntry::InputType::Pointer, sizes[7],
+        DIISEntry::InputType::Pointer, sizes[8], DIISEntry::InputType::Pointer, sizes[9],
+        DIISEntry::InputType::Pointer, sizes[10], DIISEntry::InputType::Pointer, sizes[11],
+        DIISEntry::InputType::Pointer, sizes[12], DIISEntry::InputType::Pointer, sizes[13],
+        DIISEntry::InputType::Pointer, sizes[14], DIISEntry::InputType::Pointer, sizes[15],
+        DIISEntry::InputType::Pointer, sizes[16], DIISEntry::InputType::Pointer, sizes[17],
+        DIISEntry::InputType::Pointer, sizes[18], DIISEntry::InputType::Pointer, sizes[19],
+        DIISEntry::InputType::Pointer, sizes[20], DIISEntry::InputType::Pointer, sizes[21],
+        DIISEntry::InputType::Pointer, sizes[22], DIISEntry::InputType::Pointer, sizes[23],
+        DIISEntry::InputType::Pointer, sizes[24], DIISEntry::InputType::Pointer, sizes[25],
+        DIISEntry::InputType::Pointer, sizes[26], DIISEntry::InputType::Pointer, sizes[27],
+        DIISEntry::InputType::Pointer, sizes[28], DIISEntry::InputType::Pointer, sizes[29],
+        DIISEntry::InputType::Pointer, sizes[30], DIISEntry::InputType::Pointer, sizes[31],
+        DIISEntry::InputType::Pointer, sizes[32], DIISEntry::InputType::Pointer, sizes[33],
+        DIISEntry::InputType::Pointer, sizes[34], DIISEntry::InputType::Pointer, sizes[35],
+        DIISEntry::InputType::Pointer, sizes[36], DIISEntry::InputType::Pointer, sizes[37],
+        DIISEntry::InputType::Pointer, sizes[38], DIISEntry::InputType::Pointer, sizes[39],
+        DIISEntry::InputType::Pointer, sizes[40], DIISEntry::InputType::Pointer, sizes[41],
+        DIISEntry::InputType::Pointer, sizes[42], DIISEntry::InputType::Pointer, sizes[43],
+        DIISEntry::InputType::Pointer, sizes[44], DIISEntry::InputType::Pointer, sizes[45],
+        DIISEntry::InputType::Pointer, sizes[46], DIISEntry::InputType::Pointer, sizes[47],
+        DIISEntry::InputType::Pointer, sizes[48], DIISEntry::InputType::Pointer, sizes[49],
+        DIISEntry::InputType::Pointer, sizes[50]);
 }
 
 void MRDSRG::diis_manager_add_entry() {

--- a/forte/mrdsrg-spin-integrated/mrdsrg_nonpt.cc
+++ b/forte/mrdsrg-spin-integrated/mrdsrg_nonpt.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/mrdsrg-spin-integrated/mrdsrg_pt.cc
+++ b/forte/mrdsrg-spin-integrated/mrdsrg_pt.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/mrdsrg-spin-integrated/mrdsrg_smart_s.cc
+++ b/forte/mrdsrg-spin-integrated/mrdsrg_smart_s.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -32,7 +32,6 @@
 
 #include "base_classes/mo_space_info.h"
 #include "mrdsrg.h"
-
 
 namespace forte {
 
@@ -187,4 +186,4 @@ double MRDSRG::smart_s_davg_max_delta1() {
 
     return Edelta;
 }
-}
+} // namespace forte

--- a/forte/mrdsrg-spin-integrated/mrdsrg_srg.cc
+++ b/forte/mrdsrg-spin-integrated/mrdsrg_srg.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/mrdsrg-spin-integrated/three_dsrg_mrpt2.cc
+++ b/forte/mrdsrg-spin-integrated/three_dsrg_mrpt2.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/mrdsrg-spin-integrated/three_dsrg_mrpt2.h
+++ b/forte/mrdsrg-spin-integrated/three_dsrg_mrpt2.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/orbital-helpers/ao_helper.cc
+++ b/forte/orbital-helpers/ao_helper.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/orbital-helpers/ao_helper.h
+++ b/forte/orbital-helpers/ao_helper.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/orbital-helpers/aosubspace.cc
+++ b/forte/orbital-helpers/aosubspace.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -125,8 +125,8 @@ AOSubspace::AOSubspace(std::vector<std::string> subspace_str,
                        std::shared_ptr<psi::Molecule> molecule,
                        std::shared_ptr<psi::BasisSet> minao_basis,
                        std::map<std::pair<int, int>, psi::Vector3> atom_normals, bool debug_mode)
-    : subspace_str_(subspace_str), molecule_(molecule), min_basis_(minao_basis), subspace_counter_(0),
-      atom_normals_(atom_normals), debug_(debug_mode) {
+    : subspace_str_(subspace_str), molecule_(molecule), min_basis_(minao_basis),
+      subspace_counter_(0), atom_normals_(atom_normals), debug_(debug_mode) {
     startup();
 }
 

--- a/forte/orbital-helpers/aosubspace.h
+++ b/forte/orbital-helpers/aosubspace.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/orbital-helpers/ci-no/ci-no.cc
+++ b/forte/orbital-helpers/ci-no/ci-no.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/orbital-helpers/ci-no/ci-no.h
+++ b/forte/orbital-helpers/ci-no/ci-no.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/orbital-helpers/ci-no/mrci-no.cc
+++ b/forte/orbital-helpers/ci-no/mrci-no.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/orbital-helpers/ci-no/mrci-no.h
+++ b/forte/orbital-helpers/ci-no/mrci-no.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/orbital-helpers/fragment_projector.cc
+++ b/forte/orbital-helpers/fragment_projector.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/orbital-helpers/fragment_projector.h
+++ b/forte/orbital-helpers/fragment_projector.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/orbital-helpers/localize.cc
+++ b/forte/orbital-helpers/localize.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/orbital-helpers/localize.h
+++ b/forte/orbital-helpers/localize.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -28,7 +28,6 @@
 
 #ifndef _localize_h_
 #define _localize_h_
-
 
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libmints/local.h"

--- a/forte/orbital-helpers/mp2_nos.cc
+++ b/forte/orbital-helpers/mp2_nos.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/orbital-helpers/mp2_nos.h
+++ b/forte/orbital-helpers/mp2_nos.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/orbital-helpers/orbital_embedding.cc
+++ b/forte/orbital-helpers/orbital_embedding.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/orbital-helpers/orbital_embedding.h
+++ b/forte/orbital-helpers/orbital_embedding.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -32,15 +32,16 @@
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/wavefunction.h"
 
-
 #include "base_classes/forte_options.h"
 #include "base_classes/mo_space_info.h"
 
 namespace forte {
 
-void make_avas(psi::SharedWavefunction ref_wfn, std::shared_ptr<ForteOptions> options, psi::SharedMatrix Ps);
+void make_avas(psi::SharedWavefunction ref_wfn, std::shared_ptr<ForteOptions> options,
+               psi::SharedMatrix Ps);
 
-std::shared_ptr<MOSpaceInfo> make_embedding(psi::SharedWavefunction ref_wfn, std::shared_ptr<ForteOptions> options,
+std::shared_ptr<MOSpaceInfo> make_embedding(psi::SharedWavefunction ref_wfn,
+                                            std::shared_ptr<ForteOptions> options,
                                             psi::SharedMatrix Pf, int nbf_A,
                                             std::shared_ptr<MOSpaceInfo> mo_space_info);
 

--- a/forte/orbital-helpers/orbitaloptimizer.cc
+++ b/forte/orbital-helpers/orbitaloptimizer.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/orbital-helpers/orbitaloptimizer.h
+++ b/forte/orbital-helpers/orbitaloptimizer.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/orbital-helpers/pao_builder.cc
+++ b/forte/orbital-helpers/pao_builder.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/orbital-helpers/pao_builder.h
+++ b/forte/orbital-helpers/pao_builder.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/orbital-helpers/semi_canonicalize.cc
+++ b/forte/orbital-helpers/semi_canonicalize.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/orbital-helpers/semi_canonicalize.h
+++ b/forte/orbital-helpers/semi_canonicalize.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/orbital-helpers/unpaired_density.cc
+++ b/forte/orbital-helpers/unpaired_density.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -36,7 +36,6 @@
 #include "psi4/libmints/local.h"
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/vector.h"
-
 
 #include "base_classes/forte_options.h"
 #include "unpaired_density.h"

--- a/forte/orbital-helpers/unpaired_density.h
+++ b/forte/orbital-helpers/unpaired_density.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -28,7 +28,6 @@
 
 #ifndef _updensity_h_
 #define _updensity_h_
-
 
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libmints/local.h"

--- a/forte/pci/pci.cc
+++ b/forte/pci/pci.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in
@@ -266,7 +266,7 @@ void ProjectorCI::set_options(std::shared_ptr<ForteOptions> options) {
     int ms = wavefunction_multiplicity_ - 1;
     std::vector<Determinant> reference_vec;
     CI_Reference ref(scf_info_, options, mo_space_info_, as_ints_, wavefunction_multiplicity_, ms,
-                     wavefunction_symmetry_,state_);
+                     wavefunction_symmetry_, state_);
     ref.set_ref_type("HF");
     ref.build_reference(reference_vec);
     reference_determinant_ = reference_vec[0];

--- a/forte/pci/pci.h
+++ b/forte/pci/pci.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in
@@ -69,9 +69,9 @@ class ProjectorCI : public SelectedCIMethod {
      * @param options The main options object
      * @param ints A pointer to an allocated integral object
      */
-    ProjectorCI(StateInfo state, size_t nroot, std::shared_ptr<forte::SCFInfo> scf_info, std::shared_ptr<ForteOptions> options,
-                  std::shared_ptr<MOSpaceInfo> mo_space_info,
-                  std::shared_ptr<ActiveSpaceIntegrals> as_ints);
+    ProjectorCI(StateInfo state, size_t nroot, std::shared_ptr<forte::SCFInfo> scf_info,
+                std::shared_ptr<ForteOptions> options, std::shared_ptr<MOSpaceInfo> mo_space_info,
+                std::shared_ptr<ActiveSpaceIntegrals> as_ints);
 
     // ==> Class Interface <==
 
@@ -338,7 +338,8 @@ class ProjectorCI : public SelectedCIMethod {
     double estimate_var_energy_sparse(const det_hashvec& dets_hashvec, std::vector<double>& C,
                                       double max_error = 0.0);
     /// Form the product H c
-    double form_H_C(const det_hashvec& dets_hashvec, std::vector<double>& C, size_t I, size_t &thread_num_off_diag_elem);
+    double form_H_C(const det_hashvec& dets_hashvec, std::vector<double>& C, size_t I,
+                    size_t& thread_num_off_diag_elem);
     /// Form the product H c
     double form_H_C_2(const det_hashvec& dets_hashvec, std::vector<double>& C, size_t I,
                       size_t cut_index);

--- a/forte/pci/pci_sigma.cc
+++ b/forte/pci/pci_sigma.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/pci/pci_sigma.h
+++ b/forte/pci/pci_sigma.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/post_process/spin_corr.cc
+++ b/forte/post_process/spin_corr.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/post_process/spin_corr.h
+++ b/forte/post_process/spin_corr.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -41,24 +41,22 @@
 
 namespace forte {
 
-
 /**
  * @brief The SpinCorr class
- * This class computes the spin correlation from RDMs 
+ * This class computes the spin correlation from RDMs
  */
 class SpinCorr {
 
   public:
+    SpinCorr(RDMs rdms, std::shared_ptr<ForteOptions> options,
+             std::shared_ptr<MOSpaceInfo> mo_space_info,
+             std::shared_ptr<ActiveSpaceIntegrals> as_ints);
 
-    SpinCorr(RDMs rdms, std::shared_ptr<ForteOptions> options, std::shared_ptr<MOSpaceInfo> mo_space_info,
-            std::shared_ptr<ActiveSpaceIntegrals> as_ints);
-    
     std::pair<psi::SharedMatrix, psi::SharedMatrix> compute_nos();
-    
-    void spin_analysis();
-    
-  private:
 
+    void spin_analysis();
+
+  private:
     RDMs rdms_;
 
     std::shared_ptr<ForteOptions> options_;
@@ -74,7 +72,9 @@ class SpinCorr {
     psi::Dimension nactpi_;
 };
 
-void perform_spin_analysis(RDMs rdms, std::shared_ptr<ForteOptions> options, std::shared_ptr<MOSpaceInfo> mo_space_info,std::shared_ptr<ActiveSpaceIntegrals> as_ints);
+void perform_spin_analysis(RDMs rdms, std::shared_ptr<ForteOptions> options,
+                           std::shared_ptr<MOSpaceInfo> mo_space_info,
+                           std::shared_ptr<ActiveSpaceIntegrals> as_ints);
 
 } // namespace forte
 

--- a/forte/sci/aci.cc
+++ b/forte/sci/aci.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/sci/aci.h
+++ b/forte/sci/aci.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/sci/aci_build_F.cc
+++ b/forte/sci/aci_build_F.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/sci/asci.cc
+++ b/forte/sci/asci.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/sci/asci.h
+++ b/forte/sci/asci.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -177,8 +177,8 @@ class ASCI : public SelectedCIMethod {
 
     /// Compute the RDMs
     void compute_rdms(std::shared_ptr<ActiveSpaceIntegrals> fci_ints, DeterminantHashVec& dets,
-                      DeterminantSubstitutionLists& op, psi::SharedMatrix& PQ_evecs, int root1, int root2,
-                      int max_level);
+                      DeterminantSubstitutionLists& op, psi::SharedMatrix& PQ_evecs, int root1,
+                      int root2, int max_level);
 
     void add_bad_roots(DeterminantHashVec& dets);
 

--- a/forte/sci/fci_mo.cc
+++ b/forte/sci/fci_mo.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/sci/fci_mo.h
+++ b/forte/sci/fci_mo.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/sci/gasaci_build_F.cc
+++ b/forte/sci/gasaci_build_F.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/sci/mrpt2.cc
+++ b/forte/sci/mrpt2.cc
@@ -6,7 +6,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/sci/mrpt2.h
+++ b/forte/sci/mrpt2.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/sci/sci.cc
+++ b/forte/sci/sci.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/sci/sci.h
+++ b/forte/sci/sci.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/solvers/active_space_solver.py
+++ b/forte/solvers/active_space_solver.py
@@ -1,11 +1,10 @@
 from forte.core import flog
 
 from forte.solvers.solver import Feature, Solver
-
-from forte.forte import ForteOptions
+from forte import ForteOptions
 from forte import to_state_nroots_map
 from forte import forte_options
-from forte.forte import make_active_space_ints, make_active_space_solver
+from forte import make_active_space_ints, make_active_space_solver
 
 
 class ActiveSpaceSolver(Solver):

--- a/forte/solvers/hf.py
+++ b/forte/solvers/hf.py
@@ -2,7 +2,7 @@ from forte.core import flog
 
 from forte.solvers.solver import Feature, Solver
 from forte.model import MolecularModel
-from forte.forte import SCFInfo
+from forte import SCFInfo
 
 
 class HF(Solver):

--- a/forte/solvers/solver.py
+++ b/forte/solvers/solver.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 from enum import Enum, auto
 
-from forte.forte import StateInfo
+from forte import StateInfo
 from forte.core import flog, increase_log_depth
 from forte.solvers.callback_handler import CallbackHandler
 from forte.data import Data

--- a/forte/solvers/spin_analysis.py
+++ b/forte/solvers/spin_analysis.py
@@ -4,7 +4,7 @@ from forte import forte_options
 from forte import ForteOptions
 from forte.solvers.solver import Feature, Solver
 from forte.solvers.callback_handler import CallbackHandler
-from forte.forte import perform_spin_analysis
+from forte import perform_spin_analysis
 
 
 class SpinAnalysis(Solver):

--- a/forte/sparse_ci/bitarray.hpp
+++ b/forte/sparse_ci/bitarray.hpp
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/sparse_ci/ci_reference.cc
+++ b/forte/sparse_ci/ci_reference.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -196,7 +196,7 @@ CI_Reference::gas_double_criterion() {
         aa_criterion;
     std::map<std::vector<int>, std::vector<std::tuple<size_t, size_t, size_t, size_t>>>
         bb_criterion;
-        
+
     std::map<std::vector<int>, std::vector<std::tuple<size_t, size_t, size_t, size_t>>>
         ab_criterion;
     for (size_t gas_config = 0; gas_config < gas_config_number; ++gas_config) {

--- a/forte/sparse_ci/ci_reference.h
+++ b/forte/sparse_ci/ci_reference.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/sparse_ci/determinant.h
+++ b/forte/sparse_ci/determinant.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/sparse_ci/determinant.hpp
+++ b/forte/sparse_ci/determinant.hpp
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in
@@ -174,7 +174,8 @@ template <size_t N> class DeterminantImpl : public BitArray<N> {
         if (norb > nbits_half) {
             throw std::range_error(
                 "Determinant::get_alfa_occ(int norb) was passed a value of norb (" +
-                std::to_string(norb) + "), which is larger than the maximum number of alpha orbitals (" +
+                std::to_string(norb) +
+                "), which is larger than the maximum number of alpha orbitals (" +
                 std::to_string(nbits_half) + ").");
         }
         for (int p = 0; p < norb; ++p) {
@@ -191,7 +192,8 @@ template <size_t N> class DeterminantImpl : public BitArray<N> {
         if (norb > nbits_half) {
             throw std::range_error(
                 "Determinant::get_beta_occ(int norb) was passed a value of norb (" +
-                std::to_string(norb) + "), which is larger than the maximum number of beta orbitals (" +
+                std::to_string(norb) +
+                "), which is larger than the maximum number of beta orbitals (" +
                 std::to_string(nbits_half) + ").");
         }
         for (int p = 0; p < norb; ++p) {
@@ -208,7 +210,8 @@ template <size_t N> class DeterminantImpl : public BitArray<N> {
         if (norb > nbits_half) {
             throw std::range_error(
                 "Determinant::get_alfa_occ(int norb) was passed a value of norb (" +
-                std::to_string(norb) + "), which is larger than the maximum number of alpha orbitals (" +
+                std::to_string(norb) +
+                "), which is larger than the maximum number of alpha orbitals (" +
                 std::to_string(nbits_half) + ").");
         }
         for (int p = 0; p < norb; ++p) {
@@ -225,7 +228,8 @@ template <size_t N> class DeterminantImpl : public BitArray<N> {
         if (norb > nbits_half) {
             throw std::range_error(
                 "Determinant::get_beta_occ(int norb) was passed a value of norb (" +
-                std::to_string(norb) + "), which is larger than the maximum number of beta orbitals (" +
+                std::to_string(norb) +
+                "), which is larger than the maximum number of beta orbitals (" +
                 std::to_string(nbits_half) + ").");
         }
         for (int p = 0; p < norb; ++p) {

--- a/forte/sparse_ci/determinant_functions.cc
+++ b/forte/sparse_ci/determinant_functions.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/sparse_ci/determinant_hashvector.cc
+++ b/forte/sparse_ci/determinant_hashvector.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/sparse_ci/determinant_hashvector.h
+++ b/forte/sparse_ci/determinant_hashvector.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/sparse_ci/determinant_substitution_lists.cc
+++ b/forte/sparse_ci/determinant_substitution_lists.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/sparse_ci/determinant_substitution_lists.h
+++ b/forte/sparse_ci/determinant_substitution_lists.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/sparse_ci/sigma_vector.cc
+++ b/forte/sparse_ci/sigma_vector.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -71,7 +71,8 @@ SigmaVectorFull::SigmaVectorFull(const DeterminantHashVec& space,
                                  std::shared_ptr<ActiveSpaceIntegrals> fci_ints)
     : SigmaVector(space, fci_ints, SigmaVectorType::Full, "SigmaVectorFull") {}
 
-void SigmaVectorFull::add_bad_roots(std::vector<std::vector<std::pair<size_t, double>>>& /*roots*/) {}
+void SigmaVectorFull::add_bad_roots(
+    std::vector<std::vector<std::pair<size_t, double>>>& /*roots*/) {}
 
 void SigmaVectorFull::get_diagonal(psi::Vector& /*diag*/) {}
 

--- a/forte/sparse_ci/sigma_vector.h
+++ b/forte/sparse_ci/sigma_vector.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/sparse_ci/sigma_vector_dynamic.cc
+++ b/forte/sparse_ci/sigma_vector_dynamic.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/sparse_ci/sigma_vector_dynamic.h
+++ b/forte/sparse_ci/sigma_vector_dynamic.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in

--- a/forte/sparse_ci/sigma_vector_sparse_list.cc
+++ b/forte/sparse_ci/sigma_vector_sparse_list.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/sparse_ci/sigma_vector_sparse_list.h
+++ b/forte/sparse_ci/sigma_vector_sparse_list.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/sparse_ci/sorted_string_list.cc
+++ b/forte/sparse_ci/sorted_string_list.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in
@@ -37,8 +37,8 @@ namespace forte {
 SortedStringList::SortedStringList() {}
 
 SortedStringList::SortedStringList(const DeterminantHashVec& space,
-                                             std::shared_ptr<ActiveSpaceIntegrals> fci_ints,
-                                             DetSpinType sorted_string_spin) {
+                                   std::shared_ptr<ActiveSpaceIntegrals> fci_ints,
+                                   DetSpinType sorted_string_spin) {
     nmo_ = fci_ints->nmo();
     // Copy and sort the determinants
     auto dets = space.determinants();
@@ -108,13 +108,9 @@ SortedStringList::SortedStringList(const DeterminantHashVec& space,
 
 SortedStringList::~SortedStringList() {}
 
-const std::vector<Determinant>& SortedStringList::sorted_dets() const {
-    return sorted_dets_;
-}
+const std::vector<Determinant>& SortedStringList::sorted_dets() const { return sorted_dets_; }
 
-const std::vector<String>& SortedStringList::sorted_half_dets() const {
-    return sorted_half_dets_;
-}
+const std::vector<String>& SortedStringList::sorted_half_dets() const { return sorted_half_dets_; }
 
 const std::pair<size_t, size_t>& SortedStringList::range(const String& d) const {
     return first_string_range_.at(d);

--- a/forte/sparse_ci/sorted_string_list.h
+++ b/forte/sparse_ci/sorted_string_list.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER,
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER,
  * AUTHORS).
  *
  * The copyrights for code used from other parties are included in
@@ -43,8 +43,8 @@ namespace forte {
 class SortedStringList {
   public:
     SortedStringList(const DeterminantHashVec& space,
-                          std::shared_ptr<ActiveSpaceIntegrals> fci_ints,
-                          DetSpinType sorted_string_spin);
+                     std::shared_ptr<ActiveSpaceIntegrals> fci_ints,
+                     DetSpinType sorted_string_spin);
 
     SortedStringList();
     ~SortedStringList();

--- a/forte/sparse_ci/sparse_ci_solver.cc
+++ b/forte/sparse_ci/sparse_ci_solver.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -662,7 +662,8 @@ bool SparseCISolver::davidson_liu_solver(const DeterminantHashVec& space,
     }
 
     if (converged != SolverStatus::Converged) {
-        std::string msg = "\n  The Davidson-Liu algorithm did not converge! Consider increasing the option DL_MAXITER.";
+        std::string msg = "\n  The Davidson-Liu algorithm did not converge! Consider increasing "
+                          "the option DL_MAXITER.";
         throw std::runtime_error(msg);
     }
 

--- a/forte/sparse_ci/sparse_ci_solver.h
+++ b/forte/sparse_ci/sparse_ci_solver.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -174,7 +174,8 @@ class SparseCISolver {
 
     /// Set the initial guess?
     bool set_guess_ = false;
-    std::vector<std::vector<std::pair<size_t, double>>> guess_; // nroot of guess size of (id, coefficent)
+    std::vector<std::vector<std::pair<size_t, double>>>
+        guess_; // nroot of guess size of (id, coefficent)
     // Number of guess vectors
     size_t nvec_ = 10;
 };

--- a/forte/sparse_ci/sparse_exp.cc
+++ b/forte/sparse_ci/sparse_exp.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -43,8 +43,7 @@ StateVector SparseExp::compute(const SparseOperator& sop, const StateVector& sta
     Algorithm alg = Algorithm::Cached;
     if (algorithm == "onthefly") {
         alg = Algorithm::OnTheFlySorted;
-    }
-    else if (algorithm == "ontheflystd") {
+    } else if (algorithm == "ontheflystd") {
         alg = Algorithm::OnTheFlyStd;
     }
 
@@ -267,7 +266,8 @@ StateVector SparseExp::apply_operator_sorted(const SparseOperator& sop, const St
                 if (std::fabs(sqop.coefficient() * c) > screen_thresh) {
                     // check if this operator can be applied
                     if (d.fast_a_and_b_equal_b(sqop.cre()) and d.fast_a_and_b_eq_zero(ucre)) {
-                        double value = apply_op_safe(d, sqop.ann(), sqop.cre()) * sqop.coefficient() * c;
+                        double value =
+                            apply_op_safe(d, sqop.ann(), sqop.cre()) * sqop.coefficient() * c;
                         new_terms[d] -= value;
                         num_success_++;
                     }
@@ -306,7 +306,8 @@ StateVector SparseExp::apply_operator_std(const SparseOperator& sop, const State
                 // check if this operator can be applied
                 if (d.fast_a_and_b_equal_b(sqop.ann()) and d.fast_a_and_b_eq_zero(ucre)) {
                     new_d = d;
-                    double value = apply_op_safe(new_d, sqop.cre(), sqop.ann()) * sqop.coefficient() * c;
+                    double value =
+                        apply_op_safe(new_d, sqop.cre(), sqop.ann()) * sqop.coefficient() * c;
                     new_terms[new_d] += value;
                 }
             }

--- a/forte/sparse_ci/sparse_exp.h
+++ b/forte/sparse_ci/sparse_exp.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -42,15 +42,14 @@ namespace forte {
 /**
  * @brief The SparseFactExp class
  * This class implements an algorithm to apply the exponential of an operator to a state
- * 
+ *
  *    |state> -> exp(op) |state>
- * 
+ *
  */
 class SparseExp {
     enum class Algorithm { Cached, OnTheFlySorted, OnTheFlyStd };
 
   public:
-
     /// @brief Compute the exponential applied to a state via a Taylor expansion
     ///
     ///             exp(op) |state>
@@ -64,14 +63,14 @@ class SparseExp {
     /// @param sop the operator. Each term in this operator is applied in the order provided
     /// @param state the state to which the factorized exponential will be applied
     /// @param algorithm the algorithm used to compute the exponential. If algorithm = "onthefly"
-    /// this function will compute the factorized exponential using an on-the-fly implementation (slow).
-    /// If algorithm = "cached", a cached approach is used.
-    /// @param scaling_factor A scalar factor that multiplies the operator exponentiated. If set to -1.0
-    /// it allows to compute the inverse of the exponential exp(-op)
+    /// this function will compute the factorized exponential using an on-the-fly implementation
+    /// (slow). If algorithm = "cached", a cached approach is used.
+    /// @param scaling_factor A scalar factor that multiplies the operator exponentiated. If set to
+    /// -1.0 it allows to compute the inverse of the exponential exp(-op)
     /// @param maxk the maximum power of op used in the Taylor expansion of exp(op)
-    /// @param screen_thresh a threshold to select which elements of the operator applied to the state.
-    /// An operator in the form exp(t ...), where t is an amplitude, will be applied to a determinant
-    /// Phi_I with coefficient C_I if the product |t * C_I| > screen_threshold
+    /// @param screen_thresh a threshold to select which elements of the operator applied to the
+    /// state. An operator in the form exp(t ...), where t is an amplitude, will be applied to a
+    /// determinant Phi_I with coefficient C_I if the product |t * C_I| > screen_threshold
     StateVector compute(const SparseOperator& sop, const StateVector& state,
                         const std::string& algorithm = "cached", double scaling_factor = 1.0,
                         int maxk = 19, double screen_thresh = 1.0e-12);
@@ -88,7 +87,6 @@ class SparseExp {
                                       double screen_thresh);
     StateVector apply_operator_std(const SparseOperator& sop, const StateVector& state0,
                                    double screen_thresh);
-
 
     std::map<std::string, double> timings_;
     DeterminantHashVec exp_hash_;

--- a/forte/sparse_ci/sparse_fact_exp.cc
+++ b/forte/sparse_ci/sparse_fact_exp.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -49,7 +49,7 @@ StateVector SparseFactExp::compute(const SparseOperator& sop, const StateVector&
         if (sop.is_antihermitian()) {
             result = compute_cached(sop, state, inverse, screen_thresh);
         } else {
-            result = compute_on_the_fly_excitation(sop, state, inverse, screen_thresh);                                     
+            result = compute_on_the_fly_excitation(sop, state, inverse, screen_thresh);
         }
     }
     timings_["total"] += t.get();

--- a/forte/sparse_ci/sparse_fact_exp.h
+++ b/forte/sparse_ci/sparse_fact_exp.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/sparse_ci/sparse_hamiltonian.cc
+++ b/forte/sparse_ci/sparse_hamiltonian.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/sparse_ci/sparse_hamiltonian.h
+++ b/forte/sparse_ci/sparse_hamiltonian.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -65,7 +65,7 @@ class SparseHamiltonian {
     /// @param screen_thresh a threshold to select which elements of H are applied to the state
     StateVector compute_on_the_fly(const StateVector& state, double screen_thresh);
 
-    /// @return timings for this class    
+    /// @return timings for this class
     std::map<std::string, double> timings() const;
 
   private:
@@ -81,10 +81,10 @@ class SparseHamiltonian {
     /// A map that holds the list of the determinants obtained after applying H
     DeterminantHashVec sigma_hash_;
     /// A vector of determinant couplings
-    std::map<Determinant,std::vector<std::pair<size_t, double>>> couplings_;
+    std::map<Determinant, std::vector<std::pair<size_t, double>>> couplings_;
     // std::vector<std::tuple<size_t, size_t, double>> couplings_;
     /// A map that stores timing information
-    std::map<std::string,double> timings_;
+    std::map<std::string, double> timings_;
 };
 
 } // namespace forte

--- a/forte/sparse_ci/sparse_operator.cc
+++ b/forte/sparse_ci/sparse_operator.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -72,7 +72,7 @@ void SparseOperator::add_term_from_str(std::string str, double coefficient, bool
 
     // here we match terms of the form [<orb><a/b><+/-> ...], then parse the operator part
     // and translate it into a term that is added to the operator.
-    // 
+    //
     if (std::regex_match(str, m, re)) {
         if (m.ready()) {
             auto ops_vec_tuple = sparse_parse_ops(m[1]);

--- a/forte/sparse_ci/sparse_operator.h
+++ b/forte/sparse_ci/sparse_operator.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -48,13 +48,13 @@ class ActiveSpaceIntegrals;
  * For example:
  *   0.1 * [2a+ 0a-] - 0.5 * [2a+ 0a-] + ...
  *       Term 0            Term 1
- *  
+ *
  *        This class stores operators in each term in the following canonical form
  *            a+_p1 a+_p2 ...  a+_P1 a+_P2 ...   ... a-_Q2 a-_Q1   ... a-_q2 a-_q1
  *            alpha creation   beta creation    beta annihilation  alpha annihilation
- * 
+ *
  *        with indices sorted as
- * 
+ *
  *            (p1 < p2 < ...) (P1 < P2 < ...)  (... > Q2 > Q1) (... > q2 > q1)
  */
 class SparseOperator {
@@ -74,9 +74,9 @@ class SparseOperator {
     ///     creation_i  : bool (true = creation, false = annihilation)
     ///     alpha_i     : bool (true = alpha, false = beta)
     ///     orb_i       : int  (the index of the mo)
-    /// 
-    void add_term(const std::vector<std::tuple<bool, bool, int>>& op_list,
-                  double coefficient = 0.0, bool allow_reordering = false);
+    ///
+    void add_term(const std::vector<std::tuple<bool, bool, int>>& op_list, double coefficient = 0.0,
+                  bool allow_reordering = false);
     /// add a term to this operator
     void add_term(const SQOperator& sqop);
     /// add a term to this operator of the form

--- a/forte/sparse_ci/sparse_state_vector.cc
+++ b/forte/sparse_ci/sparse_state_vector.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -121,7 +121,8 @@ StateVector apply_operator(SparseOperator& sop, const StateVector& state, double
             if (std::fabs(sqop.coefficient() * c) > screen_thresh) {
                 // check if this operator can be applied
                 if (d.fast_a_and_b_equal_b(sqop.ann()) and d.fast_a_and_b_eq_zero(ucre)) {
-                    double value = apply_op_safe(d, sqop.cre(), sqop.ann()) * sqop.coefficient() * c;
+                    double value =
+                        apply_op_safe(d, sqop.cre(), sqop.ann()) * sqop.coefficient() * c;
                     new_terms[d] += value;
                 }
             } else {
@@ -146,7 +147,8 @@ StateVector apply_operator(SparseOperator& sop, const StateVector& state, double
                 if (std::fabs(sqop.coefficient() * c) > screen_thresh) {
                     // check if this operator can be applied
                     if (d.fast_a_and_b_equal_b(sqop.cre()) and d.fast_a_and_b_eq_zero(ucre)) {
-                        double value = apply_op_safe(d, sqop.ann(), sqop.cre()) * sqop.coefficient() * c;
+                        double value =
+                            apply_op_safe(d, sqop.ann(), sqop.cre()) * sqop.coefficient() * c;
                         new_terms[d] -= value;
                     }
                 } else {

--- a/forte/sparse_ci/sparse_state_vector.h
+++ b/forte/sparse_ci/sparse_state_vector.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.

--- a/forte/sparse_ci/sq_operator.cc
+++ b/forte/sparse_ci/sq_operator.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -188,8 +188,6 @@ std::string SQOperator::latex() const {
     return s;
 }
 
-SQOperator SQOperator::adjoint() const {
-    return SQOperator(coefficient_, ann_, cre_);
-}
+SQOperator SQOperator::adjoint() const { return SQOperator(coefficient_, ann_, cre_); }
 
 } // namespace forte

--- a/forte/sparse_ci/sq_operator.h
+++ b/forte/sparse_ci/sq_operator.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -70,9 +70,9 @@ using op_tuple_t = std::vector<std::tuple<bool, bool, int>>;
  * This class stores operators in the following canonical form
  *     a+_p1 a+_p2 ...  a+_P1 a+_P2 ...   ... a-_Q2 a-_Q1   ... a-_q2 a-_q1
  *     alpha creation   beta creation    beta annihilation  alpha annihilation
- * 
+ *
  * with indices sorted as
- * 
+ *
  *     (p1 < p2 < ...) (P1 < P2 < ...)  (... > Q2 > Q1) (... > q2 > q1)
  *
  * The creation and annihilation operators are stored separately as bit arrays
@@ -84,21 +84,20 @@ class SQOperator {
 
     /**
      * @brief Create a second quantized operator
-     * 
+     *
      * @param ops a vector of triplets (is_creation, is_alpha, orb) that specify
-     *        the second quantized operators  
+     *        the second quantized operators
      * @param coefficient of the coefficient associated with this operator
-     * @param allow_reordering if true this function will reorder all terms and put them in canonical
-     *        order adjusting the coefficient to account for the number of permutations.
-     *        If set to false, this function will only accept operators that are already in the 
-     *        canonical order
+     * @param allow_reordering if true this function will reorder all terms and put them in
+     * canonical order adjusting the coefficient to account for the number of permutations. If set
+     * to false, this function will only accept operators that are already in the canonical order
      */
     SQOperator(const op_tuple_t& ops, double coefficient = 0.0, bool allow_reordering = false);
     /// @return the numerical coefficient associated with this operator
     double coefficient() const;
     /// @return a Determinant object that represents the creation operators
     const Determinant& cre() const;
-    /// @return a Determinant object that represents the annihilation operators    
+    /// @return a Determinant object that represents the annihilation operators
     const Determinant& ann() const;
     /// @param value set the coefficient associated with this operator
     void set_coefficient(double& value);

--- a/forte/v2rdm/v2rdm.cc
+++ b/forte/v2rdm/v2rdm.cc
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -56,8 +56,8 @@ struct dm3 {
     double val;
 };
 
-V2RDM::V2RDM(psi::SharedWavefunction ref_wfn, psi::Options& options, std::shared_ptr<ForteIntegrals> ints,
-             std::shared_ptr<MOSpaceInfo> mo_space_info)
+V2RDM::V2RDM(psi::SharedWavefunction ref_wfn, psi::Options& options,
+             std::shared_ptr<ForteIntegrals> ints, std::shared_ptr<MOSpaceInfo> mo_space_info)
     : Wavefunction(options), ints_(ints), mo_space_info_(mo_space_info) {
     shallow_copy(ref_wfn);
     reference_wavefunction_ = ref_wfn;
@@ -371,9 +371,8 @@ double V2RDM::compute_ref_energy() {
     /* Eref = sum_{m} h^{m}_{m} + 0.5 * sum_{mn} v^{mn}_{mn}
               + \sum_{uv} ( h^{u}_{v} + \sum_{m} v^{mu}_{mv} ) * D^{v}_{u}
               + 0.25 * \sum_{uvxy} v^{xy}_{uv} * D^{uv}_{xy} */
-    double Eref =
-        frozen_core_energy_ +
-        molecule_->nuclear_repulsion_energy(reference_wavefunction_->get_dipole_field_strength());
+    double Eref = frozen_core_energy_ + molecule_->nuclear_repulsion_energy(
+                                            reference_wavefunction_->get_dipole_field_strength());
     size_t ncore = core_mos_.size();
     size_t nactv = actv_mos_.size();
 
@@ -465,7 +464,7 @@ RDMs V2RDM::reference() {
     outfile->Printf("\n  %-45s ...", str.c_str());
     // if 3-RDMs are needed
     if (options_.get_str("THREEPDC") != "ZERO") {
-        RDMs return_ref(D1a_, D1b_, D2_[0], D2_[1], D2_[3], D3_[0], D3_[1], D3_[2], D3_[3]);   
+        RDMs return_ref(D1a_, D1b_, D2_[0], D2_[1], D2_[3], D3_[0], D3_[1], D3_[2], D3_[3]);
         if (options_.get_str("WRITE_DENSITY_TYPE") == "CUMULANT") {
             write_density_to_file();
         }
@@ -473,8 +472,8 @@ RDMs V2RDM::reference() {
         outfile->Printf("    Done.");
         return return_ref;
     } else {
-        
-        RDMs return_ref(D1a_, D1b_, D2_[0], D2_[1], D2_[3]);   
+
+        RDMs return_ref(D1a_, D1b_, D2_[0], D2_[1], D2_[3]);
         if (options_.get_str("WRITE_DENSITY_TYPE") == "CUMULANT") {
             write_density_to_file();
         }
@@ -554,4 +553,4 @@ void V2RDM::write_density_to_file() {
 
     outfile->Printf("    Done.");
 }
-}
+} // namespace forte

--- a/forte/v2rdm/v2rdm.h
+++ b/forte/v2rdm/v2rdm.h
@@ -5,7 +5,7 @@
  * that implements a variety of quantum chemistry methods for strongly
  * correlated electrons.
  *
- * Copyright (c) 2012-2021 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ * Copyright (c) 2012-2022 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
  *
  * The copyrights for code used from other parties are included in
  * the corresponding files.
@@ -56,8 +56,8 @@ class V2RDM : public psi::Wavefunction {
      * @param ints A pointer to an allocated integral object
      * @param mo_space_info The MOSpaceInfo object
      */
-    V2RDM(psi::SharedWavefunction ref_wfn, psi::Options& options, std::shared_ptr<ForteIntegrals> ints,
-          std::shared_ptr<MOSpaceInfo> mo_space_info);
+    V2RDM(psi::SharedWavefunction ref_wfn, psi::Options& options,
+          std::shared_ptr<ForteIntegrals> ints, std::shared_ptr<MOSpaceInfo> mo_space_info);
 
     /// Destructor
     ~V2RDM();
@@ -122,6 +122,6 @@ class V2RDM : public psi::Wavefunction {
     /// 3PDM: file_3pdm_aaa, file_3pdm_aab, file_3pdm_abb, file_3pdm_bbb
     void write_density_to_file();
 };
-}
+} // namespace forte
 
 #endif // V2RDM_H


### PR DESCRIPTION
## Description
A minor change worth pointing out is that the C++ module is now renamed to `_forte` to avoid confusion with the python `forte` module. This caused very minor changes in the python modules that is mostly hidden in the `forte/__init__.py` file.

## Checklist
- [x] Removed comments in code and input files
- [x] Documented source code
- [x] Ready to go!