### PR TITLE
Fixed GCC 13.2 compilation errors

### DIFF
--- a/forte/base_classes/state_info.h
+++ b/forte/base_classes/state_info.h
@@ -29,6 +29,7 @@
 #ifndef _state_info_h_
 #define _state_info_h_
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/forte/fci/fci_vector.h
+++ b/forte/fci/fci_vector.h
@@ -28,7 +28,9 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
+#include <cmath>
 
 #include "psi4/libmints/dimension.h"
 #include "ambit/tensor.h"

--- a/forte/genci/genci_string_address.cc
+++ b/forte/genci/genci_string_address.cc
@@ -124,8 +124,8 @@ StringClass::StringClass(size_t symmetry, const std::vector<int>& mopi,
     for (const auto& [aocc_idx, bocc_idx] : occupations) {
         for (size_t h_Ia = 0; h_Ia < nirrep_; h_Ia++) {
             auto h_Ib = h_Ia ^ symmetry;
-            auto aocc_h_Ia = alfa_string_classes_map_.at(std::make_tuple(aocc_idx, h_Ia));
-            auto bocc_h_Ib = beta_string_classes_map_.at(std::make_tuple(bocc_idx, h_Ib));
+            auto aocc_h_Ia = alfa_string_classes_map_.at(std::make_pair(aocc_idx, h_Ia));
+            auto bocc_h_Ib = beta_string_classes_map_.at(std::make_pair(bocc_idx, h_Ib));
             block_index_[std::make_pair(aocc_h_Ia, bocc_h_Ib)] = determinant_classes_.size();
             determinant_classes_.emplace_back(determinant_classes_.size(), aocc_h_Ia, bocc_h_Ib);
         }

--- a/forte/genci/genci_vector.h
+++ b/forte/genci/genci_vector.h
@@ -30,6 +30,7 @@
 
 #include <functional>
 #include <vector>
+#include <cmath>
 
 #include "psi4/libmints/dimension.h"
 #include "ambit/tensor.h"

--- a/forte/genci/string_lists_makers.cc
+++ b/forte/genci/string_lists_makers.cc
@@ -182,7 +182,7 @@ void make_vo(const StringList& strings, const std::shared_ptr<StringAddress>& I_
                     J[p] = true;
                     if (auto it = J_addresser->find(J); it != J_addresser->end()) {
                         const auto& [add_J, class_J] = it->second;
-                        auto& list_IJ = list[std::make_tuple(class_I, class_J)];
+                        auto& list_IJ = list[std::make_pair(class_I, class_J)];
                         list_IJ[std::make_tuple(p, q)].push_back(
                             StringSubstitution(sign, add_I, add_J));
                     }
@@ -252,7 +252,7 @@ void make_vvoo(const StringList& strings, std::shared_ptr<StringAddress> address
                             if (auto it = addresser->find(J); it != addresser->end()) {
                                 const auto& [add_I, class_I] = addresser->address_and_class(I);
                                 const auto& [add_J, class_J] = it->second;
-                                auto& list_IJ = list[std::make_tuple(class_I, class_J)];
+                                auto& list_IJ = list[std::make_pair(class_I, class_J)];
                                 list_IJ[std::make_tuple(p, q, r, s)].push_back(
                                     StringSubstitution(sign, add_I, add_J));
                             }

--- a/forte/sparse_ci/ci_spin_adaptation.h
+++ b/forte/sparse_ci/ci_spin_adaptation.h
@@ -29,6 +29,7 @@
 #ifndef _spin_adaptation_h_
 #define _spin_adaptation_h_
 
+#include <memory>
 #include <vector>
 
 namespace psi {

--- a/tests/pytest/determinant/test_string.py
+++ b/tests/pytest/determinant/test_string.py
@@ -30,7 +30,7 @@ def test_str_address():
     for s,a in zip(test_strings,symmetry):
         assert str_add.sym(s) == a        
     for h, nh in zip([0,3],[3,4]):
-        assert str_add.strpi(h) == nh
+        assert str_add.strpcls(h) == nh
 
 if __name__ == "__main__":
     test_str_constructors()


### PR DESCRIPTION
## Description
Added necessary header libraries. Fixed correct key type when calling `std::map::at`.
Fixed `test_string.py ` test case.

## User Notes
- [ ] Features added
- [x] Changes to compilation (if any)

## Checklist
- [x] Added/updated tests of new features and included a reference `output.ref` file
- [x] Removed comments in code and input files
- [x] Documented source code
- [x] Checked for redundant headers
- [x] Checked for consistency in the formatting of the output file
- [x] Documented new features in the manual
- [x] Ready to go!
