### PR TITLE
Remove unneeded arguments

### DIFF
--- a/forte/casscf/casscf.cc
+++ b/forte/casscf/casscf.cc
@@ -270,12 +270,12 @@ double CASSCF::compute_energy() {
 
         // TODO:  Add options controlled.  Iteration and g_norm
         if (do_diis and (iter >= diis_start or g_norm < diis_gradient_norm)) {
-            diis_manager->add_entry(2, Sstep.get(), S.get());
+            diis_manager->add_entry(Sstep.get(), S.get());
             diis_count++;
         }
 
         if (do_diis and iter > diis_start and (diis_count % diis_freq == 0)) {
-            diis_manager->extrapolate(1, S.get());
+            diis_manager->extrapolate(S.get());
         }
         psi::SharedMatrix Cp = orbital_optimizer.rotate_orbitals(C_start, S);
 

--- a/forte/casscf/mcscf_2step.cc
+++ b/forte/casscf/mcscf_2step.cc
@@ -322,13 +322,13 @@ double MCSCF_2STEP::compute_energy() {
                         psi::outfile->Printf("   ");
                     }
 
-                    diis_manager.add_entry(2, dG.get(), R.get());
+                    diis_manager.add_entry(dG.get(), R.get());
                     psi::outfile->Printf("S");
                 }
 
                 if ((macro - diis_start_) % diis_freq_ == 0 and
                     diis_manager.subspace_size() > diis_min_vec_) {
-                    diis_manager.extrapolate(1, R.get());
+                    diis_manager.extrapolate(R.get());
                     psi::outfile->Printf("/E");
 
                     // update the actual integrals for CI, skip gradient computation

--- a/forte/mrdsrg-spin-adapted/sa_mrdsrg_diis.cc
+++ b/forte/mrdsrg-spin-adapted/sa_mrdsrg_diis.cc
@@ -73,7 +73,7 @@ void SA_MRDSRG::diis_manager_init() {
 
 void SA_MRDSRG::diis_manager_add_entry() {
     diis_manager_->add_entry(
-        36, res_ptrs_[0], res_ptrs_[1], res_ptrs_[2], res_ptrs_[3], res_ptrs_[4], res_ptrs_[5],
+        res_ptrs_[0], res_ptrs_[1], res_ptrs_[2], res_ptrs_[3], res_ptrs_[4], res_ptrs_[5],
         res_ptrs_[6], res_ptrs_[7], res_ptrs_[8], res_ptrs_[9], res_ptrs_[10], res_ptrs_[11],
         res_ptrs_[12], res_ptrs_[13], res_ptrs_[14], res_ptrs_[15], res_ptrs_[16], res_ptrs_[17],
         amp_ptrs_[0], amp_ptrs_[1], amp_ptrs_[2], amp_ptrs_[3], amp_ptrs_[4], amp_ptrs_[5],
@@ -83,7 +83,7 @@ void SA_MRDSRG::diis_manager_add_entry() {
 
 void SA_MRDSRG::diis_manager_extrapolate() {
     diis_manager_->extrapolate(
-        18, amp_ptrs_[0], amp_ptrs_[1], amp_ptrs_[2], amp_ptrs_[3], amp_ptrs_[4], amp_ptrs_[5],
+        amp_ptrs_[0], amp_ptrs_[1], amp_ptrs_[2], amp_ptrs_[3], amp_ptrs_[4], amp_ptrs_[5],
         amp_ptrs_[6], amp_ptrs_[7], amp_ptrs_[8], amp_ptrs_[9], amp_ptrs_[10], amp_ptrs_[11],
         amp_ptrs_[12], amp_ptrs_[13], amp_ptrs_[14], amp_ptrs_[15], amp_ptrs_[16], amp_ptrs_[17]);
 }

--- a/forte/mrdsrg-spin-integrated/mrdsrg_diis.cc
+++ b/forte/mrdsrg-spin-integrated/mrdsrg_diis.cc
@@ -153,7 +153,7 @@ void MRDSRG::diis_manager_init() {
 
 void MRDSRG::diis_manager_add_entry() {
     diis_manager_->add_entry(
-        102, res_ptrs_[0], res_ptrs_[1], res_ptrs_[2], res_ptrs_[3], res_ptrs_[4], res_ptrs_[5],
+        res_ptrs_[0], res_ptrs_[1], res_ptrs_[2], res_ptrs_[3], res_ptrs_[4], res_ptrs_[5],
         res_ptrs_[6], res_ptrs_[7], res_ptrs_[8], res_ptrs_[9], res_ptrs_[10], res_ptrs_[11],
         res_ptrs_[12], res_ptrs_[13], res_ptrs_[14], res_ptrs_[15], res_ptrs_[16], res_ptrs_[17],
         res_ptrs_[18], res_ptrs_[19], res_ptrs_[20], res_ptrs_[21], res_ptrs_[22], res_ptrs_[23],
@@ -174,7 +174,7 @@ void MRDSRG::diis_manager_add_entry() {
 
 void MRDSRG::diis_manager_extrapolate() {
     diis_manager_->extrapolate(
-        51, amp_ptrs_[0], amp_ptrs_[1], amp_ptrs_[2], amp_ptrs_[3], amp_ptrs_[4], amp_ptrs_[5],
+        amp_ptrs_[0], amp_ptrs_[1], amp_ptrs_[2], amp_ptrs_[3], amp_ptrs_[4], amp_ptrs_[5],
         amp_ptrs_[6], amp_ptrs_[7], amp_ptrs_[8], amp_ptrs_[9], amp_ptrs_[10], amp_ptrs_[11],
         amp_ptrs_[12], amp_ptrs_[13], amp_ptrs_[14], amp_ptrs_[15], amp_ptrs_[16], amp_ptrs_[17],
         amp_ptrs_[18], amp_ptrs_[19], amp_ptrs_[20], amp_ptrs_[21], amp_ptrs_[22], amp_ptrs_[23],


### PR DESCRIPTION
## Description
Some additional fixes needed to get Forte and new Psi talking to each other, because #286 was merged prematurely due to a communication error.

There are _still_ some additional fixes needed (new DIIS doesn't recognize pointers but should be trained to recognize `std::vector<double>` and/or Ambit tensors), but that's a job for tomorrow.

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features and included a reference `output.ref` file
- [ ] Removed comments in code and input files
- [ ] Documented source code
- [ ] Checked for redundant headers
- [ ] Checked for consistency in the formatting of the output file
- [ ] Documented new features in the manual
- [ ] Ready to go!
