### PR TITLE
CI code improvements and merge

### DIFF
--- a/forte/api/forte_python_module.cc
+++ b/forte/api/forte_python_module.cc
@@ -267,7 +267,7 @@ PYBIND11_MODULE(_forte, m) {
         "abab...");
 
     m.def("get_gas_occupation", &get_gas_occupation);
-    m.def("get_ormas_occupation", &get_ormas_occupation);
+    m.def("get_ci_occupation_patterns", &get_ci_occupation_patterns);
 
     //     py::class_<AdaptiveCI, std::shared_ptr<AdaptiveCI>>(m, "ACI");
 

--- a/forte/api/forte_python_module.cc
+++ b/forte/api/forte_python_module.cc
@@ -269,6 +269,14 @@ PYBIND11_MODULE(_forte, m) {
     m.def("get_gas_occupation", &get_gas_occupation);
     m.def("get_ci_occupation_patterns", &get_ci_occupation_patterns);
 
+    py::enum_<PrintLevel>(m, "PrintLevel")
+        .value("Quiet", PrintLevel::Quiet)
+        .value("Brief", PrintLevel::Brief)
+        .value("Default", PrintLevel::Default)
+        .value("Verbose", PrintLevel::Verbose)
+        .value("Debug", PrintLevel::Debug)
+        .export_values();
+
     //     py::class_<AdaptiveCI, std::shared_ptr<AdaptiveCI>>(m, "ACI");
 
     export_ForteOptions(m);

--- a/forte/api/sci_api.cc
+++ b/forte/api/sci_api.cc
@@ -405,7 +405,7 @@ void export_SparseCISolver(py::module& m) {
 void export_GAS(py::module& m) {
     py::class_<GenCIStringLists, std::shared_ptr<GenCIStringLists>>(
         m, "GenCIStringLists", "A class to represent the strings of a GAS")
-        .def(py::init<std::shared_ptr<MOSpaceInfo>, size_t, size_t, int, int,
+        .def(py::init<std::shared_ptr<MOSpaceInfo>, size_t, size_t, int, PrintLevel,
                       const std::vector<int>, const std::vector<int>>())
         .def("make_determinants", &GenCIStringLists::make_determinants,
              "Return a vector of Determinants");

--- a/forte/attic/fci_mo.cc
+++ b/forte/attic/fci_mo.cc
@@ -158,7 +158,7 @@ void FCI_MO::startup() {
     read_options();
 
     // print options
-    if (print_ > 0) {
+    if (print_ > 1) {
         print_options();
     }
 
@@ -398,7 +398,7 @@ void FCI_MO::form_p_space() {
         outfile->Printf("\n");
     }
 
-    if (print_ > 1) {
+    if (print_ > 2) {
         print_det(determinant_);
     }
 
@@ -2217,7 +2217,7 @@ void FCI_MO::build_dets321() {
             }
         }
     }
-    if (print_ > 2)
+    if (print_ > 3)
         outfile->Printf("\n  dets321 sizes: a = %zu, b = %zu", dets321_a_.size(),
                         dets321_b_.size());
 
@@ -2386,7 +2386,7 @@ void FCI_MO::build_lists321() {
         }
     }
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n  list aaa size = %zu", list21_aaa_.size());
         outfile->Printf("\n  list abb size = %zu", list21_abb_.size());
         outfile->Printf("\n  list baa size = %zu", list21_baa_.size());

--- a/forte/base_classes/active_space_method.cc
+++ b/forte/base_classes/active_space_method.cc
@@ -445,7 +445,9 @@ std::shared_ptr<ActiveSpaceMethod> make_active_space_method(
     std::shared_ptr<ForteOptions> options) {
 
     std::shared_ptr<ActiveSpaceMethod> method;
-    if (type == "FCI" or type == "GENCI") {
+    if (type == "FCI") {
+        method = std::make_unique<FCISolver>(state, nroot, mo_space_info, as_ints);
+    } else if (type == "GENCI") {
         method = std::make_unique<GenCISolver>(state, nroot, mo_space_info, as_ints);
     } else if (type == "ACI") {
         method = std::make_unique<ExcitedStateSolver>(

--- a/forte/base_classes/active_space_method.cc
+++ b/forte/base_classes/active_space_method.cc
@@ -408,9 +408,7 @@ std::shared_ptr<ActiveSpaceMethod> make_active_space_method(
     std::shared_ptr<ForteOptions> options) {
 
     std::shared_ptr<ActiveSpaceMethod> method;
-    if (type == "FCI") {
-        method = std::make_unique<FCISolver>(state, nroot, mo_space_info, as_ints);
-    } else if (type == "GENCI") {
+    if (type == "FCI" or type == "GENCI") {
         method = std::make_unique<GenCISolver>(state, nroot, mo_space_info, as_ints);
     } else if (type == "ACI") {
         method = std::make_unique<ExcitedStateSolver>(

--- a/forte/base_classes/active_space_method.h
+++ b/forte/base_classes/active_space_method.h
@@ -31,17 +31,20 @@
 
 #include <vector>
 #include <unordered_set>
+
+#include "psi4/libmints/matrix.h"
+#include "psi4/libmints/vector.h"
+
 #include "ambit/tensor.h"
 
 namespace ambit {
 class BlockedTensor;
 }
 
-#include "psi4/libmints/matrix.h"
-#include "psi4/libmints/vector.h"
-
 #include "base_classes/rdms.h"
 #include "base_classes/state_info.h"
+
+#include "helpers/printing.h"
 #include "integrals/one_body_integrals.h"
 #include "sparse_ci/determinant.h"
 #include "sparse_ci/determinant_hashvector.h"
@@ -329,10 +332,10 @@ class ActiveSpaceMethod {
 
     /// Set the print level
     /// @param level the print level (0 = no printing, 1 default)
-    void set_print(int level);
+    void set_print(PrintLevel level);
 
     /// Quiet mode (no printing, for use with CASSCF)
-    void set_quiet_mode(bool quiet);
+    void set_quiet_mode();
 
     /// Get the model space
     DeterminantHashVec get_PQ_space();
@@ -381,10 +384,7 @@ class ActiveSpaceMethod {
     int root_ = 0;
 
     /// A variable to control printing information
-    int print_ = 0;
-
-    /// Quiet printing
-    bool quiet_ = false;
+    PrintLevel print_ = PrintLevel::Default;
 
     /// Eigenvalues
     std::shared_ptr<psi::Vector> evals_;

--- a/forte/base_classes/active_space_solver.h
+++ b/forte/base_classes/active_space_solver.h
@@ -32,17 +32,21 @@
 #include <map>
 #include <vector>
 #include <string>
+
 #include <ambit/tensor.h>
+#include "psi4/libmints/matrix.h"
 
 namespace ambit {
 class BlockedTensor;
 }
 
-#include "psi4/libmints/matrix.h"
 #include "base_classes/state_info.h"
 #include "base_classes/rdms.h"
+#include "helpers/printing.h"
+
 #include "integrals/one_body_integrals.h"
 #include "sparse_ci/determinant_hashvector.h"
+
 namespace forte {
 
 class ActiveSpaceMethod;
@@ -82,8 +86,8 @@ class ActiveSpaceSolver {
     // ==> Class Interface <==
 
     /// Set the print level
-    /// @param level the print level (0 = no printing, 1 default)
-    void set_print(int level);
+    /// @param level the print level
+    void set_print(PrintLevel level);
 
     /// Compute the energy and return it // TODO: document (Francesco)
     const std::map<StateInfo, std::vector<double>>& compute_energy();
@@ -247,7 +251,7 @@ class ActiveSpaceSolver {
     std::map<StateInfo, std::string> state_filename_map_;
 
     /// A variable to control printing information
-    int print_ = 1;
+    PrintLevel print_ = PrintLevel::Default;
 
     /// The energy convergence criterion
     double e_convergence_ = 1.0e-10;

--- a/forte/casscf/casscf.cc
+++ b/forte/casscf/casscf.cc
@@ -84,7 +84,7 @@ void CASSCF::startup() {
         }
     }
 
-    print_ = options_->get_int("PRINT");
+    print_ = int_to_print_level(options_->get_int("PRINT"));
     casscf_debug_print_ = options_->get_bool("CASSCF_DEBUG_PRINTING");
 
     nsopi_ = ints_->nsopi();
@@ -207,14 +207,14 @@ double CASSCF::compute_energy() {
 
         local_timer trans_ints_timer;
         tei_gaaa_ = transform_integrals(Ca);
-        if (print_ > 0) {
+        if (print_ >= PrintLevel::Default) {
             outfile->Printf("\n\n  Transform Integrals takes %8.8f s.", trans_ints_timer.get());
         }
         iter_con.push_back(iter);
 
         // Perform a CASCI
         E_casscf_old = E_casscf_;
-        if (print_ > 0) {
+        if (print_ >= PrintLevel::Default) {
             std::string ci_type = options_->get_str("CASSCF_CI_SOLVER");
             outfile->Printf("\n\n  Performing a CAS with %s", ci_type.c_str());
         }
@@ -229,7 +229,7 @@ double CASSCF::compute_energy() {
         } else {
             diagonalize_hamiltonian();
         }
-        if (print_ > 0) {
+        if (print_ >= PrintLevel::Default) {
             outfile->Printf("\n\n CAS took %8.6f seconds.", cas_timer.get());
         }
 
@@ -239,7 +239,7 @@ double CASSCF::compute_energy() {
         orbital_optimizer.set_frozen_one_body(F_frozen_core_);
         orbital_optimizer.set_symmmetry_mo(Ca);
         orbital_optimizer.one_body(Hcore_->clone());
-        if (print_ > 0) {
+        if (print_ >= PrintLevel::Default) {
             orbital_optimizer.set_print_timings(true);
         }
         orbital_optimizer.set_jk(JK_);
@@ -418,7 +418,7 @@ ambit::Tensor CASSCF::transform_integrals(std::shared_ptr<psi::Matrix> Ca) {
             index += 1;
         }
     }
-    if (print_ > 1) {
+    if (print_ >= PrintLevel::Verbose) {
         outfile->Printf("\n  CSO2AO takes %8.4f s.", CSO2AO.get());
     }
 

--- a/forte/casscf/casscf.h
+++ b/forte/casscf/casscf.h
@@ -233,7 +233,7 @@ class CASSCF {
     ambit::Tensor tei_gaaa_;
 
     /// The print level
-    int print_ = 0;
+    PrintLevel print_ = PrintLevel::Default;
 
     /// The CISolutions per iteration
     std::vector<std::vector<std::shared_ptr<FCIVector>>> CISolutions_;

--- a/forte/casscf/casscf_gradient.cc
+++ b/forte/casscf/casscf_gradient.cc
@@ -217,7 +217,7 @@ void CASSCF::tpdm_backtransform() {
         IntegralTransform::OutputType::DPDOnly,              // Output buffer
         IntegralTransform::MOOrdering::QTOrder,              // MO ordering
         IntegralTransform::FrozenOrbitals::None);            // Frozen orbitals?
-    transform->set_print(print_);
+    transform->set_print(static_cast<int>(print_));
     transform->backtransform_density();
     transform.reset();
 

--- a/forte/casscf/mcscf_2step.h
+++ b/forte/casscf/mcscf_2step.h
@@ -96,7 +96,7 @@ class MCSCF_2STEP {
     std::string der_type_;
 
     /// The printing level
-    int print_;
+    PrintLevel print_ = PrintLevel::Default;
     /// Enable debug printing or not
     bool debug_print_;
 
@@ -148,7 +148,7 @@ class MCSCF_2STEP {
     /// @return averaged energy
     double diagonalize_hamiltonian(std::shared_ptr<ActiveSpaceSolver>& as_solver,
                                    std::shared_ptr<ActiveSpaceIntegrals> fci_ints,
-                                   const std::tuple<int, double, double, bool>& params);
+                                   const std::tuple<PrintLevel, double, double, bool>& params);
 
     /// Test if we are doing a single-reference orbital optimization
     bool is_single_reference();

--- a/forte/ci_ex_states/excited_state_solver.cc
+++ b/forte/ci_ex_states/excited_state_solver.cc
@@ -78,7 +78,6 @@ void ExcitedStateSolver::set_options(std::shared_ptr<ForteOptions> options) {
     }
 
     core_ex_ = options->get_bool("SCI_CORE_EX");
-    quiet_ = options->get_bool("SCI_QUIET_MODE");
     direct_rdms_ = options->get_bool("SCI_DIRECT_RDMS");
     test_rdms_ = options->get_bool("SCI_TEST_RDMS");
     save_final_wfn_ = options->get_bool("SCI_SAVE_FINAL_WFN");
@@ -119,7 +118,7 @@ double ExcitedStateSolver::compute_energy() {
         {"Selected Configuration Interaction Excited States",
          "written by Jeffrey B. Schriber, Tianyuan Zhang, and Francesco A. Evangelista"});
     print_info();
-    if (!quiet_) {
+    if (print_ >= PrintLevel::Default) {
         psi::outfile->Printf("\n  Using %d thread(s)", omp_get_max_threads());
     }
 
@@ -150,7 +149,7 @@ double ExcitedStateSolver::compute_energy() {
     std::shared_ptr<psi::Vector> PQ_evals;
 
     for (int i = 0; i < nrun; ++i) {
-        if (!quiet_)
+        if (print_ >= PrintLevel::Default)
             psi::outfile->Printf("\n  Computing wavefunction for root %d", i);
 
         if (multi_state) {
@@ -179,7 +178,7 @@ double ExcitedStateSolver::compute_energy() {
 
         if (ex_alg_ == "ROOT_COMBINE") {
             sizes[i] = PQ_space.size();
-            if (!quiet_)
+            if (print_ >= PrintLevel::Default)
                 psi::outfile->Printf("\n  Combining determinant spaces");
             // Combine selected determinants into total space
             full_space.merge(PQ_space);
@@ -819,7 +818,7 @@ void ExcitedStateSolver::save_old_root(DeterminantHashVec& dets,
                                        int ref_root) {
     std::vector<std::pair<Determinant, double>> vec;
 
-    if (!quiet_ and nroot_ > 0) {
+    if (print_ >= PrintLevel::Default and nroot_ > 0) {
         psi::outfile->Printf("\n  Saving root %d, ref_root is %d", root, ref_root);
     }
     const det_hashvec& detmap = dets.wfn_hash();
@@ -827,7 +826,7 @@ void ExcitedStateSolver::save_old_root(DeterminantHashVec& dets,
         vec.push_back(std::make_pair(detmap[i], PQ_evecs->get(i, ref_root)));
     }
     old_roots_.push_back(vec);
-    if (!quiet_ and nroot_ > 0) {
+    if (print_ >= PrintLevel::Default and nroot_ > 0) {
         psi::outfile->Printf("\n  Number of old roots: %zu", old_roots_.size());
     }
 }

--- a/forte/fci/fci_solver.cc
+++ b/forte/fci/fci_solver.cc
@@ -140,7 +140,7 @@ void FCISolver::startup() {
         spin_adapter_->prepare_couplings(dets_);
     }
 
-    if (print_) {
+    if (print_ >= PrintLevel::Default) {
         table_printer printer;
         printer.add_int_data({{"Number of determinants", nfci_dets_},
                               {"Symmetry", symmetry_},
@@ -168,7 +168,7 @@ void FCISolver::set_options(std::shared_ptr<ForteOptions> options) {
     set_subspace_per_root(options->get_int("DL_SUBSPACE_PER_ROOT"));
     set_maxiter_davidson(options->get_int("DL_MAXITER"));
 
-    set_print(options->get_int("PRINT"));
+    set_print(int_to_print_level(options->get_int("PRINT")));
 }
 
 /*
@@ -294,7 +294,7 @@ double FCISolver::compute_energy() {
     eigen_vecs_ = dl_solver_->eigenvectors();
 
     // Print determinants
-    if (print_) {
+    if (print_ >= PrintLevel::Default) {
         print_solutions(100, b, b_basis, dl_solver_);
     }
 
@@ -374,7 +374,7 @@ void FCISolver::test_rdms(std::shared_ptr<psi::Vector> b, std::shared_ptr<psi::V
         b = b_basis;
     }
     C_->copy(b);
-    if (print_) {
+    if (print_ >= PrintLevel::Verbose) {
         std::string title_rdm = "Computing RDMs for Root No. " + std::to_string(root_);
         print_h2(title_rdm);
     }

--- a/forte/fci/fci_solver_initial_guess.cc
+++ b/forte/fci/fci_solver_initial_guess.cc
@@ -76,7 +76,7 @@ std::vector<Determinant> FCISolver::initial_guess_generate_dets(std::shared_ptr<
     // Make sure that the spin space is complete
     enforce_spin_completeness(guess_dets, active_mo_.size());
     if (guess_dets.size() > num_guess_dets) {
-        if (print_ > 0) {
+        if (print_ >= PrintLevel::Brief) {
             psi::outfile->Printf("\n  Initial guess space is incomplete.\n  Adding "
                                  "%d determinant(s).",
                                  guess_dets.size() - num_guess_dets);
@@ -98,13 +98,14 @@ FCISolver::initial_guess_det(std::shared_ptr<psi::Vector> diag, size_t num_guess
 
     // here we use a standard guess procedure
     return find_initial_guess_det(guess_dets, guess_dets_pos, num_guess_states, fci_ints,
-                                  state().multiplicity(), true, print_,
+                                  state().multiplicity(), true, print_ >= PrintLevel::Default,
                                   std::vector<std::vector<std::pair<size_t, double>>>());
 }
 
 sparse_mat FCISolver::initial_guess_csf(std::shared_ptr<psi::Vector> diag,
                                         size_t num_guess_states) {
-    return find_initial_guess_csf(diag, num_guess_states, state().multiplicity(), print_);
+    return find_initial_guess_csf(diag, num_guess_states, state().multiplicity(),
+                                  print_ >= PrintLevel::Default);
 }
 
 std::shared_ptr<psi::Vector>

--- a/forte/fci/fci_solver_rdms.cc
+++ b/forte/fci/fci_solver_rdms.cc
@@ -82,7 +82,7 @@ std::shared_ptr<RDMs> FCISolver::compute_rdms_root(size_t root_left, size_t root
         T_->copy(*C_);
     }
 
-    if (print_) {
+    if (print_ >= PrintLevel::Verbose) {
         std::string title_rdm = "Computing RDMs <" + std::to_string(root_left) + " " +
                                 state().str_minimum() + "| ... |" + std::to_string(root_right) +
                                 " " + state().str_minimum() + ">";
@@ -97,7 +97,7 @@ std::shared_ptr<RDMs> FCISolver::compute_rdms_root(size_t root_left, size_t root
     }
 
     // Print the NO if energy converged
-    if (print_no_ || print_ > 0) {
+    if (print_no_ || print_ >= PrintLevel::Default) {
         C_->print_natural_orbitals(mo_space_info_, rdms);
     }
     return rdms;

--- a/forte/fci/fci_solver_transition_rdms.cc
+++ b/forte/fci/fci_solver_transition_rdms.cc
@@ -99,10 +99,10 @@ FCISolver::compute_transition_rdms_root(size_t root_left, size_t root_right,
         FCIVector::test_rdms(*C_, *method2_fcisolver->T_, 1, type, rdms);
     }
 
-    // // Print the NO if energy converged
-    // if (print_no_ || print_ > 1) {
-    //     C_->print_natural_orbitals(mo_space_info_);
-    // }
+    // Print the NO if energy converged
+    if (print_no_ || print_ >= PrintLevel::Default) {
+        C_->print_natural_orbitals(mo_space_info_, rdms);
+    }
     return rdms;
 }
 

--- a/forte/fci/fci_solver_transition_rdms.cc
+++ b/forte/fci/fci_solver_transition_rdms.cc
@@ -85,7 +85,7 @@ FCISolver::compute_transition_rdms_root(size_t root_left, size_t root_right,
     // copy the right root onto the temporary vector C_
     method2_fcisolver->copy_state_into_fci_vector(root_right, method2_fcisolver->T_);
 
-    if (print_) {
+    if (print_ >= PrintLevel::Verbose) {
         std::string title_rdm = "Computing RDMs <" + std::to_string(root_left) + " " +
                                 state().str_minimum() + "| ... |" + std::to_string(root_right) +
                                 " " + method2->state().str_minimum() + ">";
@@ -100,7 +100,7 @@ FCISolver::compute_transition_rdms_root(size_t root_left, size_t root_right,
     }
 
     // // Print the NO if energy converged
-    // if (print_no_ || print_ > 0) {
+    // if (print_no_ || print_ > 1) {
     //     C_->print_natural_orbitals(mo_space_info_);
     // }
     return rdms;

--- a/forte/fci/fci_string_lists.cc
+++ b/forte/fci/fci_string_lists.cc
@@ -43,7 +43,8 @@ using namespace psi;
 namespace forte {
 
 FCIStringLists::FCIStringLists(psi::Dimension cmopi, std::vector<size_t> core_mo,
-                               std::vector<size_t> cmo_to_mo, size_t na, size_t nb, int print)
+                               std::vector<size_t> cmo_to_mo, size_t na, size_t nb,
+                               PrintLevel print)
     : nirrep_(cmopi.n()), ncmo_(cmopi.sum()), cmopi_(cmopi), cmo_to_mo_(cmo_to_mo),
       fomo_to_mo_(core_mo), na_(na), nb_(nb), print_(print) {
     startup();
@@ -181,21 +182,23 @@ void FCIStringLists::startup() {
     double total_time = str_list_timer + nn_list_timer + vo_list_timer + oo_list_timer +
                         vvoo_list_timer + vovo_list_timer;
 
-    if (print_) {
+    if (print_ >= PrintLevel::Default) {
         table_printer printer;
         printer.add_int_data({{"number of alpha electrons", na_},
                               {"number of beta electrons", nb_},
                               {"number of alpha strings", nas_},
                               {"number of beta strings", nbs_}});
-        printer.add_timing_data({{"timing for strings", str_list_timer},
-                                 {"timing for NN strings", nn_list_timer},
-                                 {"timing for VO strings", vo_list_timer},
-                                 {"timing for OO strings", oo_list_timer},
-                                 {"timing for VVOO strings", vvoo_list_timer},
-                                 {"timing for 1-hole strings", h1_list_timer},
-                                 {"timing for 2-hole strings", h2_list_timer},
-                                 {"timing for 3-hole strings", h3_list_timer},
-                                 {"total timing", total_time}});
+        if (print_ >= PrintLevel::Verbose) {
+            printer.add_timing_data({{"timing for strings", str_list_timer},
+                                     {"timing for NN strings", nn_list_timer},
+                                     {"timing for VO strings", vo_list_timer},
+                                     {"timing for OO strings", oo_list_timer},
+                                     {"timing for VVOO strings", vvoo_list_timer},
+                                     {"timing for 1-hole strings", h1_list_timer},
+                                     {"timing for 2-hole strings", h2_list_timer},
+                                     {"timing for 3-hole strings", h3_list_timer},
+                                     {"total timing", total_time}});
+        }
 
         std::string table = printer.get_table("String Lists");
         outfile->Printf("%s", table.c_str());

--- a/forte/fci/fci_string_lists.h
+++ b/forte/fci/fci_string_lists.h
@@ -36,6 +36,7 @@
 #include <utility>
 
 #include "helpers/timer.h"
+#include "helpers/printing.h"
 #include "sparse_ci/determinant.h"
 #include "fci/string_list_defs.h"
 
@@ -61,7 +62,7 @@ class FCIStringLists {
     /// @param nb number of beta electrons
     /// @param print print level
     FCIStringLists(psi::Dimension cmopi, std::vector<size_t> core_mo, std::vector<size_t> cmo_to_mo,
-                   size_t na, size_t nb, int print);
+                   size_t na, size_t nb, PrintLevel print);
 
     ~FCIStringLists() {}
 
@@ -180,7 +181,7 @@ class FCIStringLists {
     /// The offset array for pairpi
     std::vector<int> pair_offset_;
     /// The print level
-    int print_ = 0;
+    PrintLevel print_ = PrintLevel::Default;
 
     // String lists
     std::shared_ptr<FCIStringClass> string_class_;

--- a/forte/fci/fci_vector.cc
+++ b/forte/fci/fci_vector.cc
@@ -51,7 +51,7 @@ double FCIVector::h2_aaaa_timer = 0.0;
 double FCIVector::h2_aabb_timer = 0.0;
 double FCIVector::h2_bbbb_timer = 0.0;
 
-void FCIVector::allocate_temp_space(std::shared_ptr<FCIStringLists> lists_, int print_) {
+void FCIVector::allocate_temp_space(std::shared_ptr<FCIStringLists> lists_, PrintLevel print_) {
     size_t nirreps = lists_->nirrep();
 
     // if CR is already allocated (e.g., because we computed several roots) make sure
@@ -71,7 +71,7 @@ void FCIVector::allocate_temp_space(std::shared_ptr<FCIStringLists> lists_, int 
     if (max_size > current_size) {
         CR = std::make_shared<psi::Matrix>("CR", max_size, max_size);
         CL = std::make_shared<psi::Matrix>("CL", max_size, max_size);
-        if (print_)
+        if (print_ >= PrintLevel::Verbose)
             outfile->Printf("\n  Allocating memory for the Hamiltonian algorithm. "
                             "Size: 2 x %zu x %zu.   Memory: %8.6f GB",
                             max_size, max_size, to_gb(2 * max_size * max_size));

--- a/forte/fci/fci_vector.h
+++ b/forte/fci/fci_vector.h
@@ -36,10 +36,10 @@
 #include "ambit/tensor.h"
 
 #include "base_classes/rdms.h"
+#include "helpers/printing.h"
+
 #include "fci_string_lists.h"
 #include "fci_string_address.h"
-
-#define CAPRICCIO_USE_DAXPY 1
 
 namespace psi {
 class Matrix;
@@ -136,9 +136,9 @@ class FCIVector {
     max_abs_elements(size_t num_dets);
 
     // Temporary memory allocation
-    static void allocate_temp_space(std::shared_ptr<FCIStringLists> lists_, int print_);
+    static void allocate_temp_space(std::shared_ptr<FCIStringLists> lists_, PrintLevel print_);
     static void release_temp_space();
-    void set_print(int print) { print_ = print; }
+    void set_print(PrintLevel print) { print_ = print; }
 
     // ==> Class Static Functions <==
     static std::shared_ptr<RDMs> compute_rdms(FCIVector& C_left, FCIVector& C_right, int max_order,
@@ -167,7 +167,7 @@ class FCIVector {
     /// The number of determinants per irrep
     std::vector<size_t> detpi_;
     /// The print level
-    int print_ = 0;
+    PrintLevel print_ = PrintLevel::Default;
 
     /// The string list
     std::shared_ptr<FCIStringLists> lists_;

--- a/forte/genci/ci_occupation.cc
+++ b/forte/genci/ci_occupation.cc
@@ -163,13 +163,19 @@ get_ci_occupation_patterns(size_t na, size_t nb, const std::vector<int>& occ_min
             num_spaces += 1;
         }
     }
+    // the exception that breaks the rule
+    if (num_spaces == 0) {
+        std::vector<occupation_t> empty_occ(1, occupation_t{});
+        std::vector<std::pair<size_t, size_t>> empty_pairs(1, {0, 0});
+        return std::make_tuple(1, empty_occ, empty_occ, empty_pairs);
+    }
     return generate_ormas_occupations(na, nb, min_occ, max_occ, space_size, num_spaces);
 }
 
 std::tuple<std::vector<occupation_t>, std::vector<occupation_t>,
            std::vector<std::pair<size_t, size_t>>>
 generate_gas_occupations(int na, int nb, const occupation_t& min_occ, const occupation_t& max_occ,
-                         const occupation_t& gas_size, size_t num_spaces) {
+                         const occupation_t& gas_size) {
     std::vector<occupation_t> gas_alfa_occupations;
     std::vector<occupation_t> gas_beta_occupations;
     std::vector<std::pair<size_t, size_t>> gas_occupations;

--- a/forte/genci/ci_occupation.cc
+++ b/forte/genci/ci_occupation.cc
@@ -26,9 +26,6 @@
  * @END LICENSE
  */
 
-// #include <algorithm>
-// #include <numeric>
-// #include <cmath>
 #include <string>
 
 #define FMT_HEADER_ONLY
@@ -38,129 +35,166 @@
 #include "psi4/libpsi4util/PsiOutStream.h"
 
 #include "helpers/printing.h"
-// #include "helpers/helpers.h"
 
-// #include "base_classes/mo_space_info.h"
-
-// #include "genci_string_address.h"
-
-// #include "genci_string_lists.h"
 #include "ci_occupation.h"
 
 namespace forte {
 
-void recursive_gas_generation(const std::vector<int>& gas_mine, const std::vector<int>& gas_maxe,
-                              size_t gas_num, int& n_config, std::vector<int> gas_configuration,
-                              size_t gas_count) {
-    // outfile->Printf("\n    %6d ", ++n_config);
-    // for (size_t i = 0; i < 2 * gas_num; i++) {
-    //     outfile->Printf(" %4d", gas_configuration[i]);
-    // }
-    // if (gas_count == 0) {
-    //     int gas1_na = gas_configuration[0];
-    //     int gas1_nb = gas_configuration[1];
-    //     int gas1_max = std::max(gas1_na, gas1_nb);
-    //     int gas1_min = std::min(gas1_na, gas1_nb);
-    //     int gas1_total = gas1_na + gas1_nb;
-    //     if (gas1_total <= gas_maxe[0] and gas1_max <= gas_size[0] and gas1_min >= 0 and
-    //         gas1_total >= gas_mine[0]) {
-    //         outfile->Printf("\n    %6d ", ++n_config);
-    //         for (size_t i = 0; i < 2 * gas_num; i++) {
-    //             outfile->Printf(" %4d", gas_configuration[i]);
-    //         }
-    //     }
-    // } else {
-    //     for (int gas_na = std::max(0, gas_mine[gas_count] - gas_size[gas_count]);
-    //          gas_na <= std::min(gas_maxe[gas_count], gas_size[gas_count]); gas_na++) {
-    //         for (int gas_nb = std::max(0, gas_mine[gas_count] - gas_na);
-    //              gas_nb <= std::min(gas_maxe[gas_count] - gas_na, gas_size[gas_count]); gas_nb++)
-    //              {
-    //             gas_configuration[2 * gas_count] = gas_na;
-    //             gas_configuration[2 * gas_count + 1] = gas_nb;
-    //             recursive_gas_generation(gas_mine, gas_maxe, gas_num, n_config,
-    //             gas_configuration,
-    //                                      gas_count - 1);
-    //         }
-    //     }
-    // }
+void add_occupation_pair(const occupation_t& alfa_occ, const occupation_t& beta_occ,
+                         std::vector<occupation_t>& alfa_occupations,
+                         std::vector<occupation_t>& beta_occupations,
+                         std::vector<std::pair<size_t, size_t>>& occupation_pairs) {
+    size_t alfa_index;
+    if (auto alfa_it = std::find(alfa_occupations.begin(), alfa_occupations.end(), alfa_occ);
+        alfa_it == alfa_occupations.end()) {
+        alfa_occupations.push_back(alfa_occ);
+        alfa_index = alfa_occupations.size() - 1;
+    } else {
+        alfa_index = std::distance(alfa_occupations.begin(), alfa_it);
+    }
+    size_t beta_index;
+    if (auto beta_it = std::find(beta_occupations.begin(), beta_occupations.end(), beta_occ);
+        beta_it == beta_occupations.end()) {
+        beta_occupations.push_back(beta_occ);
+        beta_index = beta_occupations.size() - 1;
+    } else {
+        beta_index = std::distance(beta_occupations.begin(), beta_it);
+    }
+    occupation_pairs.push_back(std::make_pair(alfa_index, beta_index));
+}
+
+void recursive_ormas_generation(int na, int nb, const occupation_t& min_occ,
+                                const occupation_t& max_occ, const occupation_t& space_size,
+                                size_t num_spaces, size_t space_count, occupation_t alfa_occ,
+                                occupation_t beta_occ, std::vector<occupation_t>& alfa_occupations,
+                                std::vector<occupation_t>& beta_occupations,
+                                std::vector<std::pair<size_t, size_t>>& occupation_pairs) {
+    // if we reach the last space
+    if (space_count == num_spaces - 1) {
+        int occ_max = std::max(na, nb);
+        int occ_min = std::min(na, nb);
+        int occ_total = na + nb;
+        // ensure that the number of electrons in the last space is within the bounds
+        if (occ_total <= max_occ[space_count] and occ_total >= min_occ[space_count] and
+            occ_max <= space_size[space_count] and occ_min >= 0) {
+            // add the last space to the occupation
+            alfa_occ[space_count] = na;
+            beta_occ[space_count] = nb;
+            add_occupation_pair(alfa_occ, beta_occ, alfa_occupations, beta_occupations,
+                                occupation_pairs);
+        }
+    } else {
+        // the minimum number of alpha electrons (na_min) is the total number of electrons minus
+        // the maximum number that can filled in the beta levels of this space. To ensure that the
+        // number is positive, we take the maximum of this number and zero.
+        int na_min = std::max(min_occ[space_count] - space_size[space_count], 0);
+        // the maximum number of alpha electrons (na_max) is the total number of electrons, or
+        // at most the size of this space
+        int na_max = std::min(max_occ[space_count], space_size[space_count]);
+        for (int space_na = na_min; space_na <= na_max; space_na++) {
+            // the minimum number of beta electrons (nb_min) is the total number of electrons
+            // minus those allocated to the alpha levels of this space. To ensure that the number is
+            // positive, we take the maximum of this number and zero.
+            int nb_min = std::max(min_occ[space_count] - space_na, 0);
+            // the maximum number of beta electrons (nb_max) is the total number of electrons
+            // minus the number of alpha electrons, or at most the size of this space
+            int nb_max = std::min(max_occ[space_count] - space_na, space_size[space_count]);
+            for (int space_nb = nb_min; space_nb <= nb_max; space_nb++) {
+                int occ_total = space_na + space_nb;
+                // this next check might be useless
+                if (occ_total <= max_occ[space_count] and occ_total >= min_occ[space_count]) {
+                    // add the current space to the occupation
+                    alfa_occ[space_count] = space_na;
+                    beta_occ[space_count] = space_nb;
+                    recursive_ormas_generation(na - space_na, nb - space_nb, min_occ, max_occ,
+                                               space_size, num_spaces, space_count + 1, alfa_occ,
+                                               beta_occ, alfa_occupations, beta_occupations,
+                                               occupation_pairs);
+                }
+            }
+        }
+    }
 }
 
 std::tuple<size_t, std::vector<occupation_t>, std::vector<occupation_t>,
            std::vector<std::pair<size_t, size_t>>>
-get_ormas_occupation(size_t na, size_t nb, const std::vector<int>& gas_min,
-                     const std::vector<int>& gas_max, const std::vector<int>& gas_size) {
-    psi::outfile->Printf("\n\n    %s", container_to_string(gas_min).c_str());
-    psi::outfile->Printf("\n    %s", container_to_string(gas_max).c_str());
-    psi::outfile->Printf("\n    %s", container_to_string(gas_size).c_str());
+generate_ormas_occupations(size_t na, size_t nb, const occupation_t& min_occ,
+                           const occupation_t& max_occ, const occupation_t& space_size,
+                           size_t num_spaces) {
+    occupation_t alfa_occ{};
+    occupation_t beta_occ{};
+    std::vector<occupation_t> alfa_occupations;
+    std::vector<occupation_t> beta_occupations;
+    std::vector<std::pair<size_t, size_t>> occupation_pairs;
+    recursive_ormas_generation(na, nb, min_occ, max_occ, space_size, num_spaces, 0, alfa_occ,
+                               beta_occ, alfa_occupations, beta_occupations, occupation_pairs);
+    return std::make_tuple(num_spaces, alfa_occupations, beta_occupations, occupation_pairs);
+}
 
+std::tuple<size_t, std::vector<occupation_t>, std::vector<occupation_t>,
+           std::vector<std::pair<size_t, size_t>>>
+get_ci_occupation_patterns(size_t na, size_t nb, const std::vector<int>& occ_min,
+                           const std::vector<int>& occ_max, const std::vector<int>& gas_size) {
     // The vectors of maximum number of electrons, minimum number of electrons,
     // and the number of orbitals
-    std::vector<int> gas_max_el(6, 0);
-    std::vector<int> gas_min_el(6, 0);
-    size_t num_gas_spaces = 0;
-    for (size_t n = 0; n < 6; n++) {
-        std::string space = "GAS" + std::to_string(n + 1);
-        size_t gasn_size = n < gas_size.size() ? gas_size[n] : 0;
-        if (gasn_size) {
-            // define max_e_number to be the largest possible number of electrons in the GASn
-            int max_e_number = std::min(gasn_size * 2, na + nb);
-            // but if we can read its value, do so
-            if (gas_max.size() > n) {
-                // If the defined maximum number of electrons exceed number of orbitals,
-                // redefine the maximum number of electrons
-                max_e_number = std::min(gas_max[n], max_e_number);
-            }
-            gas_max_el[n] = max_e_number;
+    occupation_t max_occ{};
+    occupation_t min_occ{};
+    occupation_t space_size{};
 
-            // define min_e_number to be the smallest possible number of electrons in the GASn
+    size_t num_spaces = 0;
+    for (size_t n = 0; n < max_active_spaces; n++) {
+        size_t space_n_size = n < gas_size.size() ? gas_size[n] : 0;
+        if (space_n_size) {
+            // find the largest possible number of electrons in this space
+            int max_e_number = std::min(space_n_size * 2, na + nb);
+            // but if we can read its value, do so and make sure this number is within the bounds
+            if (occ_max.size() > n) {
+                max_e_number = std::min(occ_max[n], max_e_number);
+            }
+            // find the smallest possible number of electrons in this space
             size_t min_e_number = 0;
             // but if we can read its value, do so
-            if (gas_min.size() > n) {
-                min_e_number = gas_min[n];
+            if (occ_min.size() > n) {
+                min_e_number = occ_min[n];
             }
-            gas_min_el[n] = min_e_number;
-            num_gas_spaces += 1;
+            max_occ[n] = max_e_number;
+            min_occ[n] = min_e_number;
+            space_size[n] = space_n_size;
+            num_spaces += 1;
         }
     }
-
-    auto [gas_alfa_occupations, gas_beta_occupations, gas_occupations] =
-        generate_gas_occupations(na, nb, gas_min_el, gas_max_el, gas_size, num_gas_spaces);
-
-    return std::make_tuple(num_gas_spaces, gas_alfa_occupations, gas_beta_occupations,
-                           gas_occupations);
+    return generate_ormas_occupations(na, nb, min_occ, max_occ, space_size, num_spaces);
 }
 
 std::tuple<std::vector<occupation_t>, std::vector<occupation_t>,
            std::vector<std::pair<size_t, size_t>>>
-generate_gas_occupations(int na, int nb, const std::vector<int>& gas_min_el,
-                         const std::vector<int>& gas_max_el, const std::vector<int>& gas_size,
-                         size_t num_gas_spaces) {
+generate_gas_occupations(int na, int nb, const occupation_t& min_occ, const occupation_t& max_occ,
+                         const occupation_t& gas_size, size_t num_spaces) {
     std::vector<occupation_t> gas_alfa_occupations;
     std::vector<occupation_t> gas_beta_occupations;
     std::vector<std::pair<size_t, size_t>> gas_occupations;
-    for (int gas6_na = std::max(0, gas_min_el[5] - gas_size[5]);
-         gas6_na <= std::min(gas_max_el[5], gas_size[5]); gas6_na++) {
-        for (int gas6_nb = std::max(0, gas_min_el[5] - gas6_na);
-             gas6_nb <= std::min(gas_max_el[5] - gas6_na, gas_size[5]); gas6_nb++) {
-            for (int gas5_na = std::max(0, gas_min_el[4] - gas_size[4]);
-                 gas5_na <= std::min(gas_max_el[4], gas_size[4]); gas5_na++) {
-                for (int gas5_nb = std::max(0, gas_min_el[4] - gas5_na);
-                     gas5_nb <= std::min(gas_max_el[4] - gas5_na, gas_size[4]); gas5_nb++) {
-                    for (int gas4_na = std::max(0, gas_min_el[3] - gas_size[3]);
-                         gas4_na <= std::min(gas_max_el[3], gas_size[3]); gas4_na++) {
-                        for (int gas4_nb = std::max(0, gas_min_el[3] - gas4_na);
-                             gas4_nb <= std::min(gas_max_el[3] - gas4_na, gas_size[3]); gas4_nb++) {
-                            for (int gas3_na = std::max(0, gas_min_el[2] - gas_size[2]);
-                                 gas3_na <= std::min(gas_max_el[2], gas_size[2]); gas3_na++) {
-                                for (int gas3_nb = std::max(0, gas_min_el[2] - gas3_na);
-                                     gas3_nb <= std::min(gas_max_el[2] - gas3_na, gas_size[2]);
+
+    for (int gas6_na = std::max(0, min_occ[5] - gas_size[5]);
+         gas6_na <= std::min(max_occ[5], gas_size[5]); gas6_na++) {
+        for (int gas6_nb = std::max(0, min_occ[5] - gas6_na);
+             gas6_nb <= std::min(max_occ[5] - gas6_na, gas_size[5]); gas6_nb++) {
+            for (int gas5_na = std::max(0, min_occ[4] - gas_size[4]);
+                 gas5_na <= std::min(max_occ[4], gas_size[4]); gas5_na++) {
+                for (int gas5_nb = std::max(0, min_occ[4] - gas5_na);
+                     gas5_nb <= std::min(max_occ[4] - gas5_na, gas_size[4]); gas5_nb++) {
+                    for (int gas4_na = std::max(0, min_occ[3] - gas_size[3]);
+                         gas4_na <= std::min(max_occ[3], gas_size[3]); gas4_na++) {
+                        for (int gas4_nb = std::max(0, min_occ[3] - gas4_na);
+                             gas4_nb <= std::min(max_occ[3] - gas4_na, gas_size[3]); gas4_nb++) {
+                            for (int gas3_na = std::max(0, min_occ[2] - gas_size[2]);
+                                 gas3_na <= std::min(max_occ[2], gas_size[2]); gas3_na++) {
+                                for (int gas3_nb = std::max(0, min_occ[2] - gas3_na);
+                                     gas3_nb <= std::min(max_occ[2] - gas3_na, gas_size[2]);
                                      gas3_nb++) {
-                                    for (int gas2_na = std::max(0, gas_min_el[1] - gas_size[1]);
-                                         gas2_na <= std::min(gas_max_el[1], gas_size[1]);
-                                         gas2_na++) {
-                                        for (int gas2_nb = std::max(0, gas_min_el[1] - gas2_na);
-                                             gas2_nb <=
-                                             std::min(gas_max_el[1] - gas2_na, gas_size[1]);
+                                    for (int gas2_na = std::max(0, min_occ[1] - gas_size[1]);
+                                         gas2_na <= std::min(max_occ[1], gas_size[1]); gas2_na++) {
+                                        for (int gas2_nb = std::max(0, min_occ[1] - gas2_na);
+                                             gas2_nb <= std::min(max_occ[1] - gas2_na, gas_size[1]);
                                              gas2_nb++) {
                                             int gas1_na = na - gas2_na - gas3_na - gas4_na -
                                                           gas5_na - gas6_na;
@@ -169,9 +203,9 @@ generate_gas_occupations(int na, int nb, const std::vector<int>& gas_min_el,
                                             int gas1_max = std::max(gas1_na, gas1_nb);
                                             int gas1_min = std::min(gas1_na, gas1_nb);
                                             int gas1_total = gas1_na + gas1_nb;
-                                            if (gas1_total <= gas_max_el[0] and
+                                            if (gas1_total <= max_occ[0] and
                                                 gas1_max <= gas_size[0] and gas1_min >= 0 and
-                                                gas1_total >= gas_min_el[0]) {
+                                                gas1_total >= min_occ[0]) {
                                                 std::array<int, 6> alfa_occ = {gas1_na, gas2_na,
                                                                                gas3_na, gas4_na,
                                                                                gas5_na, gas6_na};
@@ -239,7 +273,8 @@ get_gas_occupation(size_t na, size_t nb, const std::vector<int>& gas_min,
         std::string space = "GAS" + std::to_string(n + 1);
         size_t gasn_size = n < gas_size.size() ? gas_size[n] : 0;
         if (gasn_size) {
-            // define max_e_number to be the largest possible number of electrons in the GASn
+            // define max_e_number to be the largest possible number of electrons in the
+            // GASn
             int max_e_number = std::min(gasn_size * 2, na + nb);
             // but if we can read its value, do so
             if (gas_max.size() > n) {
@@ -249,7 +284,8 @@ get_gas_occupation(size_t na, size_t nb, const std::vector<int>& gas_min,
             }
             gas_max_el[n] = max_e_number;
 
-            // define min_e_number to be the smallest possible number of electrons in the GASn
+            // define min_e_number to be the smallest possible number of electrons in the
+            // GASn
             size_t min_e_number = 0;
             // but if we can read its value, do so
             if (gas_min.size() > n) {

--- a/forte/genci/ci_occupation.h
+++ b/forte/genci/ci_occupation.h
@@ -43,15 +43,15 @@ std::tuple<size_t, std::vector<std::array<int, 6>>, std::vector<std::array<int, 
 get_gas_occupation(size_t na, size_t nb, const std::vector<int>& gas_min,
                    const std::vector<int>& gas_max, const std::vector<int>& gas_size);
 
-std::tuple<size_t, std::vector<std::array<int, 6>>, std::vector<std::array<int, 6>>,
+std::tuple<size_t, std::vector<occupation_t>, std::vector<occupation_t>,
            std::vector<std::pair<size_t, size_t>>>
-get_ormas_occupation(size_t na, size_t nb, const std::vector<int>& gas_min,
-                     const std::vector<int>& gas_max, const std::vector<int>& gas_size);
+get_ci_occupation_patterns(size_t na, size_t nb, const std::vector<int>& min_occ,
+                           const std::vector<int>& max_occ, const std::vector<int>& size);
 
 std::tuple<std::vector<occupation_t>, std::vector<occupation_t>,
            std::vector<std::pair<size_t, size_t>>>
-generate_gas_occupations(int na, int nb, const std::vector<int>& gas_min_el,
-                         const std::vector<int>& gas_max_el, const std::vector<int>& gas_size,
+generate_gas_occupations(int na, int nb, const occupation_t& gas_min_el,
+                         const occupation_t& gas_max_el, const occupation_t& gas_size,
                          size_t num_gas_spaces);
 
 std::vector<std::array<int, 6>>

--- a/forte/genci/ci_occupation.h
+++ b/forte/genci/ci_occupation.h
@@ -51,8 +51,7 @@ get_ci_occupation_patterns(size_t na, size_t nb, const std::vector<int>& min_occ
 std::tuple<std::vector<occupation_t>, std::vector<occupation_t>,
            std::vector<std::pair<size_t, size_t>>>
 generate_gas_occupations(int na, int nb, const occupation_t& gas_min_el,
-                         const occupation_t& gas_max_el, const occupation_t& gas_size,
-                         size_t num_gas_spaces);
+                         const occupation_t& gas_max_el, const occupation_t& gas_size);
 
 std::vector<std::array<int, 6>>
 generate_1h_occupations(const std::vector<std::array<int, 6>>& gas_occupations);

--- a/forte/genci/genci_solver_initial_guess.cc
+++ b/forte/genci/genci_solver_initial_guess.cc
@@ -76,7 +76,7 @@ std::vector<Determinant> GenCISolver::initial_guess_generate_dets(std::shared_pt
     // Make sure that the spin space is complete
     enforce_spin_completeness(guess_dets, active_mo_.size());
     if (guess_dets.size() > num_guess_dets) {
-        if (print_ > 0) {
+        if (print_ >= PrintLevel::Brief) {
             psi::outfile->Printf("\n  Initial guess space is incomplete.\n  Adding "
                                  "%d determinant(s).",
                                  guess_dets.size() - num_guess_dets);
@@ -98,13 +98,14 @@ GenCISolver::initial_guess_det(std::shared_ptr<psi::Vector> diag, size_t num_gue
 
     // here we use a standard guess procedure
     return find_initial_guess_det(guess_dets, guess_dets_pos, num_guess_states, fci_ints,
-                                  state().multiplicity(), true, print_,
+                                  state().multiplicity(), true, print_ >= PrintLevel::Default,
                                   std::vector<std::vector<std::pair<size_t, double>>>());
 }
 
 sparse_mat GenCISolver::initial_guess_csf(std::shared_ptr<psi::Vector> diag,
                                           size_t num_guess_states) {
-    return find_initial_guess_csf(diag, num_guess_states, state().multiplicity(), print_);
+    return find_initial_guess_csf(diag, num_guess_states, state().multiplicity(),
+                                  print_ >= PrintLevel::Default);
 }
 
 std::shared_ptr<psi::Vector>

--- a/forte/genci/genci_solver_rdms.cc
+++ b/forte/genci/genci_solver_rdms.cc
@@ -99,8 +99,8 @@ std::shared_ptr<RDMs> GenCISolver::compute_rdms_root(size_t root_left, size_t ro
     }
 
     // Print the NO if energy converged
-    if (print_no_ || print_ > PrintLevel::Default) {
-        // C_->print_natural_orbitals(mo_space_info_, rdms);
+    if (print_no_ || print_ >= PrintLevel::Default) {
+        C_->print_natural_orbitals(mo_space_info_, rdms);
     }
     return rdms;
 }

--- a/forte/genci/genci_solver_rdms.cc
+++ b/forte/genci/genci_solver_rdms.cc
@@ -84,7 +84,7 @@ std::shared_ptr<RDMs> GenCISolver::compute_rdms_root(size_t root_left, size_t ro
         T_->copy(*C_);
     }
 
-    if (print_) {
+    if (print_ >= PrintLevel::Verbose) {
         std::string title_rdm = "Computing RDMs <" + std::to_string(root_left) + " " +
                                 state().str_minimum() + "| ... |" + std::to_string(root_right) +
                                 " " + state().str_minimum() + ">";
@@ -99,7 +99,7 @@ std::shared_ptr<RDMs> GenCISolver::compute_rdms_root(size_t root_left, size_t ro
     }
 
     // Print the NO if energy converged
-    if (print_no_ || print_ > 0) {
+    if (print_no_ || print_ > PrintLevel::Default) {
         // C_->print_natural_orbitals(mo_space_info_, rdms);
     }
     return rdms;

--- a/forte/genci/genci_solver_transition_rdms.cc
+++ b/forte/genci/genci_solver_transition_rdms.cc
@@ -104,7 +104,7 @@ GenCISolver::compute_transition_rdms_root(size_t root_left, size_t root_right,
     }
 
     // // Print the NO if energy converged
-    // if (print_no_ || print_ > 0) {
+    // if (print_no_ || print_ > 1) {
     //     C_->print_natural_orbitals(mo_space_info_);
     // }
     return rdms;

--- a/forte/genci/genci_string_lists.cc
+++ b/forte/genci/genci_string_lists.cc
@@ -107,7 +107,7 @@ void GenCIStringLists::startup(std::shared_ptr<MOSpaceInfo> mo_space_info) {
     // });
 
     std::tie(ngas_spaces_, gas_alfa_occupations_, gas_beta_occupations_, gas_occupations_) =
-        get_gas_occupation(na_, nb_, gas_min_, gas_max_, gas_size_);
+        get_ci_occupation_patterns(na_, nb_, gas_min_, gas_max_, gas_size_);
 
     if (print_ >= PrintLevel::Default) {
         print_h2("Possible Electron Occupations");

--- a/forte/genci/genci_string_lists.cc
+++ b/forte/genci/genci_string_lists.cc
@@ -58,7 +58,7 @@ template <typename Func> void debug(Func func) {
 }
 
 GenCIStringLists::GenCIStringLists(std::shared_ptr<MOSpaceInfo> mo_space_info, size_t na, size_t nb,
-                                   int symmetry, int print, const std::vector<int> gas_min,
+                                   int symmetry, PrintLevel print, const std::vector<int> gas_min,
                                    const std::vector<int> gas_max)
     : symmetry_(symmetry), nirrep_(mo_space_info->nirrep()), ncmo_(mo_space_info->size("ACTIVE")),
       na_(na), nb_(nb), print_(print), gas_min_(gas_min), gas_max_(gas_max) {
@@ -109,10 +109,12 @@ void GenCIStringLists::startup(std::shared_ptr<MOSpaceInfo> mo_space_info) {
     std::tie(ngas_spaces_, gas_alfa_occupations_, gas_beta_occupations_, gas_occupations_) =
         get_gas_occupation(na_, nb_, gas_min_, gas_max_, gas_size_);
 
-    print_h2("Possible Electron Occupations in GAS");
-    auto table = occupation_table(ngas_spaces_, gas_alfa_occupations_, gas_beta_occupations_,
-                                  gas_occupations_);
-    outfile->Printf("%s", table.c_str());
+    if (print_ >= PrintLevel::Default) {
+        print_h2("Possible Electron Occupations");
+        auto table = occupation_table(ngas_spaces_, gas_alfa_occupations_, gas_beta_occupations_,
+                                      gas_occupations_);
+        outfile->Printf("%s", table.c_str());
+    }
 
     // local_timers
     double str_list_timer = 0.0;
@@ -252,22 +254,23 @@ void GenCIStringLists::startup(std::shared_ptr<MOSpaceInfo> mo_space_info) {
     double total_time = str_list_timer + nn_list_timer + vo_list_timer + oo_list_timer +
                         vvoo_list_timer + vovo_list_timer;
 
-    if (print_) {
+    if (print_ >= PrintLevel::Default) {
         table_printer printer;
         printer.add_int_data({{"number of alpha electrons", na_},
                               {"number of beta electrons", nb_},
                               {"number of alpha strings", nas_},
                               {"number of beta strings", nbs_}});
-        printer.add_timing_data({{"timing for strings", str_list_timer},
-                                 {"timing for NN strings", nn_list_timer},
-                                 {"timing for VO strings", vo_list_timer},
-                                 {"timing for OO strings", oo_list_timer},
-                                 {"timing for VVOO strings", vvoo_list_timer},
-                                 {"timing for 1-hole strings", h1_list_timer},
-                                 {"timing for 2-hole strings", h2_list_timer},
-                                 {"timing for 3-hole strings", h3_list_timer},
-                                 {"total timing", total_time}});
-
+        if (print_ >= PrintLevel::Verbose) {
+            printer.add_timing_data({{"timing for strings", str_list_timer},
+                                     {"timing for NN strings", nn_list_timer},
+                                     {"timing for VO strings", vo_list_timer},
+                                     {"timing for OO strings", oo_list_timer},
+                                     {"timing for VVOO strings", vvoo_list_timer},
+                                     {"timing for 1-hole strings", h1_list_timer},
+                                     {"timing for 2-hole strings", h2_list_timer},
+                                     {"timing for 3-hole strings", h3_list_timer},
+                                     {"total timing", total_time}});
+        }
         std::string table = printer.get_table("String Lists");
         outfile->Printf("%s", table.c_str());
     }

--- a/forte/genci/genci_string_lists.h
+++ b/forte/genci/genci_string_lists.h
@@ -35,6 +35,8 @@
 #include <utility>
 
 #include "helpers/timer.h"
+#include "helpers/printing.h"
+
 #include "sparse_ci/determinant.h"
 #include "fci/string_list_defs.h"
 #include "genci_string_address.h"
@@ -54,7 +56,8 @@ class GenCIStringLists {
     // ==> Constructor and Destructor <==
     /// @brief The GenCIStringLists constructor
     GenCIStringLists(std::shared_ptr<MOSpaceInfo> mo_space_info, size_t na, size_t nb, int symmetry,
-                     int print, const std::vector<int> gas_min, const std::vector<int> gas_max);
+                     PrintLevel print, const std::vector<int> gas_min,
+                     const std::vector<int> gas_max);
 
     ~GenCIStringLists() {}
 
@@ -180,7 +183,7 @@ class GenCIStringLists {
     /// The offset array for pairpi
     std::vector<int> pair_offset_;
     /// The print level
-    int print_ = 0;
+    PrintLevel print_ = PrintLevel::Default;
 
     // GAS specific data
 

--- a/forte/genci/genci_vector.cc
+++ b/forte/genci/genci_vector.cc
@@ -219,54 +219,52 @@ void GenCIVector::zero() {
         c->zero();
 }
 
-// void GenCIVector::print_natural_orbitals(std::shared_ptr<MOSpaceInfo> mo_space_info,
-//                                        std::shared_ptr<RDMs> rdms) {
-//     print_h2("Natural Orbitals");
-//     psi::Dimension active_dim = mo_space_info->dimension("ACTIVE");
-//     auto nfdocc = mo_space_info->size("FROZEN_DOCC");
+void GenCIVector::print_natural_orbitals(std::shared_ptr<MOSpaceInfo> mo_space_info,
+                                         std::shared_ptr<RDMs> rdms) {
+    print_h2("Natural Orbitals Occupation Numbers");
+    psi::Dimension active_dim = mo_space_info->dimension("ACTIVE");
+    auto nfdocc = mo_space_info->size("FROZEN_DOCC");
 
-//     auto G1 = rdms->SF_G1();
-//     auto& G1_data = G1.data();
+    auto G1 = rdms->SF_G1();
+    auto& G1_data = G1.data();
 
-//     auto opdm = std::make_shared<psi::Matrix>("OPDM", active_dim, active_dim);
+    auto opdm = std::make_shared<psi::Matrix>("OPDM", active_dim, active_dim);
 
-//     int offset = 0;
-//     for (int h = 0; h < nirrep_; h++) {
-//         for (int u = 0; u < active_dim[h]; u++) {
-//             for (int v = 0; v < active_dim[h]; v++) {
-//                 double gamma_uv = G1_data[(u + offset) * ncmo_ + v + offset];
-//                 opdm->set(h, u, v, gamma_uv);
-//             }
-//         }
-//         offset += active_dim[h];
-//     }
+    int offset = 0;
+    for (int h = 0; h < nirrep_; h++) {
+        for (int u = 0; u < active_dim[h]; u++) {
+            for (int v = 0; v < active_dim[h]; v++) {
+                double gamma_uv = G1_data[(u + offset) * ncmo_ + v + offset];
+                opdm->set(h, u, v, gamma_uv);
+            }
+        }
+        offset += active_dim[h];
+    }
 
-//     auto OCC = std::make_shared<psi::Vector>("Occupation numbers", active_dim);
-//     auto NO = std::make_shared<psi::Matrix>("MO -> NO transformation", active_dim,
-//     active_dim);
+    auto OCC = std::make_shared<psi::Vector>("Occupation numbers", active_dim);
+    auto NO = std::make_shared<psi::Matrix>("MO -> NO transformation", active_dim, active_dim);
 
-//     opdm->diagonalize(NO, OCC, psi::descending);
-//     std::vector<std::pair<double, std::pair<int, int>>> vec_irrep_occupation;
-//     for (int h = 0; h < nirrep_; h++) {
-//         for (int u = 0; u < active_dim[h]; u++) {
-//             auto irrep_occ = std::make_pair(OCC->get(h, u), std::make_pair(h, u + 1));
-//             vec_irrep_occupation.push_back(irrep_occ);
-//         }
-//     }
-//     std::sort(vec_irrep_occupation.begin(), vec_irrep_occupation.end(),
-//               std::greater<std::pair<double, std::pair<int, int>>>());
+    opdm->diagonalize(NO, OCC, psi::descending);
+    std::vector<std::pair<double, std::pair<int, int>>> vec_irrep_occupation;
+    for (int h = 0; h < nirrep_; h++) {
+        for (int u = 0; u < active_dim[h]; u++) {
+            auto irrep_occ = std::make_pair(OCC->get(h, u), std::make_pair(h, u + 1));
+            vec_irrep_occupation.push_back(irrep_occ);
+        }
+    }
+    std::sort(vec_irrep_occupation.begin(), vec_irrep_occupation.end(),
+              std::greater<std::pair<double, std::pair<int, int>>>());
 
-//     size_t count = 0;
-//     psi::outfile->Printf("\n    ");
-//     for (auto vec : vec_irrep_occupation) {
-//         psi::outfile->Printf(" %4d%-4s%11.6f  ", vec.second.second + nfdocc,
-//                              mo_space_info->irrep_label(vec.second.first).c_str(),
-//                              vec.first);
-//         if (count++ % 3 == 2 && count != vec_irrep_occupation.size())
-//             psi::outfile->Printf("\n    ");
-//     }
-//     psi::outfile->Printf("\n");
-// }
+    size_t count = 0;
+    psi::outfile->Printf("\n    ");
+    for (auto vec : vec_irrep_occupation) {
+        psi::outfile->Printf(" %4d%-4s%11.6f  ", vec.second.second + nfdocc,
+                             mo_space_info->irrep_label(vec.second.first).c_str(), vec.first);
+        if (count++ % 3 == 2 && count != vec_irrep_occupation.size())
+            psi::outfile->Printf("\n    ");
+    }
+    psi::outfile->Printf("\n");
+}
 
 double** GenCIVector::gather_C_block(std::shared_ptr<psi::Matrix> M, bool alfa,
                                      std::shared_ptr<StringAddress> alfa_address,

--- a/forte/genci/genci_vector.cc
+++ b/forte/genci/genci_vector.cc
@@ -60,7 +60,7 @@ double GenCIVector::h2_aaaa_timer = 0.0;
 double GenCIVector::h2_aabb_timer = 0.0;
 double GenCIVector::h2_bbbb_timer = 0.0;
 
-void GenCIVector::allocate_temp_space(std::shared_ptr<GenCIStringLists> lists_, int print_) {
+void GenCIVector::allocate_temp_space(std::shared_ptr<GenCIStringLists> lists_, PrintLevel print_) {
     // if CR is already allocated (e.g., because we computed several roots) make sure
     // we do not allocate a matrix of smaller size. So let's find out the size of the current CR
     size_t current_size = CR ? CR->rowdim() : 0;
@@ -79,7 +79,7 @@ void GenCIVector::allocate_temp_space(std::shared_ptr<GenCIStringLists> lists_, 
     if (max_size > current_size) {
         CR = std::make_shared<psi::Matrix>("CR", max_size, max_size);
         CL = std::make_shared<psi::Matrix>("CL", max_size, max_size);
-        if (print_)
+        if (print_ >= PrintLevel::Verbose)
             psi::outfile->Printf("\n  Allocating memory for the Hamiltonian algorithm. "
                                  "Size: 2 x %zu x %zu.   Memory: %8.6f GB",
                                  max_size, max_size, to_gb(2 * max_size * max_size));

--- a/forte/genci/genci_vector.h
+++ b/forte/genci/genci_vector.h
@@ -34,12 +34,11 @@
 
 #include "psi4/libmints/dimension.h"
 #include "ambit/tensor.h"
+#include "helpers/printing.h"
 
 #include "base_classes/rdms.h"
 #include "genci_string_lists.h"
 #include "sparse_ci/sparse_state_vector.h"
-
-#define CAPRICCIO_USE_DAXPY 1
 
 namespace psi {
 class Matrix;
@@ -140,9 +139,11 @@ class GenCIVector {
     max_abs_elements(size_t num_dets);
 
     // Temporary memory allocation
-    static void allocate_temp_space(std::shared_ptr<GenCIStringLists> lists_, int print_);
+    static void allocate_temp_space(std::shared_ptr<GenCIStringLists> lists_, PrintLevel print_);
     static void release_temp_space();
-    void set_print(int print) { print_ = print; }
+
+    /// Return the print level
+    void set_print(PrintLevel print) { print_ = print; }
 
     // ==> Class Static Functions <==
     static std::shared_ptr<RDMs> compute_rdms(GenCIVector& C_left, GenCIVector& C_right,
@@ -240,7 +241,7 @@ class GenCIVector {
     /// The number of determinants per class
     std::vector<size_t> detpi_; // TODO: remove this
     /// The print level
-    int print_ = 0;
+    PrintLevel print_ = PrintLevel::Default;
 
     /// The string list
     std::shared_ptr<GenCIStringLists> lists_;

--- a/forte/genci/genci_vector.h
+++ b/forte/genci/genci_vector.h
@@ -130,8 +130,8 @@ class GenCIVector {
 
     /// Print the natural_orbitals from FCIWFN
     /// Assume user specified active space
-    // void print_natural_orbitals(std::shared_ptr<MOSpaceInfo> mospace_info,
-    //                             std::shared_ptr<RDMs> rdms);
+    void print_natural_orbitals(std::shared_ptr<MOSpaceInfo> mospace_info,
+                                std::shared_ptr<RDMs> rdms);
 
     /// Return the elements with the largest absolute value
     /// This function returns the tuple (|C_I|,C_I,class_Ia, class_Ib,Ia,Ib)

--- a/forte/genci/genci_vector_rdm.cc
+++ b/forte/genci/genci_vector_rdm.cc
@@ -110,9 +110,9 @@ std::shared_ptr<RDMs> GenCIVector::compute_rdms(GenCIVector& C_left, GenCIVector
         rdm_timing.push_back(t.get());
     }
 
-    for (size_t n = 0; n < rdm_timing.size(); ++n) {
-        psi::outfile->Printf("\n    Timing for %d-RDM: %.3f s", n + 1, rdm_timing[n]);
-    }
+    // for (size_t n = 0; n < rdm_timing.size(); ++n) {
+    //     psi::outfile->Printf("\n    Timing for %d-RDM: %.3f s", n + 1, rdm_timing[n]);
+    // }
 
     if (type == RDMsType::spin_dependent) {
         if (max_rdm_level == 1) {

--- a/forte/genci/genci_vector_rdm.cc
+++ b/forte/genci/genci_vector_rdm.cc
@@ -459,7 +459,7 @@ ambit::Tensor GenCIVector::compute_3rdm_aab_same_irrep(GenCIVector& C_left, GenC
     // here we screen for the absolute value of the elements of the C vector, and since the vector
     // is normalized, we can guarantee that the neglected contribution to the 3-RDM is smaller or
     // equal than this value
-    const double c_threshold = 1.0e-14;
+    // const double c_threshold = 1.0e-14;
 
     size_t ncmo = C_left.ncmo_;
     const auto& lists = C_left.lists_;
@@ -501,8 +501,8 @@ ambit::Tensor GenCIVector::compute_3rdm_aab_same_irrep(GenCIVector& C_left, GenC
                             for (const auto& [sign_uv, u, v, Ja] : Ka_left_list) {
                                 for (const auto& [sign_w, w, Jb] : Kb_left_list) {
                                     const double ClJ = sign_uv * sign_w * Cl[Ja][Jb];
-                                    if (std::fabs(ClJ) < c_threshold)
-                                        continue;
+                                    // if (std::fabs(ClJ) < c_threshold)
+                                    //     continue;
                                     for (const auto& [sign_xy, x, y, Ia] : Ka_right_list) {
                                         const auto CrIa = Cr[Ia];
                                         for (const auto& [sign_z, z, Ib] : Kb_right_list) {
@@ -542,7 +542,7 @@ ambit::Tensor GenCIVector::compute_3rdm_abb_same_irrep(GenCIVector& C_left, GenC
     // here we screen for the absolute value of the elements of the C vector, and since the vector
     // is normalized, we can guarantee that the neglected contribution to the 3-RDM is smaller or
     // equal than this value
-    const double c_threshold = 1.0e-14;
+    // const double c_threshold = 1.0e-14;
 
     size_t ncmo = C_left.ncmo_;
     const auto& lists = C_left.lists_;
@@ -584,8 +584,8 @@ ambit::Tensor GenCIVector::compute_3rdm_abb_same_irrep(GenCIVector& C_left, GenC
                             for (const auto& [sign_u, u, Ja] : Ka_left_list) {
                                 for (const auto& [sign_vw, v, w, Jb] : Kb_left_list) {
                                     const double ClJ = sign_u * sign_vw * Cl[Ja][Jb];
-                                    if (std::fabs(ClJ) < c_threshold)
-                                        continue;
+                                    // if (std::fabs(ClJ) < c_threshold)
+                                    //     continue;
                                     for (const auto& [sign_x, x, Ia] : Ka_right_list) {
                                         const auto CrIa = Cr[Ia];
                                         for (const auto& [sign_yz, y, z, Ib] : Kb_right_list) {

--- a/forte/genci/genci_vector_transition_rdm.cc
+++ b/forte/genci/genci_vector_transition_rdm.cc
@@ -127,6 +127,10 @@ ambit::Tensor compute_1rdm_different_irrep(GenCIVector& C_left, GenCIVector& C_r
 
     rdm.zero();
     auto& rdm_data = rdm.data();
+
+    // Here we compute the RDMs for the case of different irreps
+    // <Ja|a^{+}_p a_q|Ia> CL_{Ja,K} CR_{Ia,K}
+
     // loop over blocks of matrix C
     for (const auto& [nI, class_Ia, class_Ib] : lists_right->determinant_classes()) {
         if (lists_right->detpblk(nI) == 0)
@@ -153,9 +157,6 @@ ambit::Tensor compute_1rdm_different_irrep(GenCIVector& C_left, GenCIVector& C_r
             auto Cl = C_left.gather_C_block(GenCIVector::get_CL(), alfa, alfa_address_left,
                                             beta_address_left, class_Ja, class_Jb, false);
 
-            // size_t maxL = alfa ? beta_address_right->strpcls(class_Ib)
-            //                    : alfa_address_right->strpcls(class_Ia);
-
             const auto& string_list_block = alfa ? string_list[std::make_pair(class_Ib, class_Jb)]
                                                  : string_list[std::make_pair(class_Ia, class_Ja)];
 
@@ -173,100 +174,6 @@ ambit::Tensor compute_1rdm_different_irrep(GenCIVector& C_left, GenCIVector& C_r
             }
         }
     }
-
-    // Here we compute the RDMs for the case of different irreps
-    // <Ja|a^{+}_p a_q|Ia> CL_{Ja,K} CR_{Ia,K}
-
-    // auto alfa_classes_right = lists_right->alfa_string_classes();
-    // auto beta_classes_right = lists_right->beta_string_classes();
-    // auto alfa_classes_left = lists_left->alfa_string_classes();
-    // auto beta_classes_left = lists_left->beta_string_classes();
-    // if (alfa_classes_right.size() != alfa_classes_left.size() or
-    //     beta_classes_right.size() != beta_classes_left.size()) {
-    //     throw std::runtime_error("FCI transition RDMs: The number of alpha and beta string "
-    //                              "classes must be the same in "
-    //                              "the two wave functions.");
-    // }
-
-    // // loop over blocks of matrix C
-    // for (const auto& [nI, class_Ia, class_Ib] : lists_right->determinant_classes()) {
-    //     if (lists_right->detpblk(nI) == 0)
-    //         continue;
-
-    //     auto Cr = C_right.gather_C_block(GenCIVector::get_CR(), alfa, alfa_address_right,
-    //                                      beta_address_right, class_Ia, class_Ib, false);
-
-    //     for (const auto& [nJ, class_Ja, class_Jb] : lists_left->determinant_classes()) {
-    //         // The string class on which we don't act must be the same for I and J
-    //         if ((alfa and (class_Ib != class_Jb)) or (not alfa and (class_Ia != class_Ja)))
-    //             continue;
-    //         if (lists_left->detpblk(nJ) == 0)
-    //             continue;
-
-    //         auto Cl = C_left.gather_C_block(GenCIVector::get_CL(), alfa, alfa_address_left,
-    //                                         beta_address_left, class_Ja, class_Jb, false);
-
-    //         size_t maxL = alfa ? beta_address_right->strpcls(class_Ib)
-    //                            : alfa_address_right->strpcls(class_Ia);
-
-    //         const auto& pq_vo_list = alfa ? lists_right->get_alfa_vo_list(class_Ia, class_Ja)
-    //                                       : lists_right->get_beta_vo_list(class_Ib,
-    //                                       class_Jb);
-
-    //         for (const auto& [pq, vo_list] : pq_vo_list) {
-    //             const auto& [p, q] = pq;
-    //             double rdm_element = 0.0;
-    //             for (const auto& [sign, I, J] : vo_list) {
-    //                 rdm_element += sign * psi::C_DDOT(maxL, Cl[J], 1, Cr[I], 1);
-    //             }
-    //             rdm_data[p * ncmo + q] += rdm_element;
-    //         }
-    //     }
-    // }
-
-    // // Loop over the irreps of the right string
-    // for (size_t h_Ia = 0; h_Ia < nirrep; ++h_Ia) {
-    //     // The beta right string symmetry is fixed by the symmetry of the right state
-    //     int h_Ib = h_Ia ^ symmetry_right;
-    //     // the alpha right string symmetry depends on the operators, if they act on the alpha
-    //     // string
-    //     // then the beta left/right strings have to be the same and so their symmetry.
-    //     int h_Ja = alfa ? h_Ib ^ symmetry_left : h_Ia;
-    //     // The beta left string symmetry is fixed by the symmetry of the left state
-    //     int h_Jb = h_Ja ^ symmetry_left;
-
-    //     if ((detpi_left[h_Ja] > 0) and (detpi_right[h_Ia] > 0)) {
-    //         // Fill CR with the correct block
-    //         auto Cl = C_left.gather_C_block(GenCIVector::get_CL(), alfa, alfa_address_left,
-    //                                         beta_address_left, h_Ja, h_Jb, false);
-    //         auto Cr = C_right.gather_C_block(GenCIVector::get_CR(), alfa, alfa_address_right,
-    //                                          beta_address_right, h_Ia, h_Ib, false);
-    //         const size_t maxL =
-    //             alfa ? beta_address_right->strpcls(h_Ib) : alfa_address_right->strpcls(h_Ia);
-    //         for (size_t p_sym = 0; p_sym < nirrep; ++p_sym) {
-    //             int q_sym =
-    //                 p_sym ^ symmetry_left ^ symmetry_right; // Select the pair pq that makes
-    //                 the
-    //                                                         // matrix element total symmetric
-    //             for (int p_rel = 0; p_rel < cmopi[p_sym]; ++p_rel) {
-    //                 for (int q_rel = 0; q_rel < cmopi[q_sym]; ++q_rel) {
-    //                     int p_abs = p_rel + cmopi_offset[p_sym];
-    //                     int q_abs = q_rel + cmopi_offset[q_sym];
-
-    //                     // const auto& vo =
-    //                     //     alfa ? lists_right->get_alfa_vo_list(p_abs, q_abs, h_Ia, h_Ja)
-    //                     //          : lists_right->get_beta_vo_list(p_abs, q_abs, h_Ib,
-    //                     h_Jb);
-    //                     // double rdm_element = 0.0;
-    //                     // for (const auto& [sign, I, J] : vo) {
-    //                     //     rdm_element += sign * psi::C_DDOT(maxL, Cl[J], 1, Cr[I], 1);
-    //                     // }
-    //                     // rdm_data[p_abs * ncmo + q_abs] += rdm_element;
-    //                 }
-    //             }
-    //         }
-    //     }
-    // } // End loop over h
     return rdm;
 }
 

--- a/forte/genci/string_lists_makers.cc
+++ b/forte/genci/string_lists_makers.cc
@@ -315,7 +315,8 @@ H2List make_2h_list(const StringList& strings, std::shared_ptr<StringAddress> ad
                                 const auto& [add_J, class_J] = it->second;
                                 std::tuple<int, size_t, int> I_tuple(class_J, add_J, class_I);
                                 list[I_tuple].push_back(H2StringSubstitution(sign, p, q, add_I));
-                                list[I_tuple].push_back(H2StringSubstitution(-sign, q, p, add_I));
+                                // list[I_tuple].push_back(H2StringSubstitution(-sign, q, p,
+                                // add_I));
                             }
                         }
                     }
@@ -338,6 +339,12 @@ H3List make_3h_list(const StringList& strings, std::shared_ptr<StringAddress> ad
     int n = addresser->nbits();
     int k = addresser->nones();
     size_t nmo = addresser->nbits();
+    // int num_occ;
+    // std::vector<int> occ(n);
+    //             find_set_bits(occ, num_occ);
+    //             for (size_t r = 0; r < nmo; ++r) {
+    //                 for (size_t q = r + 1; q < nmo; ++q) {
+    //                     for (size_t p = q + 1; p < nmo; ++p) {
     if ((k >= 0) and (k <= n)) { // check that (n > 0) makes sense.
         for (const auto& string_class : strings) {
             for (const auto& I : string_class) {

--- a/forte/gradient_tpdm/integraltransform_tpdm_restricted.cc
+++ b/forte/gradient_tpdm/integraltransform_tpdm_restricted.cc
@@ -83,7 +83,7 @@ void TPDMBackTransform::backtransform_tpdm_restricted() {
 
     global_dpd_->buf4_init(&J, PSIF_FORTE_TPDM_PRESORT, 0, DPD_ID("[A>=A]+"), DPD_ID("[A,A]"),
                            DPD_ID("[A>=A]+"), DPD_ID("[A>=A]+"), 0, "MO TPDM (AA|AA)");
-    if (print_ > 2) {
+    if (print_ > 3) {
         global_dpd_->buf4_print(&J, "outfile", 1);
     }
 
@@ -108,7 +108,7 @@ void TPDMBackTransform::backtransform_tpdm_restricted() {
             rowsLeft = 0;
         }
 
-        if (print_ > 1) {
+        if (print_ > 2) {
             outfile->Printf("\n    h = %d; memfree         = %lu", h, memFree);
             outfile->Printf("\n    h = %d; rows_per_bucket = %lu", h, rowsPerBucket);
             outfile->Printf("\n    h = %d; rows_left       = %lu", h, rowsLeft);
@@ -191,7 +191,7 @@ void TPDMBackTransform::backtransform_tpdm_restricted() {
                 rowsLeft = 0;
             }
 
-            if (print_ > 1) {
+            if (print_ > 2) {
                 outfile->Printf("\n    h = %d; memfree         = %lu", h, memFree);
                 outfile->Printf("\n    h = %d; rows_per_bucket = %lu", h, rowsPerBucket);
                 outfile->Printf("\n    h = %d; rows_left       = %lu", h, rowsLeft);
@@ -301,7 +301,7 @@ void TPDMBackTransform::backtransform_tpdm_restricted() {
             rowsLeft = 0;
         }
 
-        if (print_ > 1) {
+        if (print_ > 2) {
             outfile->Printf("\th = %d; memfree         = %lu\n", h, memFree);
             outfile->Printf("\th = %d; rows_per_bucket = %lu\n", h, rowsPerBucket);
             outfile->Printf("\th = %d; rows_left       = %lu\n", h, rowsLeft);
@@ -497,7 +497,7 @@ void TPDMBackTransform::presort_mo_tpdm_restricted() {
                 int r = lblptr[labelIndex++];
                 int s = lblptr[labelIndex++];
                 double value = (double)valptr[index];
-                if (print_ > 1) {
+                if (print_ > 2) {
                     outfile->Printf("\tp%4d q%4d r%4d s%4d = %20.10f\n", p, q, r, s, value);
                 }
                 abDpdFiller(p, q, r, s, value);
@@ -554,7 +554,7 @@ void TPDMBackTransform::presort_mo_tpdm_restricted() {
                     int r = lblptr[labelIndex++];
                     int s = lblptr[labelIndex++];
                     double value = (double)valptr[index];
-                    if (print_ > 1) {
+                    if (print_ > 2) {
                         outfile->Printf("\tp%4d q%4d r%4d s%4d = %20.10f\n", p, q, r, s, value);
                     }
                     abDpdFiller(p, q, r, s, value);

--- a/forte/gradient_tpdm/integraltransform_tpdm_unrestricted.cc
+++ b/forte/gradient_tpdm/integraltransform_tpdm_unrestricted.cc
@@ -111,7 +111,7 @@ void TPDMBackTransform::backtransform_tpdm_unrestricted() {
             rowsLeft = 0;
         }
 
-        if (print_ > 1) {
+        if (print_ > 2) {
             outfile->Printf("\n    h = %d; memfree         = %lu", h, memFree);
             outfile->Printf("\n    h = %d; rows_per_bucket = %lu", h, rowsPerBucket);
             outfile->Printf("\n    h = %d; rows_left       = %lu", h, rowsLeft);
@@ -214,7 +214,7 @@ void TPDMBackTransform::backtransform_tpdm_unrestricted() {
             rowsLeft = 0;
         }
 
-        if (print_ > 1) {
+        if (print_ > 2) {
             outfile->Printf("\n    h = %d; memfree         = %lu", h, memFree);
             outfile->Printf("\n    h = %d; rows_per_bucket = %lu", h, rowsPerBucket);
             outfile->Printf("\n    h = %d; rows_left       = %lu", h, rowsLeft);
@@ -319,7 +319,7 @@ void TPDMBackTransform::backtransform_tpdm_unrestricted() {
             rowsLeft = 0;
         }
 
-        if (print_ > 1) {
+        if (print_ > 2) {
             outfile->Printf("\n    h = %d; memfree         = %lu", h, memFree);
             outfile->Printf("\n    h = %d; rows_per_bucket = %lu", h, rowsPerBucket);
             outfile->Printf("\n    h = %d; rows_left       = %lu", h, rowsLeft);

--- a/forte/helpers/davidson_liu_solver.cc
+++ b/forte/helpers/davidson_liu_solver.cc
@@ -28,7 +28,6 @@
 
 #include <random>
 
-#include "helpers/printing.h"
 #include "helpers/davidson_liu_solver.h"
 
 // Global debug flag
@@ -101,6 +100,9 @@ void DavidsonLiuSolver::startup() {
 }
 
 void DavidsonLiuSolver::print_table() {
+    if (print_ < PrintLevel::Default)
+        return;
+
     // Print a summary of the calculation options
     table_printer printer;
     printer.add_double_data({{"Energy convergence threshold", e_convergence_},
@@ -108,12 +110,15 @@ void DavidsonLiuSolver::print_table() {
                              {"Schmidt orthogonality threshold", schmidt_orthogonality_threshold_},
                              {"Schmidt discard threshold", schmidt_discard_threshold_}});
 
-    printer.add_int_data({{"Size of the space", size_},
-                          {"Number of roots", nroot_},
-                          {"Maximum number of iterations", max_iter_},
-                          {"Collapse subspace size", collapse_size_},
-                          {"Maximum subspace size", subspace_size_},
-                          {"Print level", print_level_}});
+    printer.add_int_data({
+        {"Size of the space", size_},
+        {"Number of roots", nroot_},
+        {"Maximum number of iterations", max_iter_},
+        {"Collapse subspace size", collapse_size_},
+        {"Maximum subspace size", subspace_size_},
+    });
+
+    printer.add_string_data({{"Print level", to_string(print_)}});
 
     std::string table = printer.get_table("Davidson-Liu Solver");
     psi::outfile->Printf("%s", table.c_str());
@@ -151,7 +156,7 @@ void DavidsonLiuSolver::reset() {
     sigma_->zero();
 }
 
-void DavidsonLiuSolver::set_print_level(size_t n) { print_level_ = n; }
+void DavidsonLiuSolver::set_print_level(PrintLevel level) { print_ = level; }
 
 void DavidsonLiuSolver::set_e_convergence(double value) { e_convergence_ = value; }
 
@@ -270,15 +275,19 @@ void DavidsonLiuSolver::setup_guesses() {
         // add the guesses to temp
         if ((guesses_.size() >= nroot_) and (guesses_.size() <= subspace_size_)) {
             // guesses [copy] -> temp [orthonormalize] -> b
-            psi::outfile->Printf("\n\n  Davidson-Liu solver: adding %d guess vectors",
-                                 guesses_.size());
+            if (print_ >= PrintLevel::Default) {
+                psi::outfile->Printf("\n\n  Davidson-Liu solver: adding %d guess vectors",
+                                     guesses_.size());
+            }
             set_vector(temp_, guesses_);
 
         } else if (guesses_.size() == 0) {
             // add random vectors
             temp_->zero();
             add_random_vectors(temp_, 0, nroot_);
-            psi::outfile->Printf("\n\n  Davidson-Liu solver: adding %d random vectors", nroot_);
+            if (print_ >= PrintLevel::Default) {
+                psi::outfile->Printf("\n\n  Davidson-Liu solver: adding %d random vectors", nroot_);
+            }
         } else {
             std::string msg = "DavidsonLiuSolver: number of guess vectors (" +
                               std::to_string(guesses_.size()) +
@@ -325,6 +334,8 @@ void DavidsonLiuSolver::preiteration_sanity_checks() {
 }
 
 void DavidsonLiuSolver::print_header() {
+    if (print_ < PrintLevel::Default)
+        return;
     psi::outfile->Printf(
         "\n  Iteration     Average Energy            max(∆E)            max(Residual)  Vectors");
     psi::outfile->Printf(
@@ -332,11 +343,16 @@ void DavidsonLiuSolver::print_header() {
 }
 
 void DavidsonLiuSolver::print_footer() {
+    if (print_ < PrintLevel::Default)
+        return;
     psi::outfile->Printf(
         "\n  ---------------------------------------------------------------------------------");
 }
 
 void DavidsonLiuSolver::print_iteration(size_t iter) {
+    if (print_ < PrintLevel::Default)
+        return;
+
     auto e_diff = lambda_->clone();
     e_diff.axpy(-1.0, *lambda_old_);
 

--- a/forte/helpers/davidson_liu_solver.h
+++ b/forte/helpers/davidson_liu_solver.h
@@ -37,6 +37,8 @@
 #include "psi4/libmints/vector.h"
 #include "psi4/libmints/matrix.h"
 
+#include "helpers/printing.h"
+
 namespace psi {
 class Vector;
 class Matrix;
@@ -61,7 +63,7 @@ class DavidsonLiuSolver {
     void add_project_out_vectors(const std::vector<sparse_vec>& project_out_vectors);
 
     /// Set the print level
-    void set_print_level(size_t n);
+    void set_print_level(PrintLevel level);
     /// Set the energy convergence
     void set_e_convergence(double value);
     /// Set the residual convergence
@@ -110,7 +112,7 @@ class DavidsonLiuSolver {
     std::vector<sparse_vec> project_out_vectors_;
 
     /// The print level
-    size_t print_level_ = 1;
+    PrintLevel print_ = PrintLevel::Default;
     /// The maximum number of iterations
     size_t max_iter_ = 50;
     /// Eigenvalue convergence threshold

--- a/forte/helpers/lbfgs/lbfgs.cc
+++ b/forte/helpers/lbfgs/lbfgs.cc
@@ -67,7 +67,7 @@ template <class Foo> double LBFGS::minimize(Foo& func, std::shared_ptr<psi::Vect
     // routine of diagonal Hessian
     auto compute_h0 = [&](std::shared_ptr<psi::Vector> x) {
         func.hess_diag(x, h0_);
-        if (param_->print > 2) {
+        if (param_->print > 3) {
             print_h2("Diagonal Hessian at Iter. " + std::to_string(iter_));
             h0_->print();
         }
@@ -102,7 +102,7 @@ template <class Foo> double LBFGS::minimize(Foo& func, std::shared_ptr<psi::Vect
 
         // print current iteration
         g_norm = g_->norm();
-        if (param_->print > 0)
+        if (param_->print > 2)
             outfile->Printf("\n    L-BFGS Iter:%3d; fx = %20.15f; g_norm = %12.6e; step = %9.3e",
                             iter_ + 1, fx, g_norm, step);
 
@@ -150,7 +150,7 @@ template <class Foo> double LBFGS::minimize(Foo& func, std::shared_ptr<psi::Vect
         }
     } while (iter_ < param_->maxiter);
 
-    if ((not converged_) and param_->print > 1) {
+    if ((not converged_) and param_->print > 2) {
         outfile->Printf("\n  L-BFGS Warning: No convergence in %d iterations", iter_);
     }
 
@@ -183,7 +183,7 @@ void LBFGS::update() {
     // for descent
     p_.scale(-1.0);
 
-    if (param_->print > 2)
+    if (param_->print > 3)
         p_.print();
 }
 
@@ -200,7 +200,7 @@ void LBFGS::next_step(Foo& foo, std::shared_ptr<psi::Vector> x, double& fx, doub
         throw std::runtime_error("Unknown STEP_LENGTH_METHOD");
     }
 
-    if (param_->print > 2)
+    if (param_->print > 3)
         g_->print();
 }
 
@@ -320,7 +320,7 @@ void LBFGS::line_search_bracketing_zoom(Foo& func, std::shared_ptr<psi::Vector> 
         double dg = g_->vector_dot(p_);
 
         if (std::fabs(dg) <= w2) {
-            if (param_->print > 2) {
+            if (param_->print > 3) {
                 outfile->Printf("\n    Optimal step length from bracketing stage: %.15f", step);
             }
             return;
@@ -337,7 +337,7 @@ void LBFGS::line_search_bracketing_zoom(Foo& func, std::shared_ptr<psi::Vector> 
 
         step *= 2.0;
     }
-    if (param_->print > 2) {
+    if (param_->print > 3) {
         outfile->Printf("\n    Step lengths after bracketing stage: low = %.10f, high = %.10f",
                         step_low, step_high);
     }
@@ -360,7 +360,7 @@ void LBFGS::line_search_bracketing_zoom(Foo& func, std::shared_ptr<psi::Vector> 
             double dg = g_->vector_dot(p_);
 
             if (std::fabs(dg) <= w2) {
-                if (param_->print > 2) {
+                if (param_->print > 3) {
                     outfile->Printf("\n    Optimal step length from zooming stage: %.15f", step);
                 }
                 break;
@@ -375,7 +375,7 @@ void LBFGS::line_search_bracketing_zoom(Foo& func, std::shared_ptr<psi::Vector> 
             fx_low = fx;
         }
     }
-    if (param_->print > 2) {
+    if (param_->print > 3) {
         outfile->Printf("\n    Step lengths after zooming stage: low = %.10f, high = %.10f",
                         step_low, step_high);
     }
@@ -396,7 +396,7 @@ void LBFGS::line_search_bracketing_zoom(Foo& func, std::shared_ptr<psi::Vector> 
 void LBFGS::apply_h0(psi::Vector& q) {
     if (param_->h0_freq < 0) {
         double gamma = compute_gamma();
-        if (param_->print > 2)
+        if (param_->print > 3)
             outfile->Printf("\n    gamma for H0: %.15f", gamma);
         q.scale(gamma);
     } else {

--- a/forte/helpers/printing.cc
+++ b/forte/helpers/printing.cc
@@ -43,6 +43,45 @@ std::vector<std::string> __s2_labels{
 
 namespace forte {
 
+PrintLevel int_to_print_level(int level) {
+    switch (level) {
+    case 0:
+        return PrintLevel::Quiet;
+    case 1:
+        return PrintLevel::Brief;
+    case 2:
+        return PrintLevel::Default;
+    case 3:
+        return PrintLevel::Verbose;
+    case 4:
+        return PrintLevel::Debug;
+    default:
+        throw std::out_of_range("Invalid PrintLevel value");
+    }
+}
+
+/// @brief Return the string representation of a PrintLevel
+std::string to_string(PrintLevel level) {
+    switch (level) {
+    case PrintLevel::Quiet:
+        return "Quiet";
+    case PrintLevel::Brief:
+        return "Brief";
+    case PrintLevel::Default:
+        return "Default";
+    case PrintLevel::Verbose:
+        return "Verbose";
+    case PrintLevel::Debug:
+        return "Debug";
+    default:
+        throw std::out_of_range("Invalid PrintLevel value");
+    }
+}
+
+bool operator>(PrintLevel a, PrintLevel b) { return static_cast<int>(a) > static_cast<int>(b); }
+
+bool operator<(PrintLevel a, PrintLevel b) { return static_cast<int>(a) < static_cast<int>(b); }
+
 void print_h1(const std::string& text, bool centerd, const std::string& left_filler,
               const std::string& right_filler) {
     int text_width = static_cast<int>(text.size());

--- a/forte/helpers/printing.h
+++ b/forte/helpers/printing.h
@@ -38,7 +38,27 @@
 
 namespace forte {
 
-enum class PrintLevel { Quiet = 0, Mini = 1, Default = 2, Debug = 3 };
+/// This enum is used to control the verbosity of the output
+/// The higher the level, the more verbose the output
+/// This is roughly how these should be used:
+/// - Quiet: No output at all, except for errors
+/// - Mini: Only the most important information
+/// - Default: The most important information and some extra information
+/// - Debug: All the information and more
+enum class PrintLevel { Quiet = 0, Brief = 1, Default = 2, Verbose = 3, Debug = 4 };
+
+bool operator>(PrintLevel a, PrintLevel b);
+
+bool operator<(PrintLevel a, PrintLevel b);
+
+/// @brief  Convert an integer to a PrintLevel
+/// @param level the print level as an integer (0 = quiet, 1 = brief, 2 = default, 3 = verbose, 4
+/// =debug)
+/// @return
+PrintLevel int_to_print_level(int level);
+
+/// @brief Return the string representation of a PrintLevel
+std::string to_string(PrintLevel level);
 
 /**
  * @brief print_h1 Print a header

--- a/forte/helpers/printing.h
+++ b/forte/helpers/printing.h
@@ -135,6 +135,8 @@ class table_printer {
     std::string get_table(const std::string& title) const {
         std::ostringstream oss;
         print_h2(oss, title);
+        std::string line(56, '-');
+        oss << "\n    " << line;
         print_data(oss, info_string, [](const std::string& val) { return val; });
         print_data(oss, info_bool,
                    [](bool val) { return val ? std::string("TRUE") : std::string("FALSE"); });
@@ -146,7 +148,7 @@ class table_printer {
         });
         print_data(oss, info_timing,
                    [](double val) { return format_double(val, "%15.3f") + " s"; });
-        oss << "\n";
+        oss << "\n    " << line;
         return oss.str();
     }
 

--- a/forte/integrals/cholesky_integrals.cc
+++ b/forte/integrals/cholesky_integrals.cc
@@ -283,7 +283,7 @@ void CholeskyIntegrals::transform_integrals() {
 }
 
 void CholeskyIntegrals::resort_integrals_after_freezing() {
-    if (print_ > 0) {
+    if (print_ > 1) {
         outfile->Printf("\n  Resorting integrals after freezing core.");
     }
     // Resort the three-index integrals

--- a/forte/integrals/conventional_integrals.cc
+++ b/forte/integrals/conventional_integrals.cc
@@ -100,7 +100,7 @@ std::shared_ptr<psi::IntegralTransform> ConventionalIntegrals::transform_integra
     integral_transform->transform_tei(MOSpace::all, MOSpace::all, MOSpace::all, MOSpace::all);
 
     dpd_set_default(integral_transform->get_dpd_id());
-    if (print_ > 0) {
+    if (print_ > 1) {
         outfile->Printf("\n  Integral transformation done. %8.8f s", int_timer.get());
     }
     return integral_transform;
@@ -174,7 +174,7 @@ void ConventionalIntegrals::gather_integrals() {
     mints.integrals();
     auto integral_transform = transform_integrals();
 
-    if (print_ > 0) {
+    if (print_ > 1) {
         outfile->Printf("\n  Reading the two-electron integrals from disk");
         outfile->Printf("\n  Size of two-electron integrals: %10.6f GB",
                         double(3 * 8 * num_aptei_) / 1073741824.0);
@@ -240,7 +240,7 @@ void ConventionalIntegrals::gather_integrals() {
 }
 
 void ConventionalIntegrals::resort_integrals_after_freezing() {
-    if (print_ > 0) {
+    if (print_ > 1) {
         outfile->Printf("\n  Resorting integrals after freezing core.");
     }
     // Resort the four-index integrals

--- a/forte/integrals/custom_integrals.cc
+++ b/forte/integrals/custom_integrals.cc
@@ -163,7 +163,7 @@ void CustomIntegrals::gather_integrals() {
 }
 
 void CustomIntegrals::resort_integrals_after_freezing() {
-    if (print_ > 0) {
+    if (print_ > 1) {
         outfile->Printf("\n  Resorting integrals after freezing core.");
     }
     // Resort the four-index integrals
@@ -219,11 +219,11 @@ void CustomIntegrals::compute_frozen_one_body_operator() {
         corr_offset += ncmopi_[h];
     }
 
-    if (print_ > 0) {
+    if (print_ > 1) {
         outfile->Printf("\n  Frozen-core energy        %20.15f a.u.", frozen_core_energy_);
         print_timing("frozen one-body operator", timer_frozen_one_body.get());
     }
-    if (print_ > 2) {
+    if (print_ > 3) {
         print_h1("One-body Hamiltonian elements dressed by frozen-core orbitals");
         Fock_a->set_name("Frozen One Body (alpha)");
         Fock_a->print();

--- a/forte/integrals/df_integrals.cc
+++ b/forte/integrals/df_integrals.cc
@@ -187,7 +187,7 @@ void DFIntegrals::set_tei(size_t, size_t, size_t, size_t, double, bool, bool) {
 
 void DFIntegrals::gather_integrals() {
 
-    if (print_ > 0) {
+    if (print_ > 1) {
         outfile->Printf("\n  Computing density fitted integrals\n");
     }
 
@@ -197,7 +197,7 @@ void DFIntegrals::gather_integrals() {
     size_t nprim = primary->nbf();
     size_t naux = auxiliary->nbf();
     nthree_ = naux;
-    if (print_ > 0) {
+    if (print_ > 1) {
         outfile->Printf("\n  Number of auxiliary basis functions:  %u", naux);
         auto mem_info = to_xb2<double>(nprim * nprim * naux);
         outfile->Printf("\n  Need %.2f %s to store DF integrals\n", mem_info.first,
@@ -241,11 +241,11 @@ void DFIntegrals::gather_integrals() {
     // Finally computes the df integrals
     // Does the timings also
     local_timer timer;
-    if (print_ > 0) {
+    if (print_ > 1) {
         outfile->Printf("\n  Transforming DF Integrals");
     }
     df->transform();
-    if (print_ > 0) {
+    if (print_ > 1) {
         print_timing("density-fitting transformation", timer.get());
         outfile->Printf("\n");
     }
@@ -283,13 +283,13 @@ void DFIntegrals::resort_three(std::shared_ptr<psi::Matrix>& threeint, std::vect
 
 void DFIntegrals::resort_integrals_after_freezing() {
     local_timer timer_resort;
-    if (print_ > 0) {
+    if (print_ > 1) {
         outfile->Printf("\n  Resorting integrals after freezing core.");
     }
 
     resort_three(ThreeIntegral_, cmotomo_);
 
-    if (print_ > 0) {
+    if (print_ > 1) {
         print_timing("resorting DF integrals", timer_resort.get());
     }
 }

--- a/forte/integrals/integrals.h
+++ b/forte/integrals/integrals.h
@@ -153,10 +153,10 @@ class ForteIntegrals {
     /// temporary solution for not having a Wavefunction
     std::shared_ptr<psi::Wavefunction> wfn();
 
-    /// Return the Pis4 JK object
+    /// Return the Psi4 JK object
     std::shared_ptr<psi::JK> jk();
 
-    /// Enum class for the status of Pis4 JK
+    /// Enum class for the status of Psi4 JK
     enum class JKStatus { empty, initialized, finalized };
     /// Return the status of Psi4 JK object
     JKStatus jk_status();

--- a/forte/integrals/integrals_psi4_interface.cc
+++ b/forte/integrals/integrals_psi4_interface.cc
@@ -196,7 +196,7 @@ void Psi4Integrals::make_psi4_JK() {
             JK_ = JK::build_JK(basis, basis_aux, psi4_options, "MEM_DF");
         }
     } else {
-        throw psi::PSIEXCEPTION("Unknown Pis4 integral type to initialize JK in Forte");
+        throw psi::PSIEXCEPTION("Unknown Psi4 integral type to initialize JK in Forte");
     }
 
     JK_->set_cutoff(schwarz_cutoff_);

--- a/forte/integrals/integrals_psi4_interface.cc
+++ b/forte/integrals/integrals_psi4_interface.cc
@@ -243,11 +243,11 @@ void Psi4Integrals::compute_frozen_one_body_operator() {
         corr_offset += ncmopi_[h];
     }
 
-    if (print_ > 0) {
+    if (print_ > 1) {
         outfile->Printf("\n  Frozen-core energy        %20.15f a.u.", frozen_core_energy_);
         print_timing("frozen one-body operator", timer_frozen_one_body.get());
     }
-    if (print_ > 2) {
+    if (print_ > 3) {
         print_h1("One-body Hamiltonian elements dressed by frozen-core orbitals");
         if (Fock_a == Fock_b) {
             Fock_a->set_name("Frozen One Body");

--- a/forte/mrdsrg-so/so-mrdsrg.cc
+++ b/forte/mrdsrg-so/so-mrdsrg.cc
@@ -558,16 +558,16 @@ void SOMRDSRG::startup() {
 
     //    // Print levels
     //    print_ = foptions_->get_int("PRINT");
-    //    if(print_ > 1){
+    //    if(print_ > 2){
     //        Gamma1.print(stdout);
     //        Eta1.print(stdout);
     //        F.print(stdout);
     //    }
-    //    if(print_ > 2){
+    //    if(print_ > 3){
     //        V.print(stdout);
     //        Lambda2.print(stdout);
     //    }
-    //    if(print_ > 3){
+    //    if(print_ > 4){
     //        Lambda3.print(stdout);
     //    }
 }
@@ -625,14 +625,14 @@ double SOMRDSRG::compute_energy() {
     compute_hbar();
 
     while (!converged) {
-        if (print_ > 1) {
+        if (print_ > 2) {
             outfile->Printf("\n  Updating the S amplitudes...");
         }
 
         update_T1();
         update_T2();
 
-        if (print_ > 1) {
+        if (print_ > 2) {
             outfile->Printf("\n  --------------------------------------------");
             outfile->Printf("\n  nExc           |S|                  |R|");
             outfile->Printf("\n  --------------------------------------------");
@@ -660,7 +660,7 @@ double SOMRDSRG::compute_energy() {
             //            }
         }
 
-        if (print_ > 1) {
+        if (print_ > 2) {
             outfile->Printf(" done.");
         }
         //        if(diis_manager){
@@ -701,14 +701,14 @@ double SOMRDSRG::compute_energy() {
         //                }
         //            }
         //        }
-        if (print_ > 1) {
+        if (print_ > 2) {
             outfile->Printf("\n  Compute recursive single commutator...");
         }
 
         // Compute the new similarity-transformed Hamiltonian
         double energy = E0_ + compute_hbar();
 
-        if (print_ > 1) {
+        if (print_ > 2) {
             outfile->Printf(" done.");
         }
 
@@ -792,7 +792,7 @@ void SOMRDSRG::mp2_guess() {
 }
 
 double SOMRDSRG::compute_hbar() {
-    if (print_ > 1) {
+    if (print_ > 2) {
         outfile->Printf("\n\n  Computing the similarity-transformed Hamiltonian");
         outfile->Printf("\n  "
                         "------------------------------------------------------"
@@ -812,7 +812,7 @@ double SOMRDSRG::compute_hbar() {
     O1["pq"] = F["pq"];
     O2["pqrs"] = V["pqrs"];
 
-    if (print_ > 1) {
+    if (print_ > 2) {
         outfile->Printf("\n  %2d %20.12f %20e %20e", 0, Hbar0, Hbar1.norm(), Hbar2.norm());
     }
 
@@ -841,14 +841,14 @@ double SOMRDSRG::compute_hbar() {
         double norm_C1 = C1.norm();
         double norm_C2 = C2.norm();
 
-        if (print_ > 1) {
+        if (print_ > 2) {
             outfile->Printf("\n  %2d %20.12f %20e %20e", n, C0, norm_C1, norm_C2);
         }
         if (std::sqrt(norm_C2 * norm_C2 + norm_C1 * norm_C1) < ct_threshold) {
             break;
         }
     }
-    if (print_ > 1) {
+    if (print_ > 2) {
         outfile->Printf("\n  "
                         "------------------------------------------------------"
                         "-----------");

--- a/forte/mrdsrg-spin-adapted/dsrg_mrpt_comm.cc
+++ b/forte/mrdsrg-spin-adapted/dsrg_mrpt_comm.cc
@@ -48,7 +48,7 @@ void DSRG_MRPT::H1_T1_C0(BlockedTensor& H1, BlockedTensor& T1, const double& alp
     E *= alpha;
     C0 += E;
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H1, T1] -> C0 : %10.3f", timer.get());
     }
     dsrg_time_.add("110", timer.get());
@@ -68,7 +68,7 @@ void DSRG_MRPT::H1_T2_C0(BlockedTensor& H1, BlockedTensor& T2, const double& alp
     E *= alpha;
     C0 += E;
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H1, T2] -> C0 : %10.3f", timer.get());
     }
     dsrg_time_.add("120", timer.get());
@@ -88,7 +88,7 @@ void DSRG_MRPT::H2_T1_C0(BlockedTensor& H2, BlockedTensor& T1, const double& alp
     E *= alpha;
     C0 += E;
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T1] -> C0 : %10.3f", timer.get());
     }
     dsrg_time_.add("210", timer.get());
@@ -107,7 +107,7 @@ void DSRG_MRPT::H2_T2_C0(BlockedTensor& H2, BlockedTensor& T2, const double& alp
     E *= alpha;
     C0 += E;
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C0 : %10.3f", timer.get());
     }
     dsrg_time_.add("220", timer.get());

--- a/forte/mrdsrg-spin-adapted/sa_ldsrg2.cc
+++ b/forte/mrdsrg-spin-adapted/sa_ldsrg2.cc
@@ -187,7 +187,7 @@ double SA_MRDSRG::compute_energy_ldsrg2() {
 }
 
 void SA_MRDSRG::compute_hbar() {
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n\n  ==> Computing the DSRG Transformed Hamiltonian <==\n");
     }
 
@@ -219,7 +219,7 @@ void SA_MRDSRG::compute_hbar() {
         C2_.zero();
 
         // printing level
-        if (print_ > 2) {
+        if (print_ > 3) {
             std::string dash(38, '-');
             outfile->Printf("\n    %s", dash.c_str());
         }
@@ -257,7 +257,7 @@ void SA_MRDSRG::compute_hbar() {
         }
 
         // printing level
-        if (print_ > 2) {
+        if (print_ > 3) {
             std::string dash(38, '-');
             outfile->Printf("\n    %s\n", dash.c_str());
         }
@@ -281,7 +281,7 @@ void SA_MRDSRG::compute_hbar() {
         // test convergence of C
         double norm_C1 = C1_.norm();
         double norm_C2 = C2_.norm();
-        if (print_ > 2) {
+        if (print_ > 3) {
             outfile->Printf("\n  n: %3d, C0: %20.15f, C1 max: %20.15f, C2 max: %20.15f", n, C0,
                             C1_.norm(0), C2_.norm(0));
         }
@@ -298,7 +298,7 @@ void SA_MRDSRG::compute_hbar() {
 }
 
 void SA_MRDSRG::compute_hbar_sequential() {
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n\n  ==> Computing the DSRG Transformed Hamiltonian <==\n");
     }
 
@@ -413,7 +413,7 @@ void SA_MRDSRG::compute_hbar_sequential() {
         C2_.zero();
 
         // printing level
-        if (print_ > 2) {
+        if (print_ > 3) {
             std::string dash(38, '-');
             outfile->Printf("\n    %s", dash.c_str());
         }
@@ -441,7 +441,7 @@ void SA_MRDSRG::compute_hbar_sequential() {
         }
 
         // printing level
-        if (print_ > 2) {
+        if (print_ > 3) {
             std::string dash(38, '-');
             outfile->Printf("\n    %s\n", dash.c_str());
         }
@@ -465,7 +465,7 @@ void SA_MRDSRG::compute_hbar_sequential() {
         // test convergence of C
         double norm_C1 = C1_.norm();
         double norm_C2 = C2_.norm();
-        if (print_ > 2) {
+        if (print_ > 3) {
             outfile->Printf("\n  n: %3d, C0: %20.15f, C1 max: %20.15f, C2 max: %20.15f", n, C0,
                             C1_.norm(0), C2_.norm(0));
         }

--- a/forte/mrdsrg-spin-adapted/sadsrg_comm.cc
+++ b/forte/mrdsrg-spin-adapted/sadsrg_comm.cc
@@ -51,7 +51,7 @@ double SADSRG::H1_T1_C0(BlockedTensor& H1, BlockedTensor& T1, const double& alph
     E *= alpha;
     C0 += E;
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H1, T1] -> C0 : %12.3f", timer.get());
     }
     dsrg_time_.add("110", timer.get());
@@ -71,7 +71,7 @@ double SADSRG::H1_T2_C0(BlockedTensor& H1, BlockedTensor& T2, const double& alph
     E *= alpha;
     C0 += E;
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H1, T2] -> C0 : %12.3f", timer.get());
     }
     dsrg_time_.add("120", timer.get());
@@ -92,7 +92,7 @@ double SADSRG::H2_T1_C0(BlockedTensor& H2, BlockedTensor& T1, const double& alph
     E *= alpha;
     C0 += E;
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T1] -> C0 : %12.3f", timer.get());
     }
     dsrg_time_.add("210", timer.get());
@@ -130,7 +130,7 @@ std::vector<double> SADSRG::H2_T2_C0(BlockedTensor& H2, BlockedTensor& T2, Block
     E *= alpha;
     C0 += E;
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C0 : %12.3f", timer.get());
     }
     dsrg_time_.add("220", timer.get());
@@ -303,7 +303,7 @@ void SADSRG::H1_T1_C1(BlockedTensor& H1, BlockedTensor& T1, const double& alpha,
     C1["ip"] += alpha * H1["ap"] * T1["ia"];
     C1["qa"] -= alpha * H1["qi"] * T1["ia"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H1, T1] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("111", timer.get());
@@ -322,7 +322,7 @@ void SADSRG::H1_T2_C1(BlockedTensor& H1, BlockedTensor& T2, const double& alpha,
     C1["ia"] -= alpha * H1["vj"] * T2["ijau"] * L1_["uv"];
     C1["ia"] += 0.5 * alpha * H1["vj"] * T2["jiau"] * L1_["uv"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H1, T2] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("121", timer.get());
@@ -341,7 +341,7 @@ void SADSRG::H2_T1_C1(BlockedTensor& H2, BlockedTensor& T1, const double& alpha,
     C1["qp"] -= alpha * T1["mu"] * L1_["uv"] * H2["qvpm"];
     C1["qp"] += 0.5 * alpha * T1["mu"] * L1_["uv"] * H2["vqpm"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T1] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("211", timer.get());
@@ -402,7 +402,7 @@ void SADSRG::H2_T2_C1(BlockedTensor& H2, BlockedTensor& T2, BlockedTensor& S2, c
     C1["qs"] -= alpha * H2["uqms"] * T2["mvxy"] * L2_["xyuv"];
     C1["qs"] += 0.5 * alpha * H2["uqsm"] * T2["mvxy"] * L2_["xyuv"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("221", timer.get());
@@ -418,7 +418,7 @@ void SADSRG::H1_T2_C2(BlockedTensor& H1, BlockedTensor& T2, const double& alpha,
     C2["qjab"] -= alpha * T2["ijab"] * H1["qi"];
     C2["jqba"] -= alpha * T2["ijab"] * H1["qi"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H1, T2] -> C2 : %12.3f", timer.get());
     }
     dsrg_time_.add("122", timer.get());
@@ -434,7 +434,7 @@ void SADSRG::H2_T1_C2(BlockedTensor& H2, BlockedTensor& T1, const double& alpha,
     C2["rsaq"] -= alpha * T1["ia"] * H2["rsiq"];
     C2["srqa"] -= alpha * T1["ia"] * H2["rsiq"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T1] -> C2 : %12.3f", timer.get());
     }
     dsrg_time_.add("212", timer.get());
@@ -492,7 +492,7 @@ void SADSRG::H2_T2_C2(BlockedTensor& H2, BlockedTensor& T2, BlockedTensor& S2, c
     C2["jqsb"] += temp["jqsb"];
     C2["qjbs"] += temp["jqsb"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C2 : %12.3f", timer.get());
     }
     dsrg_time_.add("222", timer.get());
@@ -512,7 +512,7 @@ void SADSRG::V_T1_C0_DF(BlockedTensor& B, BlockedTensor& T1, const double& alpha
     E *= alpha;
     C0 += E;
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T1] -> C0 : %12.3f", timer.get());
     }
     dsrg_time_.add("210", timer.get());
@@ -549,7 +549,7 @@ std::vector<double> SADSRG::V_T2_C0_DF(BlockedTensor& B, BlockedTensor& T2, Bloc
     E *= alpha;
     C0 += E;
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C0 : %12.3f", timer.get());
     }
     dsrg_time_.add("220", timer.get());
@@ -573,7 +573,7 @@ void SADSRG::V_T1_C1_DF(BlockedTensor& B, BlockedTensor& T1, const double& alpha
 
     C1["qp"] -= 0.5 * alpha * T1["xe"] * L1_["yx"] * B["gep"] * B["gqy"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T1] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("211", timer.get());
@@ -646,7 +646,7 @@ void SADSRG::V_T2_C1_DF(BlockedTensor& B, BlockedTensor& T2, BlockedTensor& S2, 
 
     C1["qs"] += 0.5 * alpha * B["gus"] * B["gqm"] * T2["mvxy"] * L2_["xyuv"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("221", timer.get());
@@ -661,7 +661,7 @@ void SADSRG::V_T1_C2_DF(BlockedTensor& B, BlockedTensor& T1, const double& alpha
     C2["rsaq"] -= alpha * T1["ia"] * B["gri"] * B["gsq"];
     C2["srqa"] -= alpha * T1["ia"] * B["gri"] * B["gsq"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T1] -> C2 : %12.3f", timer.get());
     }
     dsrg_time_.add("212", timer.get());
@@ -720,7 +720,7 @@ void SADSRG::V_T2_C2_DF(BlockedTensor& B, BlockedTensor& T2, BlockedTensor& S2, 
     // exchange like terms
     V_T2_C2_DF_PH_X(B, T2, alpha, C2);
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C2 : %12.3f", timer.get());
     }
     dsrg_time_.add("222", timer.get());

--- a/forte/mrdsrg-spin-integrated/dsrg_mrpt2.cc
+++ b/forte/mrdsrg-spin-integrated/dsrg_mrpt2.cc
@@ -102,16 +102,16 @@ void DSRG_MRPT2::startup() {
     }
 
     // print levels
-    if (print_ > 1) {
+    if (print_ > 2) {
         Gamma1_.print(stdout);
         Eta1_.print(stdout);
         F_.print(stdout);
     }
-    if (print_ > 2) {
+    if (print_ > 3) {
         V_.print(stdout);
         Lambda2_.print(stdout);
     }
-    if (print_ > 3 and do_cu3_) {
+    if (print_ > 4 and do_cu3_) {
         L3aaa_.print();
         L3aab_.print();
         L3abb_.print();
@@ -344,9 +344,9 @@ double DSRG_MRPT2::compute_energy() {
     } else {
         outfile->Printf("\n    Ignore [H0th, A1st] in DSRG-MRPT2!");
     }
-    if (print_ > 1)
+    if (print_ > 2)
         F_.print(stdout);
-    if (print_ > 2) {
+    if (print_ > 3) {
         T1_.print(stdout);
         T2_.print(stdout);
         V_.print(stdout);
@@ -2193,7 +2193,7 @@ void DSRG_MRPT2::H1_T1_C1aa(BlockedTensor& H1, BlockedTensor& T1, const double& 
     C1["UV"] += alpha * H1["AV"] * T1["UA"];
     C1["VU"] -= alpha * T1["IU"] * H1["VI"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H1, T1] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("111", timer.get());
@@ -2217,7 +2217,7 @@ void DSRG_MRPT2::H1_T2_C1aa(BlockedTensor& H1, BlockedTensor& T2, const double& 
     C1["YX"] += alpha * H1["BU"] * T2["YVXB"] * Gamma1_["UV"];
     C1["YX"] -= alpha * H1["VJ"] * T2["YJXU"] * Gamma1_["UV"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H1, T2] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("121", timer.get());
@@ -2241,7 +2241,7 @@ void DSRG_MRPT2::H2_T1_C1aa(BlockedTensor& H2, BlockedTensor& T1, const double& 
     C1["UV"] += alpha * T1["XE"] * Gamma1_["YX"] * H2["UEVY"];
     C1["UV"] -= alpha * T1["MX"] * Gamma1_["XY"] * H2["UYVM"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T1] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("211", timer.get());
@@ -2402,7 +2402,7 @@ void DSRG_MRPT2::H2_T2_C1aa(BlockedTensor& H2, BlockedTensor& T2, const double& 
     C1["xy"] -= alpha * temp["MU"] * H2["xUyM"];
     C1["XY"] -= alpha * temp["MU"] * H2["UXMY"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("221", timer.get());
@@ -2427,7 +2427,7 @@ void DSRG_MRPT2::H1_T2_C2aaaa(BlockedTensor& H1, BlockedTensor& T2, const double
     C2["UVXY"] -= alpha * T2["IVXY"] * H1["UI"];
     C2["UVXY"] -= alpha * T2["UJXY"] * H1["VJ"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H1, T2] -> C2 : %12.3f", timer.get());
     }
     dsrg_time_.add("122", timer.get());
@@ -2452,7 +2452,7 @@ void DSRG_MRPT2::H2_T1_C2aaaa(BlockedTensor& H2, BlockedTensor& T1, const double
     C2["UVXY"] -= alpha * T1["IX"] * H2["UVIY"];
     C2["UVXY"] -= alpha * T1["IY"] * H2["UVXI"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T1] -> C2 : %12.3f", timer.get());
     }
     dsrg_time_.add("212", timer.get());
@@ -2529,7 +2529,7 @@ void DSRG_MRPT2::H2_T2_C2aaaa(BlockedTensor& H2, BlockedTensor& T2, const double
     C2["uVxY"] -= alpha * Gamma1_["wz"] * H2["zVjY"] * T2["ujxw"];
     C2["uVxY"] -= alpha * Gamma1_["WZ"] * H2["ZVJY"] * T2["uJxW"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C2 : %12.3f", timer.get());
     }
     dsrg_time_.add("222", timer.get());
@@ -2612,7 +2612,7 @@ void DSRG_MRPT2::H2_T2_C3aaaaaa(BlockedTensor& H2, BlockedTensor& T2, const doub
     C3["xYZuWV"] -= temp["xYZuVW"];
     C3["xZYuWV"] += temp["xYZuVW"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C3 : %12.3f", timer.get());
     }
     dsrg_time_.add("223", timer.get());

--- a/forte/mrdsrg-spin-integrated/dsrg_mrpt3.cc
+++ b/forte/mrdsrg-spin-integrated/dsrg_mrpt3.cc
@@ -186,12 +186,12 @@ void DSRG_MRPT3::startup() {
     }
 
     // Print levels
-    if (print_ > 1) {
+    if (print_ > 2) {
         Gamma1_.print(stdout);
         Eta1_.print(stdout);
         F_.print(stdout);
     }
-    if (print_ > 3) {
+    if (print_ > 4) {
         V_.print(stdout);
     }
     profile_print_ = foptions_->get_bool("PRINT_TIME_PROFILE");
@@ -2177,7 +2177,7 @@ void DSRG_MRPT3::V_T1_C1_DF(BlockedTensor& B, BlockedTensor& T1, const double& a
     C1["QP"] += alpha * temp["gPM"] * B["gQM"];
     C1["QP"] += alpha * temp["gPY"] * B["gQY"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T1] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("211", timer.get());
@@ -2219,7 +2219,7 @@ void DSRG_MRPT3::V_T1_C2_DF(BlockedTensor& B, BlockedTensor& T1, const double& a
     C2["RSQA"] += alpha * temp["gRA"] * B["gSQ"];
     C2["sRpA"] -= alpha * temp["gRA"] * B["gsp"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T1] -> C2 : %12.3f", timer.get());
     }
     dsrg_time_.add("212", timer.get());
@@ -2470,7 +2470,7 @@ void DSRG_MRPT3::V_T2_C1_DF(BlockedTensor& B, BlockedTensor& T2, const double& a
                         compute_elapsed_time(start_, end_).count());
     }
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("221", timer.get());
@@ -3064,7 +3064,7 @@ void DSRG_MRPT3::V_T2_C2_DF(BlockedTensor& B, BlockedTensor& T2, const double& a
         V_T2_C2_DF_VA_EX(B, T2, alpha, C2, qs_lower, jb_lower);
     }
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C2 : %12.3f", timer.get());
     }
     dsrg_time_.add("222", timer.get());

--- a/forte/mrdsrg-spin-integrated/master_mrdsrg.cc
+++ b/forte/mrdsrg-spin-integrated/master_mrdsrg.cc
@@ -844,7 +844,7 @@ void MASTER_DSRG::H1_T1_C0(BlockedTensor& H1, BlockedTensor& T1, const double& a
     E *= alpha;
     C0 += E;
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H1, T1] -> C0 : %12.3f", timer.get());
     }
     dsrg_time_.add("110", timer.get());
@@ -875,7 +875,7 @@ void MASTER_DSRG::H1_T2_C0(BlockedTensor& H1, BlockedTensor& T2, const double& a
     E *= alpha;
     C0 += E;
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H1, T2] -> C0 : %12.3f", timer.get());
     }
     dsrg_time_.add("120", timer.get());
@@ -906,7 +906,7 @@ void MASTER_DSRG::H2_T1_C0(BlockedTensor& H2, BlockedTensor& T1, const double& a
     E *= alpha;
     C0 += E;
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T1] -> C0 : %12.3f", timer.get());
     }
     dsrg_time_.add("210", timer.get());
@@ -1072,7 +1072,7 @@ void MASTER_DSRG::H2_T2_C0(BlockedTensor& H2, BlockedTensor& T2, const double& a
     E *= alpha;
     C0 += E;
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C0 : %12.3f", timer.get());
     }
     dsrg_time_.add("220", timer.get());
@@ -1087,7 +1087,7 @@ void MASTER_DSRG::H1_T1_C1(BlockedTensor& H1, BlockedTensor& T1, const double& a
     C1["IP"] += alpha * H1["AP"] * T1["IA"];
     C1["QA"] -= alpha * T1["IA"] * H1["QI"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H1, T1] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("111", timer.get());
@@ -1102,7 +1102,7 @@ void MASTER_DSRG::H1_T1_C1(BlockedTensor& H1, BlockedTensor& T1, const double& a
 //    C1["UV"] += alpha * H1["AV"] * T1["UA"];
 //    C1["UV"] -= alpha * T1["IV"] * H1["UI"];
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H1, T1] -> C1aa : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("111", timer.get());
@@ -1117,7 +1117,7 @@ void MASTER_DSRG::H1_T1_C1(BlockedTensor& H1, BlockedTensor& T1, const double& a
 //    C1["UI"] += alpha * H1["AI"] * T1["UA"];
 //    C1["AU"] -= alpha * T1["IU"] * H1["AI"];
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H1, T1] -> C1ph : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("111", timer.get());
@@ -1132,7 +1132,7 @@ void MASTER_DSRG::H1_T1_C1(BlockedTensor& H1, BlockedTensor& T1, const double& a
 //    C1["IB"] += alpha * H1["AB"] * T1["IA"];
 //    C1["JA"] -= alpha * T1["IA"] * H1["JI"];
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H1, T1] -> C1hp : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("111", timer.get());
@@ -1156,7 +1156,7 @@ void MASTER_DSRG::H1_T2_C1(BlockedTensor& H1, BlockedTensor& T2, const double& a
     C1["IA"] += alpha * H1["BU"] * Gamma1_["UV"] * T2["IVAB"];
     C1["IA"] -= alpha * H1["VJ"] * Gamma1_["UV"] * T2["IJAU"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H1, T2] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("121", timer.get());
@@ -1180,7 +1180,7 @@ void MASTER_DSRG::H1_T2_C1(BlockedTensor& H1, BlockedTensor& T2, const double& a
 //    C1["XY"] += alpha * H1["BU"] * Gamma1_["UV"] * T2["XVYB"];
 //    C1["XY"] -= alpha * H1["VJ"] * Gamma1_["UV"] * T2["XJYU"];
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H1, T2] -> C1aa : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("121", timer.get());
@@ -1214,7 +1214,7 @@ void MASTER_DSRG::H2_T1_C1(BlockedTensor& H2, BlockedTensor& T1, const double& a
     C1["QP"] += alpha * T1["XE"] * Gamma1_["YX"] * H2["QEPY"];
     C1["QP"] -= alpha * T1["MU"] * Gamma1_["UV"] * H2["QVPM"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T1] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("211", timer.get());
@@ -1238,7 +1238,7 @@ void MASTER_DSRG::H2_T1_C1(BlockedTensor& H2, BlockedTensor& T1, const double& a
 //    C1["XY"] += alpha * T1["UE"] * Gamma1_["VU"] * H2["XEYV"];
 //    C1["XY"] -= alpha * T1["MU"] * Gamma1_["UV"] * H2["XVYM"];
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H2, T1] -> C1aa : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("211", timer.get());
@@ -1262,7 +1262,7 @@ void MASTER_DSRG::H2_T1_C1(BlockedTensor& H2, BlockedTensor& T1, const double& a
 //    C1["KC"] += alpha * T1["XE"] * Gamma1_["YX"] * H2["KECY"];
 //    C1["KC"] -= alpha * T1["MU"] * Gamma1_["UV"] * H2["KVCM"];
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H2, T1] -> C1hp : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("211", timer.get());
@@ -1286,7 +1286,7 @@ void MASTER_DSRG::H2_T1_C1(BlockedTensor& H2, BlockedTensor& T1, const double& a
 //    C1["CK"] += alpha * T1["XE"] * Gamma1_["YX"] * H2["CEKY"];
 //    C1["CK"] -= alpha * T1["MU"] * Gamma1_["UV"] * H2["CVKM"];
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H2, T1] -> C1ph : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("211", timer.get());
@@ -1449,7 +1449,7 @@ void MASTER_DSRG::H2_T2_C1(BlockedTensor& H2, BlockedTensor& T2, const double& a
     C1["qs"] -= alpha * temp["MU"] * H2["qUsM"];
     C1["QS"] -= alpha * temp["MU"] * H2["UQMS"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("221", timer.get());
@@ -1474,7 +1474,7 @@ void MASTER_DSRG::H1_T2_C2(BlockedTensor& H1, BlockedTensor& T2, const double& a
     C2["QJAB"] -= alpha * T2["IJAB"] * H1["QI"];
     C2["IQAB"] -= alpha * T2["IJAB"] * H1["QJ"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H1, T2] -> C2 : %12.3f", timer.get());
     }
     dsrg_time_.add("122", timer.get());
@@ -1499,7 +1499,7 @@ void MASTER_DSRG::H2_T1_C2(BlockedTensor& H2, BlockedTensor& T1, const double& a
     C2["RSAQ"] -= alpha * T1["IA"] * H2["RSIQ"];
     C2["RSPA"] -= alpha * T1["IA"] * H2["RSPI"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T1] -> C2 : %12.3f", timer.get());
     }
     dsrg_time_.add("212", timer.get());
@@ -1615,7 +1615,7 @@ void MASTER_DSRG::H2_T2_C2(BlockedTensor& H2, BlockedTensor& T2, const double& a
     C2["iQaS"] -= alpha * Gamma1_["xy"] * T2["ijax"] * H2["yQjS"];
     C2["iQaS"] -= alpha * Gamma1_["XY"] * T2["iJaX"] * H2["YQJS"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C2 : %12.3f", timer.get());
     }
     dsrg_time_.add("222", timer.get());
@@ -1778,7 +1778,7 @@ void MASTER_DSRG::H2_T2_C3(BlockedTensor& H2, BlockedTensor& T2, const double& a
     C3["iJSbPQ"] += alpha * H2["ASPQ"] * T2["iJbA"];
     C3["iSJbPQ"] -= alpha * H2["ASPQ"] * T2["iJbA"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C3 : %12.3f", timer.get());
     }
     dsrg_time_.add("223", timer.get());

--- a/forte/mrdsrg-spin-integrated/mcsrgpt2_mo.cc
+++ b/forte/mrdsrg-spin-integrated/mcsrgpt2_mo.cc
@@ -140,7 +140,7 @@ void MCSRGPT2_MO::startup() {
 
     // Print Delta
     print_ = options_->get_int("PRINT");
-    if (print_ > 1) {
+    if (print_ > 2) {
         PrintDelta();
         test_D1_RE();
         test_D2_RE();
@@ -3363,7 +3363,7 @@ void MCSRGPT2_MO::Form_Fock(d2& A, d2& B) {
     }
     timer_off("Form Fock");
 
-    if (print_ > 1) {
+    if (print_ > 2) {
         print_Fock("Alpha", A);
         print_Fock("Beta", B);
     }
@@ -3383,7 +3383,7 @@ void MCSRGPT2_MO::fill_naive_cumulants(std::shared_ptr<RDMs> ref, const int leve
     ambit::Tensor L1a = ref->g1a();
     ambit::Tensor L1b = ref->g1b();
     fill_one_cumulant(L1a, L1b);
-    if (print_ > 1) {
+    if (print_ > 2) {
         print_density("Alpha", Da_);
         print_density("Beta", Db_);
     }
@@ -3394,7 +3394,7 @@ void MCSRGPT2_MO::fill_naive_cumulants(std::shared_ptr<RDMs> ref, const int leve
         ambit::Tensor L2ab = ref->L2ab();
         ambit::Tensor L2bb = ref->L2bb();
         fill_two_cumulant(L2aa, L2ab, L2bb);
-        if (print_ > 2) {
+        if (print_ > 3) {
             print2PDC("L2aa", L2aa_, print_);
             print2PDC("L2ab", L2ab_, print_);
             print2PDC("L2bb", L2bb_, print_);
@@ -3408,7 +3408,7 @@ void MCSRGPT2_MO::fill_naive_cumulants(std::shared_ptr<RDMs> ref, const int leve
         ambit::Tensor L3abb = ref->L3abb();
         ambit::Tensor L3bbb = ref->L3bbb();
         fill_three_cumulant(L3aaa, L3aab, L3abb, L3bbb);
-        if (print_ > 3) {
+        if (print_ > 4) {
             print3PDC("L3aaa", L3aaa_, print_);
             print3PDC("L3aab", L3aab_, print_);
             print3PDC("L3abb", L3abb_, print_);

--- a/forte/mrdsrg-spin-integrated/mrdsrg_commutator.cc
+++ b/forte/mrdsrg-spin-integrated/mrdsrg_commutator.cc
@@ -279,7 +279,7 @@ void MRDSRG::H2_T2_C1_DF(BlockedTensor& B, BlockedTensor& T2, const double& alph
     C1["QS"] -= alpha * temp["MU"] * B["gUM"] * B["gQS"];
     C1["QS"] += alpha * temp["MU"] * B["gUS"] * B["gQM"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("221", timer.get());
@@ -314,7 +314,7 @@ void MRDSRG::H2_T1_C0_DF(BlockedTensor& B, BlockedTensor& T1, const double& alph
     E *= alpha;
     C0 += E;
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T1] -> C0 : %12.3f", timer.get());
     }
     dsrg_time_.add("210", timer.get());
@@ -344,7 +344,7 @@ void MRDSRG::H2_T1_C1_DF(BlockedTensor& B, BlockedTensor& T1, const double& alph
     C1["QP"] -= alpha * T1["MU"] * Gamma1_["UV"] * B["gQP"] * B["gVM"];
     C1["QP"] += alpha * T1["MU"] * Gamma1_["UV"] * B["gQM"] * B["gVP"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T1] -> C1 : %12.3f", timer.get());
     }
     dsrg_time_.add("211", timer.get());
@@ -377,7 +377,7 @@ void MRDSRG::H2_T1_C2_DF(BlockedTensor& B, BlockedTensor& T1, const double& alph
     C2["RSPA"] -= alpha * T1["IA"] * B["gRP"] * B["gSI"];
     C2["RSPA"] += alpha * T1["IA"] * B["gRI"] * B["gSP"];
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T1] -> C2 : %12.3f", timer.get());
     }
     dsrg_time_.add("212", timer.get());
@@ -587,7 +587,7 @@ void MRDSRG::H2_T2_C0_DF(BlockedTensor& B, BlockedTensor& T2, const double& alph
     E *= alpha;
     C0 += E;
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C0 : %12.3f", timer.get());
     }
     dsrg_time_.add("220", timer.get());
@@ -698,7 +698,7 @@ void MRDSRG::H2_T2_C2_DF(BlockedTensor& B, BlockedTensor& T2, const double& alph
     C2["iQaS"] += alpha * Gamma1_["XY"] * B["gYS"] * B["gQJ"] * T2["iJaX"];
     hp.stop();
 
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n    Time for [H2, T2] -> C2 : %12.3f", timer.get());
     }
     dsrg_time_.add("222", timer.get());
@@ -1339,7 +1339,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    E *= alpha;
 //    C0 += E;
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H1, T1] -> C0 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("110", timer.get());
@@ -1370,7 +1370,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    E *= alpha;
 //    C0 += E;
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H1, T2] -> C0 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("120", timer.get());
@@ -1401,7 +1401,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    E *= alpha;
 //    C0 += E;
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H2, T1] -> C0 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("210", timer.get());
@@ -1568,7 +1568,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    E *= alpha;
 //    C0 += E;
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H2, T2] -> C0 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("220", timer.get());
@@ -1583,7 +1583,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    C1["IP"] += alpha * H1["AP"] * T1["IA"];
 //    C1["QA"] -= alpha * T1["IA"] * H1["QI"];
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H1, T1] -> C1 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("111", timer.get());
@@ -1607,7 +1607,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    C1["IA"] += alpha * H1["BU"] * T2["IVAB"] * Gamma1_["UV"];
 //    C1["IA"] -= alpha * H1["VJ"] * T2["IJAU"] * Gamma1_["UV"];
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H1, T2] -> C1 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("121", timer.get());
@@ -1631,7 +1631,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    C1["QP"] += alpha * T1["XE"] * Gamma1_["YX"] * H2["QEPY"];
 //    C1["QP"] -= alpha * T1["MU"] * Gamma1_["UV"] * H2["QVPM"];
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H2, T1] -> C1 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("211", timer.get());
@@ -1792,7 +1792,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    C1["qs"] -= alpha * temp["MU"] * H2["qUsM"];
 //    C1["QS"] -= alpha * temp["MU"] * H2["UQMS"];
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H2, T2] -> C1 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("221", timer.get());
@@ -1843,7 +1843,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    //    C2["QJAB"] -= temp["QJAB"]; // explicitly evaluate by temp
 //    //    C2["IQAB"] += temp["QIAB"]; // use permutation of temp
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H1, T2] -> C2 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("122", timer.get());
@@ -1868,7 +1868,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    C2["RSAQ"] -= alpha * T1["IA"] * H2["RSIQ"];
 //    C2["RSPA"] -= alpha * T1["IA"] * H2["RSPI"];
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H2, T1] -> C2 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("212", timer.get());
@@ -1959,7 +1959,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    C2["iQaS"] -= alpha * Gamma1_["XY"] * H2["YQJS"] * T2["iJaX"];
 //    hp.stop();
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H2, T2] -> C2 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("222", timer.get());
@@ -1975,7 +1975,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    C1["IP"] += alpha * H1["AP"] * T1["IA"];
 //    C1["QA"] -= alpha * T1["IA"] * H1["QI"];
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H1, T1] -> C1 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("111", timer.get());
@@ -1999,7 +1999,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    C1["IA"] += alpha * H1["BU"] * T2["IVAB"] * Gamma1_["UV"];
 //    C1["IA"] -= alpha * H1["VJ"] * T2["IJAU"] * Gamma1_["UV"];
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H1, T2] -> C1 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("121", timer.get());
@@ -2023,7 +2023,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    C1["QP"] += alpha * T1["XE"] * Gamma1_["YX"] * H2["QEPY"];
 //    C1["QP"] -= alpha * T1["MU"] * Gamma1_["UV"] * H2["QVPM"];
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H2, T1] -> C1 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("211", timer.get());
@@ -2184,7 +2184,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    C1["qs"] -= alpha * temp["MU"] * H2["qUsM"];
 //    C1["QS"] -= alpha * temp["MU"] * H2["UQMS"];
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H2, T2] -> C1 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("221", timer.get());
@@ -2235,7 +2235,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    //    C2["QJAB"] -= temp["QJAB"]; // explicitly evaluate by temp
 //    //    C2["IQAB"] += temp["QIAB"]; // use permutation of temp
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H1, T2] -> C2 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("122", timer.get());
@@ -2260,7 +2260,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    C2["RSAQ"] -= alpha * T1["IA"] * H2["RSIQ"];
 //    C2["RSPA"] -= alpha * T1["IA"] * H2["RSPI"];
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H2, T1] -> C2 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("212", timer.get());
@@ -2351,7 +2351,7 @@ void MRDSRG::H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha,
 //    C2["iQaS"] -= alpha * Gamma1_["XY"] * H2["YQJS"] * T2["iJaX"];
 //    hp.stop();
 
-//    if (print_ > 2) {
+//    if (print_ > 3) {
 //        outfile->Printf("\n    Time for [H2, T2] -> C2 : %12.3f", timer.get());
 //    }
 //    dsrg_time_.add("222", timer.get());

--- a/forte/mrdsrg-spin-integrated/mrdsrg_nonpt.cc
+++ b/forte/mrdsrg-spin-integrated/mrdsrg_nonpt.cc
@@ -47,7 +47,7 @@ using namespace psi;
 namespace forte {
 
 void MRDSRG::compute_hbar() {
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n\n  ==> Computing the DSRG Transformed Hamiltonian <==\n");
     }
 
@@ -93,7 +93,7 @@ void MRDSRG::compute_hbar() {
         C2_.zero();
 
         // printing level
-        if (print_ > 2) {
+        if (print_ > 3) {
             std::string dash(38, '-');
             outfile->Printf("\n    %s", dash.c_str());
         }
@@ -165,7 +165,7 @@ void MRDSRG::compute_hbar() {
         }
 
         // printing level
-        if (print_ > 2) {
+        if (print_ > 3) {
             std::string dash(38, '-');
             outfile->Printf("\n    %s\n", dash.c_str());
         }
@@ -203,7 +203,7 @@ void MRDSRG::compute_hbar() {
         // test convergence of C
         double norm_C1 = C1_.norm();
         double norm_C2 = C2_.norm();
-        if (print_ > 2) {
+        if (print_ > 3) {
             outfile->Printf("\n  n: %3d, C0: %20.15f, C1 max: %20.15f, C2 max: %20.15f", n, C0,
                             C1_.norm(0), C2_.norm(0));
         }
@@ -219,7 +219,7 @@ void MRDSRG::compute_hbar() {
 }
 
 void MRDSRG::compute_hbar_sequential() {
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n\n  ==> Computing the DSRG Transformed Hamiltonian <==\n");
     }
     //    outfile->Printf("\n\n  ==> compute_hbar_sequential() <==\n");
@@ -256,7 +256,7 @@ void MRDSRG::compute_hbar_sequential() {
         C2_.zero();
 
         // printing level
-        if (print_ > 2) {
+        if (print_ > 3) {
             std::string dash(38, '-');
             outfile->Printf("\n    %s", dash.c_str());
         }
@@ -271,7 +271,7 @@ void MRDSRG::compute_hbar_sequential() {
         H2_T1_C2(O2_, T1_, factor, C2_);
 
         // printing level
-        if (print_ > 2) {
+        if (print_ > 3) {
             std::string dash(38, '-');
             outfile->Printf("\n    %s\n", dash.c_str());
         }
@@ -309,7 +309,7 @@ void MRDSRG::compute_hbar_sequential() {
         // test convergence of C
         double norm_C1 = C1_.norm();
         double norm_C2 = C2_.norm();
-        if (print_ > 2) {
+        if (print_ > 3) {
             outfile->Printf("\n  n: %3d, C0: %20.15f, C1 max: %20.15f, C2 max: %20.15f", n, C0,
                             C1_.norm(0), C2_.norm(0));
         }
@@ -344,7 +344,7 @@ void MRDSRG::compute_hbar_sequential() {
         C2_.zero();
 
         // printing level
-        if (print_ > 2) {
+        if (print_ > 3) {
             std::string dash(38, '-');
             outfile->Printf("\n    %s", dash.c_str());
         }
@@ -360,7 +360,7 @@ void MRDSRG::compute_hbar_sequential() {
         H2_T2_C2(O2_, T2_, factor, C2_);
 
         // printing level
-        if (print_ > 2) {
+        if (print_ > 3) {
             std::string dash(38, '-');
             outfile->Printf("\n    %s\n", dash.c_str());
         }
@@ -398,7 +398,7 @@ void MRDSRG::compute_hbar_sequential() {
         // test convergence of C
         double norm_C1 = C1_.norm();
         double norm_C2 = C2_.norm();
-        if (print_ > 2) {
+        if (print_ > 3) {
             outfile->Printf("\n  n = %3d, C1norm = %20.15f, C2norm = %20.15f", n, norm_C1, norm_C2);
         }
         if (std::sqrt(norm_C2 * norm_C2 + norm_C1 * norm_C1) < ct_threshold) {
@@ -413,7 +413,7 @@ void MRDSRG::compute_hbar_sequential() {
 }
 
 void MRDSRG::compute_hbar_sequential_rotation() {
-    if (print_ > 2) {
+    if (print_ > 3) {
         outfile->Printf("\n\n  ==> Computing the DSRG Transformed Hamiltonian <==\n");
     }
 
@@ -586,7 +586,7 @@ void MRDSRG::compute_hbar_sequential_rotation() {
         C2_.zero();
 
         // printing level
-        if (print_ > 2) {
+        if (print_ > 3) {
             std::string dash(38, '-');
             outfile->Printf("\n    %s", dash.c_str());
         }
@@ -614,7 +614,7 @@ void MRDSRG::compute_hbar_sequential_rotation() {
         }
 
         // printing level
-        if (print_ > 2) {
+        if (print_ > 3) {
             std::string dash(38, '-');
             outfile->Printf("\n    %s\n", dash.c_str());
         }
@@ -652,7 +652,7 @@ void MRDSRG::compute_hbar_sequential_rotation() {
         // test convergence of C
         double norm_C1 = C1_.norm();
         double norm_C2 = C2_.norm();
-        if (print_ > 2) {
+        if (print_ > 3) {
             outfile->Printf("\n  n: %3d, C0: %20.15f, C1 max: %20.15f, C2 max: %20.15f", n, C0,
                             C1_.norm(0), C2_.norm(0));
         }

--- a/forte/mrdsrg-spin-integrated/three_dsrg_mrpt2.cc
+++ b/forte/mrdsrg-spin-integrated/three_dsrg_mrpt2.cc
@@ -211,7 +211,7 @@ void THREE_DSRG_MRPT2::startup() {
         Fa_ = Fdiag_a_;
         Fb_ = Fdiag_b_;
 
-        if (print_ > 1) {
+        if (print_ > 2) {
             Gamma1_.print(stdout);
             Eta1_.print(stdout);
             F_.print(stdout);
@@ -384,10 +384,10 @@ double THREE_DSRG_MRPT2::compute_energy() {
         // renormalize F
         renormalize_F();
 
-        if (print_ > 1) {
+        if (print_ > 2) {
             F_.print();
         }
-        if (print_ > 2) {
+        if (print_ > 3) {
             T1_.print();
         }
     }
@@ -1567,7 +1567,7 @@ double THREE_DSRG_MRPT2::E_VT2_6() {
             //            Lambda3_aAA("pqrstu") = L3abb_("pqrstu");
             //            Lambda3_AAA("pqrstu") = L3bbb_("pqrstu");
 
-            //            if (print_ > 3){
+            //            if (print_ > 4){
             //                Lambda3.print(stdout);
             //            }
 
@@ -2819,7 +2819,7 @@ double THREE_DSRG_MRPT2::E_VT2_2_one_active() {
     Eacvv += tempTAA_all("v,u") * Gamma1_AA("v,u");
     Eacvv += tempTaa_all("v,u") * Gamma1_aa("v,u");
 
-    if (print_ > 0) {
+    if (print_ > 1) {
         outfile->Printf("\n\n  CAVV computation takes %8.8f", ccvaTimer.get());
     }
 
@@ -2949,7 +2949,7 @@ double THREE_DSRG_MRPT2::E_VT2_2_one_active() {
     }
     Eccva += tempTaa_all("vu") * Eta1_aa("uv");
     Eccva += tempTAA_all("VU") * Eta1_AA("UV");
-    if (print_ > 0) {
+    if (print_ > 1) {
         outfile->Printf("\n\n  CCVA takes %8.8f", cavvTimer.get());
     }
 

--- a/forte/orbital-helpers/semi_canonicalize.cc
+++ b/forte/orbital-helpers/semi_canonicalize.cc
@@ -134,8 +134,8 @@ void SemiCanonical::semicanonicalize(std::shared_ptr<RDMs> rdms, const bool& bui
 
     print_h2("Semicanonicalize Orbitals");
     auto true_or_false = [](bool x) { return x ? "TRUE" : "FALSE"; };
-    outfile->Printf("\n    MIX INACTIVE ORBITALS   ...... %5s", true_or_false(inactive_mix_));
-    outfile->Printf("\n    MIX GAS ACTIVE ORBITALS ...... %5s", true_or_false(active_mix_));
+    outfile->Printf("\n    MIX INACTIVE ORBITALS         %5s", true_or_false(inactive_mix_));
+    outfile->Printf("\n    MIX GAS ACTIVE ORBITALS       %5s", true_or_false(active_mix_));
 
     // build Fock matrix
     if (build_fock) {
@@ -167,12 +167,12 @@ bool SemiCanonical::check_orbitals(std::shared_ptr<RDMs> rdms, const bool& nat_o
         std::string name = pair.first;
         if (name.find("GAS") != std::string::npos) {
             if (pair.second.sum() != 0) {
-                outfile->Printf("\n    %-15s ... %10s", name.c_str(), nat.c_str());
+                outfile->Printf("\n    %-15s              %10s", name.c_str(), nat.c_str());
             }
         } else if (name.find("ACTIVE") != std::string::npos) {
-            outfile->Printf("\n    %-15s ... %10s", name.c_str(), nat.c_str());
+            outfile->Printf("\n    %-15s              %10s", name.c_str(), nat.c_str());
         } else {
-            outfile->Printf("\n    %-15s ... %10s", name.c_str(), "CANONICAL");
+            outfile->Printf("\n    %-15s              %10s", name.c_str(), "CANONICAL");
         }
     }
 

--- a/forte/pymodule.py
+++ b/forte/pymodule.py
@@ -513,7 +513,7 @@ def forte_driver(state_weights_map, scf_info, options, ints, mo_space_info):
         dsrg_proc.print_summary()
         dsrg_proc.push_to_psi4_environment()
 
-        if options.get_str("DERTYPE") == "FIRST" and active_space_solver_type == "DETCI":
+        if options.get_str("DERTYPE") == "FIRST" and active_space_solver_type in ["DETCI", "GENCI"]:
             # Compute coupling coefficients
             # NOTE: 1. Orbitals have to be semicanonicalized already to make sure
             #          DSRG reads consistent CI coefficients before and after SemiCanonical class.

--- a/forte/pymodule.py
+++ b/forte/pymodule.py
@@ -616,7 +616,7 @@ def run_forte(name, **kwargs):
         active_space_method = forte.make_active_space_method(
             "ACI", state, options.get_int("NROOT"), scf_info, mo_space_info, as_ints, options
         )
-        active_space_method.set_quiet_mode(True)
+        active_space_method.set_quiet_mode()
         active_space_method.compute_energy()
 
         tdci = forte.TDCI(active_space_method, scf_info, options, mo_space_info, as_ints)

--- a/forte/register_forte_options.py
+++ b/forte/register_forte_options.py
@@ -116,7 +116,7 @@ def register_driver_options(options):
         "Active space solver used in the relaxation when using `external` active space solver",
     )
 
-    options.add_int("PRINT", 1, "Set the print level.")
+    options.add_int("PRINT", 2, "Set the print level. (0 = quiet, 1 = brief, 2 = default, 3 = verbose, 4 = debug)")
 
     options.add_bool("READ_ORBITALS", False, "Read orbitals from file if true")
 

--- a/forte/sci/aci.cc
+++ b/forte/sci/aci.cc
@@ -124,6 +124,8 @@ void AdaptiveCI::startup() {
 }
 
 void AdaptiveCI::print_info() {
+    if (quiet_mode_)
+        return;
 
     print_method_banner({"Adaptive Configuration Interaction",
                          "written by Jeffrey B. Schriber and Francesco A. Evangelista"});
@@ -131,44 +133,46 @@ void AdaptiveCI::print_info() {
     outfile->Printf("\n  There are %d frozen orbitals.", nfrzc_);
     outfile->Printf("\n  There are %zu active orbitals.\n", nact_);
 
-    // Print a summary
-    std::vector<std::pair<std::string, int>> calculation_info{
-        {"Multiplicity", multiplicity_},
-        {"Symmetry", wavefunction_symmetry_},
-        {"Number of roots", nroot_},
-        {"Root used for properties", root_},
-        {"Roots used for averaging", naverage_},
-        {"Root averaging offset", average_offset_}};
+    table_printer printer;
+    printer.add_string_data(
+        {{"Ms", get_ms_string(twice_ms_)},
+         {"Diagonalization algorithm", options_->get_str("DIAG_ALGORITHM")},
+         {"Excited Algorithm", ex_alg_},
+         //        {"Q Type", q_rel_ ? "Relative Energy" : "Absolute Energy"},
+         //        {"PT2 Parameters", options_->get_bool("PERTURB_SELECT") ?
+         //        "True" : "False"},
+         {"Project out spin contaminants", project_out_spin_contaminants_ ? "True" : "False"},
+         {"Enforce spin completeness of basis", spin_complete_ ? "True" : "False"},
+         {"Enforce complete aimed selection", add_aimed_degenerate_ ? "True" : "False"},
+         {"Multiroot averaging ", average_function_ == AverageFunction::MaxF ? "Max" : "Average"}});
 
-    std::vector<std::pair<std::string, double>> calculation_info_double{
-        {"Sigma (Eh)", sigma_},
-        {"Gamma (Eh^(-1))", gamma_},
-        {"Convergence threshold", options_->get_double("ACI_CONVERGENCE")}};
-    std::vector<std::pair<std::string, std::string>> calculation_info_string{
-        {"Ms", get_ms_string(twice_ms_)},
-        {"Diagonalization algorithm", options_->get_str("DIAG_ALGORITHM")},
-        {"Excited Algorithm", ex_alg_},
-        //        {"Q Type", q_rel_ ? "Relative Energy" : "Absolute Energy"},
-        //        {"PT2 Parameters", options_->get_bool("PERTURB_SELECT") ?
-        //        "True" : "False"},
-        {"Project out spin contaminants", project_out_spin_contaminants_ ? "True" : "False"},
-        {"Enforce spin completeness of basis", spin_complete_ ? "True" : "False"},
-        {"Enforce complete aimed selection", add_aimed_degenerate_ ? "True" : "False"},
-        {"Multiroot averaging ", average_function_ == AverageFunction::MaxF ? "Max" : "Average"}};
+    printer.add_double_data({{{"Sigma (Eh)", sigma_},
+                              {"Gamma (Eh^(-1))", gamma_},
+                              {"Convergence threshold", options_->get_double("ACI_CONVERGENCE")}}});
 
-    // Print some information
-    outfile->Printf("\n  ==> Calculation Information <==\n");
-    outfile->Printf("\n  %s", std::string(65, '-').c_str());
-    for (auto& str_dim : calculation_info) {
-        outfile->Printf("\n    %-40s %-5d", str_dim.first.c_str(), str_dim.second);
-    }
-    for (auto& str_dim : calculation_info_double) {
-        outfile->Printf("\n    %-40s %8.2e", str_dim.first.c_str(), str_dim.second);
-    }
-    for (auto& str_dim : calculation_info_string) {
-        outfile->Printf("\n    %-40s %s", str_dim.first.c_str(), str_dim.second.c_str());
-    }
-    outfile->Printf("\n  %s", std::string(65, '-').c_str());
+    printer.add_int_data({{"Multiplicity", multiplicity_},
+                          {"Symmetry", wavefunction_symmetry_},
+                          {"Number of roots", nroot_},
+                          {"Root used for properties", root_},
+                          {"Roots used for averaging", naverage_},
+                          {"Root averaging offset", average_offset_}});
+                          
+    std::string table = printer.get_table("ACI Solver");
+    psi::outfile->Printf("%s", table.c_str());
+
+    // // Print some information
+    // outfile->Printf("\n  ==> Calculation Information <==\n");
+    // outfile->Printf("\n  %s", std::string(65, '-').c_str());
+    // for (auto& str_dim : calculation_info) {
+    //     outfile->Printf("\n    %-40s %-5d", str_dim.first.c_str(), str_dim.second);
+    // }
+    // for (auto& str_dim : calculation_info_double) {
+    //     outfile->Printf("\n    %-40s %8.2e", str_dim.first.c_str(), str_dim.second);
+    // }
+    // for (auto& str_dim : calculation_info_string) {
+    //     outfile->Printf("\n    %-40s %s", str_dim.first.c_str(), str_dim.second.c_str());
+    // }
+    // outfile->Printf("\n  %s", std::string(65, '-').c_str());
 
     if (options_->get_bool("PRINT_1BODY_EVALS")) {
         outfile->Printf("\n  Reference orbital energies:");

--- a/forte/sci/detci.cc
+++ b/forte/sci/detci.cc
@@ -86,7 +86,7 @@ double DETCI::compute_energy() {
     compute_1rdms();
 
     // print CI vectors
-    if (not quiet_) {
+    if (print_ >= PrintLevel::Default) {
         print_ci_wfn();
     }
 
@@ -124,13 +124,13 @@ void DETCI::build_determinant_space() {
             "input (symmetry and multiplicity of the root, etc.)!");
     }
 
-    if (print_ > 2) {
+    if (print_ >= PrintLevel::Debug) {
         print_h2("Determinants");
         for (const auto& det : dets) {
             outfile->Printf("\n  %s", str(det, nactv_).c_str());
         }
     }
-    if (not quiet_) {
+    if (print_ >= PrintLevel::Default) {
         outfile->Printf("\n  Number of determinants (%s): %zu", actv_space_type_.c_str(), size);
     }
 
@@ -170,7 +170,7 @@ std::shared_ptr<SparseCISolver> DETCI::prepare_ci_solver() {
     auto solver = std::make_shared<SparseCISolver>();
     solver->set_options(options_);
     solver->set_spin_project(true);
-    solver->set_print_details(not quiet_);
+    solver->set_print_details(print_ >= PrintLevel::Default);
 
     if (read_wfn_guess_) {
         outfile->Printf("\n  Reading wave function from disk as initial guess:");

--- a/forte/sparse_ci/bitarray.hpp
+++ b/forte/sparse_ci/bitarray.hpp
@@ -418,6 +418,24 @@ template <size_t N> class BitArray {
         return ~word_t(0);
     }
 
+    /// Find all the bits set to one and store their indices in the vector occ
+    /// @param occ a vector of integers where the indices of the bits set to one are stored
+    /// @param n the number of bits set to one
+    /// @param begin the index of the first word to test
+    /// @param end the index of the last word to test (not included)
+    void find_set_bits(std::vector<int>& occ, int& n, size_t begin = 0,
+                       size_t end = nwords_) const {
+        n = 0;
+        uint64_t x;
+        for (; begin < end; ++begin) {
+            x = words_[begin];
+            while (x != 0) {
+                occ[n] = ui64_find_and_clear_lowest_one_bit(x) + begin * bits_per_word;
+                ++n;
+            }
+        }
+    }
+
     /// Implements the operation: (a & b) == b
     bool fast_a_and_b_equal_b(const BitArray<N>& b) const {
         bool result = false;

--- a/forte/sparse_ci/sparse_ci_solver.cc
+++ b/forte/sparse_ci/sparse_ci_solver.cc
@@ -82,7 +82,7 @@ void SparseCISolver::set_spin_project_full(bool value) { spin_project_full_ = va
 
 void SparseCISolver::set_spin_adapt(bool value) { spin_adapt_ = value; }
 
-void SparseCISolver::set_print(int value) { print_ = value; }
+void SparseCISolver::set_print(PrintLevel value) { print_ = value; }
 
 void SparseCISolver::set_spin_adapt_full_preconditioner(bool value) {
     spin_adapt_full_preconditioner_ = value;
@@ -114,7 +114,7 @@ void SparseCISolver::set_options(std::shared_ptr<ForteOptions> options) {
     set_spin_project(options->get_bool("SCI_PROJECT_OUT_SPIN_CONTAMINANTS"));
     set_spin_project_full(options->get_bool("SCI_PROJECT_OUT_SPIN_CONTAMINANTS"));
 
-    set_print(options->get_int("PRINT"));
+    set_print(int_to_print_level(options->get_int("PRINT")));
 
     set_spin_adapt(options->get_bool("CI_SPIN_ADAPT"));
     set_spin_adapt_full_preconditioner(options->get_bool("CI_SPIN_ADAPT_FULL_PRECONDITIONER"));
@@ -418,14 +418,15 @@ auto SparseCISolver::initial_guess_det(const DeterminantHashVec& space,
     }
 
     return find_initial_guess_det(guess_dets, guess_dets_pos, num_guess_states,
-                                  sigma_vector->as_ints(), multiplicity, do_spin_project, print_,
-                                  user_guess_);
+                                  sigma_vector->as_ints(), multiplicity, do_spin_project,
+                                  print_ >= PrintLevel::Default, user_guess_);
 }
 
 auto SparseCISolver::initial_guess_csf(std::shared_ptr<psi::Vector> diag, size_t num_guess_states,
                                        int multiplicity) {
 
-    return find_initial_guess_csf(diag, num_guess_states, multiplicity, print_details_);
+    return find_initial_guess_csf(diag, num_guess_states, multiplicity,
+                                  print_ >= PrintLevel::Default);
 }
 
 std::shared_ptr<psi::Vector>

--- a/forte/sparse_ci/sparse_ci_solver.h
+++ b/forte/sparse_ci/sparse_ci_solver.h
@@ -29,11 +29,9 @@
 #ifndef _sparse_ci_h_
 #define _sparse_ci_h_
 
-#include "sparse_ci/determinant_hashvector.h"
 #include "psi4/libmints/dimension.h"
-
-#define BIGNUM 1E100
-#define MAXIT 100
+#include "sparse_ci/determinant_hashvector.h"
+#include "helpers/printing.h"
 
 namespace psi {
 class Matrix;
@@ -92,7 +90,7 @@ class SparseCISolver {
     void set_parallel(bool parallel) { parallel_ = parallel; }
 
     /// Set the print level
-    void set_print(int value);
+    void set_print(PrintLevel print);
 
     /// Enable/disable printing of details
     void set_print_details(bool print_details) { print_details_ = print_details; }
@@ -203,7 +201,7 @@ class SparseCISolver {
     /// Print details?
     bool print_details_ = true;
     /// A variable to control printing information
-    int print_ = 0;
+    PrintLevel print_ = PrintLevel::Default;
     /// Project solutions onto given multiplicity?
     bool spin_project_ = false;
     /// Project solutions onto given multiplicity in full algorithm?

--- a/tests/methods/casscf-1/input.dat
+++ b/tests/methods/casscf-1/input.dat
@@ -17,13 +17,13 @@ molecule {
 
 set globals {
    scf_type             out_of_core
-   MCSCF_E_CONVERGENCE  8
-   MCSCF_R_CONVERGENCE  6
+   mcscf_e_convergence  8
+   mcscf_r_convergence  6
    basis                3-21g
    restricted_docc      [2,0,0,0]
    active               [1,0,0,1]
    maxiter              20
-   reference            RHF
+   reference            rhf
    mcscf_type           conv
    diag_method          rsp
 }
@@ -34,14 +34,11 @@ set scf_type direct
 set forte{
    job_type             mcscf_two_step
    active_space_solver  fci
-   CASSCF_G_CONVERGENCE 1e-6
-   CASSCF_E_CONVERGENCE 1e-8
+   casscf_g_convergence 1e-6
+   casscf_e_convergence 1e-8
    restricted_docc      [2,0,0,0]
    active               [1,0,0,1]
-   #restricted_docc      [2]
-   #active               [2]
    int_type             conventional
-#   casscf_do_diis       true
 }
 e_casscf = energy('forte')
 

--- a/tests/pytest/determinant/test_occupation.py
+++ b/tests/pytest/determinant/test_occupation.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import forte
+import pytest
+
+
+def test_gas_occupation1():
+    """Test class constructors"""
+    print("Testing determinant interface")
+    na = 2
+    nb = 2
+    gas_size = [2, 2]
+    gas_min = [1]
+    gas_max = [1]
+    n, occsa, occsb, pair_occs = forte.get_gas_occupation(na, nb, gas_min, gas_max, gas_size)
+    assert n == 2
+    assert occsa == [[1, 1, 0, 0, 0, 0], [0, 2, 0, 0, 0, 0]]
+    assert occsb == [[0, 2, 0, 0, 0, 0], [1, 1, 0, 0, 0, 0]]
+    assert pair_occs == [(0, 0), (1, 1)]
+    ref_occs = []
+    for i, j in pair_occs:
+        ref_occs.append(occsa[i] + occsb[j])
+    ref_occs.sort()
+
+    n, occsa, occsb, pair_occs = forte.get_ci_occupation_patterns(na, nb, gas_min, gas_max, gas_size)
+    occs = []
+    for i, j in pair_occs:
+        occs.append(occsa[i] + occsb[j])
+    occs.sort()
+    assert occs == ref_occs
+
+
+def test_gas_occupation2():
+    """Test class constructors"""
+    print("Testing determinant interface")
+    na = 2
+    nb = 2
+    gas_size = [2, 2]
+    gas_min = [0]
+    gas_max = [0]
+    n, occsa, occsb, pair_occs = forte.get_gas_occupation(na, nb, gas_min, gas_max, gas_size)
+    assert n == 2
+    assert occsa == [[0, 2, 0, 0, 0, 0]]
+    assert occsb == [[0, 2, 0, 0, 0, 0]]
+    assert pair_occs == [(0, 0)]
+    ref_occs = []
+    for i, j in pair_occs:
+        ref_occs.append(occsa[i] + occsb[j])
+    ref_occs.sort()
+
+    n, occsa, occsb, pair_occs = forte.get_ci_occupation_patterns(na, nb, gas_min, gas_max, gas_size)
+    occs = []
+    for i, j in pair_occs:
+        occs.append(occsa[i] + occsb[j])
+    occs.sort()
+    assert occs == ref_occs
+
+
+def test_gas_occupation3():
+    """Test class constructors"""
+    print("Testing determinant interface")
+    na = 2
+    nb = 2
+    gas_size = [2, 2]
+    gas_min = [0]
+    gas_max = [1]
+    n, occsa, occsb, pair_occs = forte.get_gas_occupation(na, nb, gas_min, gas_max, gas_size)
+    assert n == 2
+    assert occsa == [[1, 1, 0, 0, 0, 0], [0, 2, 0, 0, 0, 0]]
+    assert occsb == [[0, 2, 0, 0, 0, 0], [1, 1, 0, 0, 0, 0]]
+    assert pair_occs == [(0, 0), (1, 1), (1, 0)]
+    ref_occs = []
+    for i, j in pair_occs:
+        ref_occs.append(occsa[i] + occsb[j])
+    ref_occs.sort()
+
+    n, occsa, occsb, pair_occs = forte.get_ci_occupation_patterns(na, nb, gas_min, gas_max, gas_size)
+    occs = []
+    for i, j in pair_occs:
+        occs.append(occsa[i] + occsb[j])
+    occs.sort()
+    assert occs == ref_occs
+
+
+if __name__ == "__main__":
+    test_gas_occupation1()
+    test_gas_occupation2()
+    test_gas_occupation3()


### PR DESCRIPTION
## Description
This PR improves the performance of the GenCISolver RDM computation and improves the handling of printing.

## User Notes
- [x] aab and abb components of the 3-RDM are now computed with an algorithm that evaluates only the unique elements. This can bring up to x4 speedup.
- [x] Introduced the `PrintLevel` enum to control printing.
- [x] Supports 5 levels of printing, Quiet, Brief, Default, Verbose, Debug. 
- [x] Reduced printing in `MCSCF_TWO_STEPS`. Turn on verbose (print = 3) to see details of each intermediate CI computation.
- [x] Added more printing via table class.
- [x] Introduce new recursive algorithm to generate CI occupations.
- [x] Still keeps the `FCISolver` as the default CI code. 

## Checklist
- [x] Added/updated tests of new features and included a reference `output.ref` file
- [x] Removed comments in code and input files
- [x] Documented source code
- [x] Checked for redundant headers
- [x] Checked for consistency in the formatting of the output file
- [x] Ready to go!
