### PR TITLE
Introducing Modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.log
 *.dat
 *.clean
+*.swp
 Makefile.*
 Makefile
 timer.dat

--- a/forte/__init__.py
+++ b/forte/__init__.py
@@ -42,8 +42,8 @@ from .register_forte_options import *
 from .core import ForteManager, clean_options
 from ._forte import *
 
-__version__ = '0.2.3'
-__author__ = 'Forte Developers'
+__version__ = "0.2.4"
+__author__ = "Forte Developers"
 
 # Create a global ForteOptions object (stores all options)
 forte_options = forte.ForteOptions()
@@ -55,7 +55,7 @@ register_forte_options(forte_options)
 ForteManager()
 
 # If we are running psi4, push the options defined in forte_options to psi
-if 'psi4' in sys.modules:
+if "psi4" in sys.modules:
     psi_options = psi4.core.get_options()
-    psi_options.set_current_module('FORTE')
+    psi_options.set_current_module("FORTE")
     forte_options.push_options_to_psi4(psi_options)

--- a/forte/core.py
+++ b/forte/core.py
@@ -52,12 +52,13 @@ def clean_options():
 
     # push the options defined in forte_options to psi
     psi_options = psi4.core.get_options()
-    psi_options.set_current_module('FORTE')
+    psi_options.set_current_module("FORTE")
     forte.forte_options.push_options_to_psi4(psi_options)
 
 
 class ForteManager(object):
     """Singleton class to handle startup and cleanup of forte (mostly ambit)"""
+
     _instance = None
 
     def __new__(cls):
@@ -71,7 +72,7 @@ class ForteManager(object):
         forte.cleanup()
 
 
-def start_logging(filename='forte.log', level=logging.DEBUG):
+def start_logging(filename="forte.log", level=logging.DEBUG):
     """
     This function sets the output of logs to ``filename`` (default = forte.log)
     and sets the log level to all information.
@@ -83,8 +84,8 @@ def start_logging(filename='forte.log', level=logging.DEBUG):
     level: {logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL}
         the level of severity of the events tracked (default = logging.DEBUG, which means track everything)
     """
-    logging.basicConfig(filename=filename, level=level, format='# %(asctime)s | %(levelname)s | %(message)s')
-    logging.info('Starting the Forte logger')
+    logging.basicConfig(filename=filename, level=level, format="# %(asctime)s | %(levelname)s | %(message)s")
+    logging.info("Starting the Forte logger")
 
 
 def flog(level, msg):
@@ -109,18 +110,18 @@ def flog(level, msg):
     """
     global logging_depth
     level = level.lower()
-    spaces = ' ' * max((logging_depth - 1), 0) * 2
+    spaces = " " * max((logging_depth - 1), 0) * 2
     s = f"{spaces}{msg}"
-    if level == 'info':
+    if level == "info":
         logging.info(s)
-    elif level == 'warning':
+    elif level == "warning":
         logging.warning(s)
-    elif level == 'debug':
+    elif level == "debug":
         logging.debug(s)
-    elif level == 'error':
+    elif level == "error":
         logging.error(s)
     else:
-        raise ValueError(f'forte.core.flog was called with an unrecognized level ({level})')
+        raise ValueError(f"forte.core.flog was called with an unrecognized level ({level})")
 
 
 def increase_log_depth(func):
@@ -132,10 +133,12 @@ def increase_log_depth(func):
             def run(self):
                 ...
     """
+
     def wrapper(*args, **kwargs):
         global logging_depth
         logging_depth += 1
-        func(*args, **kwargs)
+        result = func(*args, **kwargs)
         logging_depth += -1
+        return result
 
     return wrapper

--- a/forte/data.py
+++ b/forte/data.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass
 
-import psi4
+from psi4.core import Wavefunction
 from forte import Model
 from ._forte import ForteOptions, SCFInfo, MOSpaceInfo, ForteIntegrals, ActiveSpaceIntegrals, StateInfo
 
 
 @dataclass
 class ForteData:
-    """Dataclass for holding data used by forte."""
+    """Dataclass for holding data passed around in forte."""
 
     options: ForteOptions = None
     state_weights_map: dict[StateInfo] = None
@@ -16,4 +16,4 @@ class ForteData:
     mo_space_info: MOSpaceInfo = None
     ints: ForteIntegrals = None
     as_ints: ActiveSpaceIntegrals = None
-    psi_wfn: psi4.core.Wavefunction = None
+    psi_wfn: Wavefunction = None

--- a/forte/data.py
+++ b/forte/data.py
@@ -1,13 +1,17 @@
 from dataclasses import dataclass
 
 from psi4.core import Wavefunction
-from forte import Model
+
 from ._forte import ForteOptions, SCFInfo, MOSpaceInfo, ForteIntegrals, ActiveSpaceIntegrals, StateInfo
+from forte import Model
 
 
 @dataclass
 class ForteData:
-    """Dataclass for holding data passed around in forte."""
+    """Dataclass for holding data passed around in forte.
+
+    This class is the container for all the data that is passed around in forte from one module to another.
+    """
 
     options: ForteOptions = None
     state_weights_map: dict[StateInfo] = None

--- a/forte/data.py
+++ b/forte/data.py
@@ -1,14 +1,19 @@
 from dataclasses import dataclass
 
 import psi4
-import forte
+from forte import Model
+from ._forte import ForteOptions, SCFInfo, MOSpaceInfo, ForteIntegrals, ActiveSpaceIntegrals, StateInfo
 
 
 @dataclass
-class Data:
-    model: forte.Model = None
-    scf_info: forte.SCFInfo = None
-    mo_space_info: forte.MOSpaceInfo = None
-    ints: forte.ForteIntegrals = None
-    as_ints: forte.ActiveSpaceIntegrals = None
+class ForteData:
+    """Dataclass for holding data used by forte."""
+
+    options: ForteOptions = None
+    state_weights_map: dict[StateInfo] = None
+    model: Model = None
+    scf_info: SCFInfo = None
+    mo_space_info: MOSpaceInfo = None
+    ints: ForteIntegrals = None
+    as_ints: ActiveSpaceIntegrals = None
     psi_wfn: psi4.core.Wavefunction = None

--- a/forte/modules/__init__.py
+++ b/forte/modules/__init__.py
@@ -4,4 +4,6 @@ from .graph_visualizer import GraphVisualizer
 from .options_factory import OptionsFactory
 from .objects_factory_fcidump import ObjectsFactoryFCIDUMP
 from .objects_factory_psi4 import ObjectsFactoryPsi4
+from .active_space_ints_factory import ActiveSpaceIntsFactory
 from .mock import HF, FCI, Ints, Ints2, Localizer
+from .objects_util_psi4 import ObjectsUtilPsi4

--- a/forte/modules/__init__.py
+++ b/forte/modules/__init__.py
@@ -2,4 +2,5 @@ from .module import Module
 from .sequential import Sequential
 from .graph_visualizer import GraphVisualizer
 from .options_factory import OptionsFactory
+from .objects_factory_fcidump import ObjectsFactoryFCIDUMP
 from .mock import HF, FCI, Ints, Ints2, Localizer

--- a/forte/modules/__init__.py
+++ b/forte/modules/__init__.py
@@ -1,0 +1,5 @@
+from .module import Module
+from .sequential import Sequential
+from .graph_visualizer import GraphVisualizer
+from .options_factory import OptionsFactory
+from .mock import HF, FCI, Ints, Ints2, Localizer

--- a/forte/modules/__init__.py
+++ b/forte/modules/__init__.py
@@ -3,4 +3,5 @@ from .sequential import Sequential
 from .graph_visualizer import GraphVisualizer
 from .options_factory import OptionsFactory
 from .objects_factory_fcidump import ObjectsFactoryFCIDUMP
+from .objects_factory_psi4 import ObjectsFactoryPsi4
 from .mock import HF, FCI, Ints, Ints2, Localizer

--- a/forte/modules/active_space_ints_factory.py
+++ b/forte/modules/active_space_ints_factory.py
@@ -1,0 +1,28 @@
+from typing import List
+from .module import Module
+from forte.data import ForteData
+
+
+class ActiveSpaceIntsFactory(Module):
+    """
+    A module to prepare an ActiveSpaceIntegral
+    """
+
+    def __init__(self, active: str, core: List[str]):
+        """
+        Parameters
+        ----------
+        active : str
+            The label of the space to be used for the active space
+        core : List[str]
+            A list of labels of the spaces to be used for the core space
+        """
+        super().__init__()
+        self.active = active
+        self.core = core
+
+    def _run(self, data: ForteData) -> ForteData:
+        import forte
+
+        data.as_ints = forte.make_active_space_ints(data.mo_space_info, data.ints, self.active, self.core)
+        return data

--- a/forte/modules/check_mo_orthogonality.py
+++ b/forte/modules/check_mo_orthogonality.py
@@ -1,0 +1,36 @@
+from psi4.core import Matrix, print_out
+
+
+def check_mo_orthonormality(S: Matrix, Ca: Matrix):
+    """
+    Return whether the MO overlap matrix is identity or not.
+    S_MO = Ca^T S_SO Ca.
+    The MO overlap is the identity if and only if the orbitals are orthonormal.
+    Most electronic structure methods are derived assuming orthonormal orbitals.
+
+    :param S: a Psi4 Matrix of overlap integrals in the SO basis
+    :param Ca: a Psi4 Matrix that holds orbital coefficients
+
+    :return: S_MO == I
+    """
+    p4print = print_out
+
+    p4print("\n  Checking orbital orthonormality against current geometry ...")
+
+    S = S.clone()
+    S.transform(Ca)  # S = Ca^T S Ca
+
+    # test orbital orthonormality
+    identity = S.clone()
+    identity.identity()
+    S.subtract(identity)
+    absmax = S.absmax()
+
+    if absmax > 1.0e-8:
+        p4print("\n\n  Forte Warning: ")
+        p4print("Input orbitals are NOT from the current geometry!")
+        p4print(f"\n  Max value of MO overlap: {absmax:.15f}\n")
+        return False
+    else:
+        p4print(" Done (OK)\n\n")
+        return True

--- a/forte/modules/graph_visualizer.py
+++ b/forte/modules/graph_visualizer.py
@@ -1,0 +1,33 @@
+from .module import Module
+
+
+class GraphVisualizer:
+    """
+    Handles the visualization of the computational graph.
+    """
+
+    def visualize(self, root_module: Module):
+        """
+        Creates a visual representation of the computational graph.
+        """
+        return self._make_graph(root_module)
+
+    def _make_graph(self, module: Module, level: int = 0, prefix=None, last=False):
+        graph = []
+        prefix = [] if prefix is None else prefix
+
+        if level == 0:
+            graph.append(repr(module))
+        else:
+            connector = "└──" if last else "├──"
+            graph.append("".join(prefix[: level - 1]) + f"{connector}{repr(module)}")
+
+        prefix.append("│  " if len(module.input_modules) > 1 else "   ")
+
+        for k, input_module in enumerate(module.input_modules):
+            is_last = k == len(module.input_modules) - 1
+            prefix[-1] = "   " if is_last else prefix[-1]
+            graph.append(self._make_graph(input_module, level + 1, prefix, is_last))
+
+        prefix.pop()
+        return "\n".join(graph)

--- a/forte/modules/mock.py
+++ b/forte/modules/mock.py
@@ -1,0 +1,58 @@
+from typing import List, Type, Union
+
+from .module import Module
+
+
+class Ints(Module):
+    def __init__(self, input_modules: Union["Module", List["Module"]] = None):
+        super().__init__(input_modules)
+
+    def _run(self, input_data):
+        data = input_data
+        for input_module in self.input_modules:
+            data = input_module.run(data)
+        print("Running Ints")
+
+
+class Ints2(Module):
+    def __init__(self, input_modules: Union["Module", List["Module"]] = None):
+        super().__init__(input_modules)
+
+    def _run(self, input_data):
+        data = input_data
+        for input_module in self.input_modules:
+            data = input_module.run(data)
+        print("Running Ints2")
+
+
+class HF(Module):
+    def __init__(self, input_modules: Union["Module", List["Module"]] = None):
+        super().__init__(input_modules)
+
+    def _run(self, input_data):
+        data = input_data
+        for input_module in self.input_modules:
+            data = input_module.run(data)
+        print("Running HF")
+
+
+class Localizer(Module):
+    def __init__(self, input_modules: Union["Module", List["Module"]] = None):
+        super().__init__(input_modules)
+
+    def _run(self, input_data):
+        data = input_data
+        for input_module in self.input_modules:
+            data = input_module.run(data)
+        print("Running Localizer")
+
+
+class FCI(Module):
+    def __init__(self, input_modules: Union["Module", List["Module"]] = None):
+        super().__init__(input_modules)
+
+    def _run(self, input_data):
+        data = input_data
+        for input_module in self.input_modules:
+            data = input_module.run(data)
+        print("Running FCI")

--- a/forte/modules/mock.py
+++ b/forte/modules/mock.py
@@ -7,52 +7,42 @@ class Ints(Module):
     def __init__(self, input_modules: Union["Module", List["Module"]] = None):
         super().__init__(input_modules)
 
-    def _run(self, input_data):
-        data = input_data
-        for input_module in self.input_modules:
-            data = input_module.run(data)
+    def _run(self, data: "ForteData") -> "ForteData":
         print("Running Ints")
+        return data
 
 
 class Ints2(Module):
     def __init__(self, input_modules: Union["Module", List["Module"]] = None):
         super().__init__(input_modules)
 
-    def _run(self, input_data):
-        data = input_data
-        for input_module in self.input_modules:
-            data = input_module.run(data)
+    def _run(self, data: "ForteData") -> "ForteData":
         print("Running Ints2")
+        return data
 
 
 class HF(Module):
     def __init__(self, input_modules: Union["Module", List["Module"]] = None):
         super().__init__(input_modules)
 
-    def _run(self, input_data):
-        data = input_data
-        for input_module in self.input_modules:
-            data = input_module.run(data)
+    def _run(self, data: "ForteData") -> "ForteData":
         print("Running HF")
+        return data
 
 
 class Localizer(Module):
     def __init__(self, input_modules: Union["Module", List["Module"]] = None):
         super().__init__(input_modules)
 
-    def _run(self, input_data):
-        data = input_data
-        for input_module in self.input_modules:
-            data = input_module.run(data)
+    def _run(self, data: "ForteData") -> "ForteData":
         print("Running Localizer")
+        return data
 
 
 class FCI(Module):
     def __init__(self, input_modules: Union["Module", List["Module"]] = None):
         super().__init__(input_modules)
 
-    def _run(self, input_data):
-        data = input_data
-        for input_module in self.input_modules:
-            data = input_module.run(data)
+    def _run(self, data: "ForteData") -> "ForteData":
         print("Running FCI")
+        return data

--- a/forte/modules/module.py
+++ b/forte/modules/module.py
@@ -1,0 +1,84 @@
+from abc import abstractmethod
+from typing import List, Type, Union
+
+from forte.data import ForteData
+from forte.core import flog, increase_log_depth
+
+
+class Module:
+    """
+    Represents a module in a computational graph.
+
+    A `Module` can store a list of input modules and the features needed and provided.
+    """
+
+    def __init__(self, input_modules: Union["Module", List["Module"]] = None, options=None):
+        """
+        Parameters
+        ----------
+        input_modules: Union[Module, List[Module]]
+            A single input module or a list of input modules. Defaults to None.
+        options: dict
+            A dictionary of options. Defaults to None.
+        """
+        if input_modules is None:
+            self._input_modules = []
+        elif isinstance(input_modules, Module):
+            self._input_modules = [input_modules]
+        else:
+            self._input_modules = input_modules
+        self._options = options
+
+    @property
+    def input_modules(self) -> List["Module"]:
+        return self._input_modules
+
+    @property
+    def options(self) -> dict:
+        return self._options
+
+    def _check_input(self):
+        """
+        Verify that this module can get all that it needs from its inputs.
+        """
+        for need in self.needs:
+            if not any(need in input_module.provides for input_module in self.input_modules):
+                missing_feature_error = (
+                    f"{self.__class__.__name__} needs {need}, " "which is not provided by input modules."
+                )
+                raise AssertionError(missing_feature_error)
+
+    # decorate to increase the log depth
+    @increase_log_depth
+    def run(self, data: ForteData = None) -> ForteData:
+        """
+        A general solver interface.
+
+        This method is common to all solvers, and in turn it is routed to
+        the method ``_run()`` implemented differently in each solver.
+
+        Return
+        ------
+            A data object
+        """
+        # log call to run()
+        flog("info", f"{type(self).__name__}: calling run()")
+
+        # call derived class implementation of _run()
+        data = self._run(data)
+
+        # log end of run()
+        flog("info", f"{type(self).__name__}: run() finished executing")
+
+        # set executed flag
+        self._executed = True
+
+        return data
+
+    @abstractmethod
+    def _run(self, data: ForteData = None) -> ForteData:
+        """The actual run function implemented by each method"""
+        NotImplementedError
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}"

--- a/forte/modules/module.py
+++ b/forte/modules/module.py
@@ -64,6 +64,9 @@ class Module:
         # log call to run()
         flog("info", f"{type(self).__name__}: calling run()")
 
+        for input_module in self.input_modules:
+            data = input_module.run(data)
+
         # call derived class implementation of _run()
         data = self._run(data)
 

--- a/forte/modules/objects_factory_fcidump.py
+++ b/forte/modules/objects_factory_fcidump.py
@@ -164,6 +164,7 @@ class ObjectsFactoryFCIDUMP(Module):
             A dictionary of options. Defaults to None, in which case the options are read from psi4.
         """
         super().__init__(options=options)
+        psi4.core.print_out("\n  Forte will use custom integrals")
 
     def _run(self, data: ForteData = None) -> ForteData:
         if "FIRST" in data.options.get_str("DERTYPE"):

--- a/forte/modules/objects_factory_fcidump.py
+++ b/forte/modules/objects_factory_fcidump.py
@@ -1,0 +1,178 @@
+import pathlib
+
+import numpy as np
+import psi4
+import forte
+
+from forte.data import ForteData
+from .module import Module
+
+from forte.register_forte_options import register_forte_options
+
+
+def _make_ints_from_fcidump(fcidump, data: ForteData):
+    # transform two-electron integrals from chemist to physicist notation
+    eri = fcidump["eri"]
+    nmo = fcidump["norb"]
+    eri_aa = np.zeros((nmo, nmo, nmo, nmo))
+    eri_ab = np.zeros((nmo, nmo, nmo, nmo))
+    eri_bb = np.zeros((nmo, nmo, nmo, nmo))
+    # <ij||kl> = (ik|jl) - (il|jk)
+    eri_aa += np.einsum("ikjl->ijkl", eri)
+    eri_aa -= np.einsum("iljk->ijkl", eri)
+    # <ij|kl> = (ik|jl)
+    eri_ab = np.einsum("ikjl->ijkl", eri)
+    # <ij||kl> = (ik|jl) - (il|jk)
+    eri_bb += np.einsum("ikjl->ijkl", eri)
+    eri_bb -= np.einsum("iljk->ijkl", eri)
+
+    ints = forte.make_custom_ints(
+        data.options,
+        data.mo_space_info,
+        fcidump["enuc"],
+        fcidump["hcore"].flatten(),
+        fcidump["hcore"].flatten(),
+        eri_aa.flatten(),
+        eri_ab.flatten(),
+        eri_bb.flatten(),
+    )
+    data.ints = ints
+    return data
+
+
+def _make_state_info_from_fcidump(fcidump, options):
+    nel = fcidump["nelec"]
+    if not options.is_none("NEL"):
+        nel = options.get_int("NEL")
+
+    multiplicity = fcidump["ms2"] + 1
+    if not options.is_none("MULTIPLICITY"):
+        multiplicity = options.get_int("MULTIPLICITY")
+
+    # If the user did not specify ms determine the value from the input or
+    # take the lowest value consistent with the value of "MULTIPLICITY"
+    # For example:
+    #    singlet: multiplicity = 1 -> twice_ms = 0 (ms = 0)
+    #    doublet: multiplicity = 2 -> twice_ms = 1 (ms = 1/2)
+    #    triplet: multiplicity = 3 -> twice_ms = 0 (ms = 0)
+    twice_ms = (multiplicity + 1) % 2
+    if not options.is_none("MS"):
+        twice_ms = int(round(2.0 * options.get_double("MS")))
+
+    if ((nel - twice_ms) % 2) != 0:
+        raise Exception(f"Forte: the value of MS ({twice_ms}/2) is incompatible with the number of electrons ({nel})")
+
+    na = (nel + twice_ms) // 2
+    nb = nel - na
+
+    irrep = fcidump["isym"]
+    if not options.is_none("ROOT_SYM"):
+        irrep = options.get_int("ROOT_SYM")
+
+    return forte.StateInfo(na, nb, multiplicity, twice_ms, irrep)
+
+
+def _prepare_forte_objects_from_fcidump(data, path="."):
+    options = data.options
+    fcidump_file = data.options.get_str("FCIDUMP_FILE")
+    filename = pathlib.Path(path) / fcidump_file
+    psi4.core.print_out(f"\n  Reading integral information from FCIDUMP file {filename}")
+    fcidump = forte.proc.fcidump_from_file(filename, convert_to_psi4=True)
+
+    irrep_size = {"c1": 1, "ci": 2, "c2": 2, "cs": 2, "d2": 4, "c2v": 4, "c2h": 4, "d2h": 8}
+
+    nmo = len(fcidump["orbsym"])
+    if "pntgrp" in fcidump:
+        nirrep = irrep_size[fcidump["pntgrp"].lower()]
+        nmopi_list = [fcidump["orbsym"].count(h) for h in range(nirrep)]
+    else:
+        fcidump["pntgrp"] = "C1"  # set the point group to C1
+        fcidump["isym"] = 0  # shift by -1
+        nirrep = 1
+        nmopi_list = [nmo]
+
+    nmopi_offset = [sum(nmopi_list[0:h]) for h in range(nirrep)]
+
+    nmopi = psi4.core.Dimension(nmopi_list)
+
+    # Create the MOSpaceInfo object
+    data.mo_space_info = forte.make_mo_space_info(nmopi, fcidump["pntgrp"], options)
+
+    # manufacture a SCFInfo object from the FCIDUMP file (this assumes C1 symmetry)
+    nel = fcidump["nelec"]
+    ms2 = fcidump["ms2"]
+    na = (nel + ms2) // 2
+    nb = nel - na
+    if fcidump["pntgrp"] == "C1":
+        doccpi = psi4.core.Dimension([nb])
+        soccpi = psi4.core.Dimension([ms2])
+    else:
+        doccpi = options.get_int_list("FCIDUMP_DOCC")
+        soccpi = options.get_int_list("FCIDUMP_SOCC")
+        if len(doccpi) + len(soccpi) == 0:
+            print("Reading a FCIDUMP file that uses symmetry but no DOCC and SOCC is specified.")
+            print("Use the FCIDUMP_DOCC and FCIDUMP_SOCC options to specify the number of occupied orbitals per irrep.")
+            doccpi = psi4.core.Dimension([0] * nirrep)
+            soccpi = psi4.core.Dimension([0] * nirrep)
+
+    if "epsilon" in fcidump:
+        epsilon_a = psi4.core.Vector.from_array(fcidump["epsilon"])
+        epsilon_b = psi4.core.Vector.from_array(fcidump["epsilon"])
+    else:
+        # manufacture Fock matrices
+        epsilon_a = psi4.core.Vector(nmo)
+        epsilon_b = psi4.core.Vector(nmo)
+        hcore = fcidump["hcore"]
+        eri = fcidump["eri"]
+        nmo = fcidump["norb"]
+        for i in range(nmo):
+            val = hcore[i, i]
+            for h in range(nirrep):
+                for j in range(nmopi_offset[h], nmopi_offset[h] + doccpi[h] + soccpi[h]):
+                    val += eri[i, i, j, j] - eri[i, j, i, j]
+                for j in range(nmopi_offset[h], nmopi_offset[h] + doccpi[h]):
+                    val += eri[i, i, j, j]
+            epsilon_a.set(i, val)
+
+            val = hcore[i, i]
+            for h in range(nirrep):
+                for j in range(nmopi_offset[h], nmopi_offset[h] + doccpi[h] + soccpi[h]):
+                    val += eri[i, i, j, j]
+                for j in range(nmopi_offset[h], nmopi_offset[h] + doccpi[h]):
+                    val += eri[i, i, j, j] - eri[i, j, i, j]
+            epsilon_b.set(i, val)
+
+    data.scf_info = forte.SCFInfo(nmopi, doccpi, soccpi, 0.0, epsilon_a, epsilon_b)
+
+    state_info = _make_state_info_from_fcidump(fcidump, options)
+    data.state_weights_map = {state_info: [1.0]}
+    data.psi_wfn = None
+
+    return data, fcidump
+
+
+class ObjectsFactoryFCIDUMP(Module):
+    """
+    A module to prepare the ForteIntegrals, SCFInfo, and MOSpaceInfo objects from a Psi4 Wavefunction object
+    """
+
+    def __init__(self, options: dict = None):
+        """
+        Parameters
+        ----------
+        options: dict
+            A dictionary of options. Defaults to None, in which case the options are read from psi4.
+        """
+        super().__init__(options=options)
+
+    def _run(self, data: ForteData = None) -> ForteData:
+        if "FIRST" in data.options.get_str("DERTYPE"):
+            raise Exception("Energy gradients NOT available for custom integrals!")
+
+        psi4.core.print_out("\n  Preparing forte objects from a custom source\n")
+        data, fcidump = _prepare_forte_objects_from_fcidump(data)
+        # state_weights_map, mo_space_info, scf_info, fcidump = forte_objects
+
+        # Make an integral object from the psi4 wavefunction object
+        data = _make_ints_from_fcidump(fcidump, data)
+        return data

--- a/forte/modules/objects_factory_fcidump.py
+++ b/forte/modules/objects_factory_fcidump.py
@@ -153,7 +153,7 @@ def _prepare_forte_objects_from_fcidump(data, path="."):
 
 class ObjectsFactoryFCIDUMP(Module):
     """
-    A module to prepare the ForteIntegrals, SCFInfo, and MOSpaceInfo objects from a Psi4 Wavefunction object
+    A module to prepare the ForteIntegrals, SCFInfo, and MOSpaceInfo objects from a FCIDUMP file
     """
 
     def __init__(self, options: dict = None):

--- a/forte/modules/objects_factory_psi4.py
+++ b/forte/modules/objects_factory_psi4.py
@@ -1,0 +1,261 @@
+import pathlib
+import warnings
+
+
+import numpy as np
+import psi4
+import psi4.driver.p4util as p4util
+
+import forte
+
+from forte.data import ForteData
+from .module import Module
+
+from forte.register_forte_options import register_forte_options
+from forte.proc.orbital_helpers import orbital_projection
+
+
+def run_psi4_ref(ref_type, molecule, print_warning=False, **kwargs):
+    """
+    Perform a new Psi4 computation and return a Psi4 Wavefunction object.
+
+    :param ref_type: a Python string for reference type
+    :param molecule: a Psi4 Molecule object on which computation is performed
+    :param print_warning: Boolean for printing warnings on screen
+    :param kwargs: named arguments associated with Psi4
+
+    :return: a Psi4 Wavefunction object from the fresh Psi4 run
+    """
+    ref_type = ref_type.lower().strip()
+
+    if ref_type in ["scf", "hf", "rhf", "rohf", "uhf"]:
+        if print_warning:
+            msg = [
+                "Forte is using orbitals from a Psi4 SCF reference.",
+                "This is not the best for multireference computations.",
+                "To use Psi4 CASSCF orbitals, set REF_TYPE to CASSCF.",
+            ]
+            msg = "\n  ".join(msg)
+            warnings.warn(f"\n  {msg}\n", UserWarning)
+
+        wfn = psi4.driver.scf_helper("forte", molecule=molecule, **kwargs)
+    elif ref_type in ["casscf", "rasscf"]:
+        wfn = psi4.proc.run_detcas(ref_type, molecule=molecule, **kwargs)
+    else:
+        raise ValueError(f"Invalid REF_TYPE: {ref_type.upper()} not available!")
+
+    return wfn
+
+
+def prepare_psi4_ref_wfn(options, **kwargs):
+    """
+    Prepare a Psi4 Wavefunction as reference for Forte.
+    :param options: a ForteOptions object for options
+    :param kwargs: named arguments associated with Psi4
+    :return: (the processed Psi4 Wavefunction, a Forte MOSpaceInfo object)
+
+    Notes:
+        We will create a new Psi4 Wavefunction (wfn_new) if necessary.
+
+        1. For an empty ref_wfn, wfn_new will come from Psi4 SCF or MCSCF.
+
+        2. For a valid ref_wfn, we will test the orbital orthonormality against molecule.
+           If the orbitals from ref_wfn are consistent with the active geometry,
+           wfn_new will simply be a link to ref_wfn.
+           If not, we will rerun a Psi4 SCF and orthogonalize orbitals, where
+           wfn_new comes from this new Psi4 SCF computation.
+    """
+    p4print = psi4.core.print_out
+
+    # grab reference Wavefunction and Molecule from kwargs
+    kwargs = p4util.kwargs_lower(kwargs)
+
+    ref_wfn = kwargs.get("ref_wfn", None)
+
+    molecule = kwargs.pop("molecule", psi4.core.get_active_molecule())
+    point_group = molecule.point_group().symbol()
+
+    # try to read orbitals from file
+    Ca = read_orbitals() if options.get_bool("READ_ORBITALS") else None
+
+    need_orbital_check = True
+    fresh_ref_wfn = True if ref_wfn is None else False
+
+    if ref_wfn is None:
+        ref_type = options.get_str("REF_TYPE")
+        p4print("\n  No reference wave function provided for Forte." f" Computing {ref_type} orbitals using Psi4 ...\n")
+
+        # no warning printing for MCSCF
+        job_type = options.get_str("JOB_TYPE")
+        do_mcscf = job_type in ["CASSCF", "MCSCF_TWO_STEP"] or options.get_bool("CASSCF_REFERENCE")
+
+        # run Psi4 SCF or MCSCF
+        ref_wfn = run_psi4_ref(ref_type, molecule, not do_mcscf, **kwargs)
+
+        need_orbital_check = False if Ca is None else True
+    else:
+        # Ca from file has higher priority than that of ref_wfn
+        Ca = ref_wfn.Ca().clone() if Ca is None else Ca
+
+    # build Forte MOSpaceInfo
+    nmopi = ref_wfn.nmopi()
+    mo_space_info = forte.make_mo_space_info(nmopi, point_group, options)
+
+    # do we need to check MO overlap?
+    if not need_orbital_check:
+        wfn_new = ref_wfn
+    else:
+        # test if input Ca has the correct dimension
+        if Ca.rowdim() != ref_wfn.nsopi() or Ca.coldim() != nmopi:
+            p4print("\n  Expecting orbital dimensions:\n")
+            p4print("\n  row:    ")
+            ref_wfn.nsopi().print_out()
+            p4print("  column: ")
+            nmopi.print_out()
+            p4print("\n  Actual orbital dimensions:\n")
+            p4print("\n  row:    ")
+            Ca.rowdim().print_out()
+            p4print("  column: ")
+            Ca.coldim().print_out()
+            msg = "Invalid orbitals: different basis set / molecule! Check output for more."
+            raise ValueError(msg)
+
+        new_S = psi4.core.Wavefunction.build(molecule, options.get_str("BASIS")).S()
+
+        if check_MO_orthonormality(new_S, Ca):
+            wfn_new = ref_wfn
+            wfn_new.Ca().copy(Ca)
+        else:
+            if fresh_ref_wfn:
+                wfn_new = ref_wfn
+                wfn_new.Ca().copy(ortho_orbs_forte(wfn_new, mo_space_info, Ca))
+            else:
+                p4print("\n  Perform new SCF at current geometry ...\n")
+
+                kwargs_copy = {k: v for k, v in kwargs.items() if k != "ref_wfn"}
+                wfn_new = run_psi4_ref("scf", molecule, False, **kwargs_copy)
+
+                # orthonormalize orbitals
+                wfn_new.Ca().copy(ortho_orbs_forte(wfn_new, mo_space_info, Ca))
+
+                # copy wfn_new to ref_wfn
+                ref_wfn.shallow_copy(wfn_new)
+
+    # set DF and MINAO basis
+    if "DF" in options.get_str("INT_TYPE"):
+        aux_basis = psi4.core.BasisSet.build(
+            molecule,
+            "DF_BASIS_MP2",
+            options.get_str("DF_BASIS_MP2"),
+            "RIFIT",
+            options.get_str("BASIS"),
+            puream=wfn_new.basisset().has_puream(),
+        )
+        wfn_new.set_basisset("DF_BASIS_MP2", aux_basis)
+
+    if options.get_str("MINAO_BASIS"):
+        minao_basis = psi4.core.BasisSet.build(molecule, "MINAO_BASIS", options.get_str("MINAO_BASIS"))
+        wfn_new.set_basisset("MINAO_BASIS", minao_basis)
+
+    return wfn_new, mo_space_info
+
+
+def prepare_forte_objects_from_psi4_wfn(options, wfn, mo_space_info):
+    """
+    Take a psi4 wavefunction object and prepare the ForteIntegrals, SCFInfo, and MOSpaceInfo objects
+
+    Parameters
+    ----------
+    options : ForteOptions
+        A Forte ForteOptions object
+    wfn : psi4 Wavefunction
+        A psi4 Wavefunction object
+    mo_space_info : the MO space info read from options
+        A Forte MOSpaceInfo object
+
+    Returns
+    -------
+    tuple(ForteIntegrals, SCFInfo, MOSpaceInfo)
+        a tuple containing the ForteIntegrals, SCFInfo, and MOSpaceInfo objects
+    """
+
+    # Call methods that project the orbitals (AVAS, embedding)
+    mo_space_info = orbital_projection(wfn, options, mo_space_info)
+
+    # Build Forte SCFInfo object
+    scf_info = forte.SCFInfo(wfn)
+
+    # Build a map from Forte StateInfo to the weights
+    state_weights_map = forte.make_state_weights_map(options, mo_space_info)
+
+    return (state_weights_map, mo_space_info, scf_info)
+
+
+def prepare_forte_objects(data, kwargs):
+    """
+    Prepare the ForteIntegrals, SCFInfo, and MOSpaceInfo objects.
+    :param data: the ForteOptions object
+    :param name: the name of the module associated with Psi4
+    :param kwargs: named arguments associated with Psi4
+    :return: a tuple of (Wavefunction, ForteIntegrals, SCFInfo, MOSpaceInfo, FCIDUMP)
+    """
+    lowername = "forte"
+    options = data.options
+
+    psi4.core.print_out("\n\n  Preparing forte objects from a Psi4 Wavefunction object")
+    kwargs = {}
+    ref_wfn, mo_space_info = prepare_psi4_ref_wfn(options, **kwargs)
+    forte_objects = prepare_forte_objects_from_psi4_wfn(options, ref_wfn, mo_space_info)
+    state_weights_map, mo_space_info, scf_info = forte_objects
+    fcidump = None
+
+    data.mo_space_info = mo_space_info
+    data.scf_info = scf_info
+    data.state_weights_map = state_weights_map
+    data.psi_wfn = ref_wfn
+
+    return data, fcidump
+
+
+class ObjectsFactoryPsi4(Module):
+    """
+    A module to prepare the ForteIntegrals, SCFInfo, and MOSpaceInfo objects from a Psi4 Wavefunction object
+    """
+
+    def __init__(self, options: dict = None):
+        """
+        Parameters
+        ----------
+        options: dict
+            A dictionary of options. Defaults to None, in which case the options are read from psi4.
+        """
+        super().__init__(options=options)
+
+    def _run(self, data: ForteData = None) -> ForteData:
+        name = "forte"
+        kwargs = {}
+        data, fcidump = prepare_forte_objects(data, name, **kwargs)
+
+        job_type = data.options.get_str("JOB_TYPE")
+        if job_type == "NONE" and data.options.get_str("ORBITAL_TYPE") == "CANONICAL":
+            psi4.core.set_scalar_variable("CURRENT ENERGY", 0.0)
+            return data.psi_wfn
+
+        # these two functions are used by the external solver to read and write MO coefficients
+        if data.options.get_bool("WRITE_WFN"):
+            write_wavefunction(data)
+
+        if data.options.get_bool("READ_WFN"):
+            if not os.path.isfile("coeff.json"):
+                print("No coefficient files in input folder, run a SCF first!")
+                exit()
+            read_wavefunction(data)
+
+        if "FCIDUMP" in data.options.get_str("INT_TYPE"):
+            pass
+        else:
+            psi4.core.print_out("\n  Forte will use psi4 integrals")
+            # Make an integral object from the psi4 wavefunction object
+            data.ints = forte.make_ints_from_psi4(data.psi_wfn, data.options, data.mo_space_info)
+
+        return data

--- a/forte/modules/objects_factory_psi4.py
+++ b/forte/modules/objects_factory_psi4.py
@@ -15,6 +15,7 @@ from .module import Module
 
 from forte.register_forte_options import register_forte_options
 from forte.proc.orbital_helpers import orbital_projection
+from forte.proc.orbital_helpers import read_orbitals, dump_orbitals, ortho_orbs_forte
 
 
 def run_psi4_ref(ref_type, molecule, print_warning=False, **kwargs):

--- a/forte/modules/objects_factory_psi4.py
+++ b/forte/modules/objects_factory_psi4.py
@@ -108,9 +108,12 @@ def prepare_psi4_ref_wfn(options, **kwargs):
         # Ca from file has higher priority than that of ref_wfn
         Ca = ref_wfn.Ca().clone() if Ca is None else Ca
 
-    # build Forte MOSpaceInfo
+    # create a MOSpaceInfo object
     nmopi = ref_wfn.nmopi()
-    mo_space_info = forte.make_mo_space_info(nmopi, point_group, options)
+    if kwargs.get("mo_spaces") is None:
+        mo_space_info = forte.make_mo_space_info(nmopi, point_group, options)
+    else:
+        mo_space_info = forte.make_mo_space_info_from_map(nmopi, point_group, kwargs.get("mo_spaces"), [])
 
     # do we need to check MO overlap?
     if not need_orbital_check:

--- a/forte/modules/objects_factory_psi4.py
+++ b/forte/modules/objects_factory_psi4.py
@@ -1,5 +1,6 @@
 import pathlib
 import warnings
+import os
 
 
 import numpy as np
@@ -16,6 +17,13 @@ from .module import Module
 from forte.register_forte_options import register_forte_options
 from forte.proc.orbital_helpers import orbital_projection
 from forte.proc.orbital_helpers import read_orbitals, dump_orbitals, ortho_orbs_forte
+from forte.proc.external_active_space_solver import (
+    write_external_active_space_file,
+    write_external_rdm_file,
+    write_wavefunction,
+    read_wavefunction,
+    make_hamiltonian,
+)
 
 
 def run_psi4_ref(ref_type, molecule, print_warning=False, **kwargs):
@@ -241,7 +249,7 @@ class ObjectsFactoryPsi4(Module):
         job_type = data.options.get_str("JOB_TYPE")
         if job_type == "NONE" and data.options.get_str("ORBITAL_TYPE") == "CANONICAL":
             psi4.core.set_scalar_variable("CURRENT ENERGY", 0.0)
-            return data.psi_wfn
+            return data
 
         # these two functions are used by the external solver to read and write MO coefficients
         if data.options.get_bool("WRITE_WFN"):

--- a/forte/modules/objects_util_psi4.py
+++ b/forte/modules/objects_util_psi4.py
@@ -1,0 +1,31 @@
+from forte.data import ForteData
+from .module import Module
+from .sequential import Sequential
+from .options_factory import OptionsFactory
+from .objects_factory_psi4 import ObjectsFactoryPsi4
+from .active_space_ints_factory import ActiveSpaceIntsFactory
+
+
+class ObjectsUtilPsi4(Module):
+    """
+    A utility module to prepare options through active space integrals from a Psi4 Wavefunction object
+    """
+
+    def __init__(self, active="ACTIVE", core=["RESTRICTED_DOCC"], options: dict = None, **kwargs):
+        """
+        Parameters
+        ----------
+        options: dict
+            A dictionary of options. Defaults to None, in which case the options are read from psi4.
+        """
+        super().__init__(options=options)
+        self.seq = Sequential(
+            [
+                OptionsFactory(options=options),
+                ObjectsFactoryPsi4(options=options, **kwargs),
+                ActiveSpaceIntsFactory(active, core),
+            ]
+        )
+
+    def _run(self, data: ForteData = None) -> ForteData:
+        return self.seq.run(data)

--- a/forte/modules/options_factory.py
+++ b/forte/modules/options_factory.py
@@ -1,0 +1,61 @@
+import psi4
+import forte
+
+from forte.data import ForteData
+from .module import Module
+
+from forte.register_forte_options import register_forte_options
+
+
+class OptionsFactory(Module):
+    """
+    A module to generate the ForteOptions object
+    """
+
+    def __init__(self, options: dict = None):
+        """
+        Parameters
+        ----------
+        options: dict
+            A dictionary of options. Defaults to None, in which case the options are read from psi4.
+        """
+        super().__init__(options=options)
+
+    def _run(self, data: ForteData = None) -> ForteData:
+        if data is None:
+            data = ForteData()
+        data.options = forte.forte_options
+        # if no options dict is provided then read from psi4
+        if self.options is None:
+            # Get the option object
+            psi4_options = psi4.core.get_options()
+            psi4_options.set_current_module("FORTE")
+
+            # Get the forte option object
+            data.options.get_options_from_psi4(psi4_options)
+        else:
+            psi4.core.print_out(
+                f"\n  Forte will use options passed as a dictionary. Option read from psi4 will be ignored\n"
+            )
+            data.options = forte.ForteOptions()
+            register_forte_options(data.options)
+            data.options.set_from_dict(self.options)
+
+        return data
+
+    # def run(self, data: ForteData = None) -> ForteData:
+    #     """
+    #     A general solver interface.
+
+    #     This method is common to all solvers, and in turn it is routed to
+    #     the method ``_run()`` implemented differently in each solver.
+
+    #     Return
+    #     ------
+    #         A data object
+    #     """
+
+    #     # Run the module
+    #     data = self._run(data)
+
+    #     return data

--- a/forte/modules/options_factory.py
+++ b/forte/modules/options_factory.py
@@ -42,20 +42,3 @@ class OptionsFactory(Module):
             data.options.set_from_dict(self.options)
 
         return data
-
-    # def run(self, data: ForteData = None) -> ForteData:
-    #     """
-    #     A general solver interface.
-
-    #     This method is common to all solvers, and in turn it is routed to
-    #     the method ``_run()`` implemented differently in each solver.
-
-    #     Return
-    #     ------
-    #         A data object
-    #     """
-
-    #     # Run the module
-    #     data = self._run(data)
-
-    #     return data

--- a/forte/modules/sequential.py
+++ b/forte/modules/sequential.py
@@ -30,8 +30,6 @@ class Sequential(Module):
 
     def _run(self, input_data):
         data = input_data
-        for input_module in self.input_modules:
-            data = input_module.run(data)
         for module in self.modules:
             data = module.run(data)
         return data

--- a/forte/modules/sequential.py
+++ b/forte/modules/sequential.py
@@ -1,0 +1,40 @@
+from typing import List, Type, Union
+
+from .module import Module
+
+
+class Sequential(Module):
+    def __init__(
+        self, modules: List[Type[Module]] = None, input_modules: Union["Module", List["Module"]] = None, options=None
+    ):
+        """
+        Parameters
+        ----------
+        modules: List[Type[Module]]
+            A list of modules. Defaults to None.
+        options: dict
+            A dictionary of options. Defaults to None.
+        input_modules: Union[Module, List[Module]]
+            A single input module or a list of input modules. Defaults to None.
+        """
+        super().__init__(input_modules, options)
+        self.modules = modules or []
+
+    def add(self, module: Module):
+        """
+        Add a module to the sequential module.
+        """
+        if self.modules:
+            module._input_modules = [self.modules[-1]]
+        self.modules.append(module)
+
+    def _run(self, input_data):
+        data = input_data
+        for input_module in self.input_modules:
+            data = input_module.run(data)
+        for module in self.modules:
+            data = module.run(data)
+        return data
+
+    def __repr__(self):
+        return f"Sequential({self.modules})"

--- a/forte/proc/external_active_space_solver.py
+++ b/forte/proc/external_active_space_solver.py
@@ -15,7 +15,7 @@ class NumpyEncoder(json.JSONEncoder):
 
 
 def write_wavefunction(data):
-    Ca = data.ref_wfn.Ca().to_array()
+    Ca = data.psi_wfn.Ca().to_array()
 
     with open("coeff.json", "w+") as f:
         json.dump({"Ca": Ca}, f, cls=NumpyEncoder)
@@ -33,12 +33,12 @@ def read_wavefunction(data):
         else:
             C_list.append(np.asarray(C_read[i]))
 
-    if data.ref_wfn.nirrep() != 1:
+    if data.psi_wfn.nirrep() != 1:
         C_mat = psi4.core.Matrix.from_array(C_list)
     else:  # C1 no spatial symmetry, input is list(np.ndarray)
         C_mat = psi4.core.Matrix.from_array([np.asarray(C_list)])
-    data.ref_wfn.Ca().copy(C_mat)
-    data.ref_wfn.Cb().copy(C_mat)
+    data.psi_wfn.Ca().copy(C_mat)
+    data.psi_wfn.Cb().copy(C_mat)
 
 
 def write_external_active_space_file(as_ints, state_map, mo_space_info, json_file="forte_ints.json"):

--- a/forte/proc/external_active_space_solver.py
+++ b/forte/proc/external_active_space_solver.py
@@ -14,17 +14,17 @@ class NumpyEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-def write_wavefunction(ref_wfn):
-    Ca = ref_wfn.Ca().to_array()
+def write_wavefunction(data):
+    Ca = data.ref_wfn.Ca().to_array()
 
-    with open('coeff.json', 'w+') as f:
-        json.dump({'Ca': Ca}, f, cls=NumpyEncoder)
+    with open("coeff.json", "w+") as f:
+        json.dump({"Ca": Ca}, f, cls=NumpyEncoder)
 
 
-def read_wavefunction(ref_wfn):
-    with open('coeff.json') as f:
-        data = json.load(f)
-        C_read = data["Ca"]
+def read_wavefunction(data):
+    with open("coeff.json") as f:
+        coeff_data = json.load(f)
+        C_read = coeff_data["Ca"]
 
     C_list = []
     for i in range(len(C_read)):
@@ -33,12 +33,12 @@ def read_wavefunction(ref_wfn):
         else:
             C_list.append(np.asarray(C_read[i]))
 
-    if ref_wfn.nirrep() != 1:
+    if data.ref_wfn.nirrep() != 1:
         C_mat = psi4.core.Matrix.from_array(C_list)
     else:  # C1 no spatial symmetry, input is list(np.ndarray)
         C_mat = psi4.core.Matrix.from_array([np.asarray(C_list)])
-    ref_wfn.Ca().copy(C_mat)
-    ref_wfn.Cb().copy(C_mat)
+    data.ref_wfn.Ca().copy(C_mat)
+    data.ref_wfn.Cb().copy(C_mat)
 
 
 def write_external_active_space_file(as_ints, state_map, mo_space_info, json_file="forte_ints.json"):
@@ -49,34 +49,34 @@ def write_external_active_space_file(as_ints, state_map, mo_space_info, json_fil
 
         nmo = as_ints.nmo()
 
-        file['state_symmetry'] = {"data": state.irrep(), "description": "Symmetry of the state"}
+        file["state_symmetry"] = {"data": state.irrep(), "description": "Symmetry of the state"}
 
-        file['na'] = {"data": state.na() - ndocc, "description": "number of alpha electrons in the active space"}
+        file["na"] = {"data": state.na() - ndocc, "description": "number of alpha electrons in the active space"}
 
-        file['nb'] = {"data": state.nb() - ndocc, "description": "number of beta electrons in the active space"}
+        file["nb"] = {"data": state.nb() - ndocc, "description": "number of beta electrons in the active space"}
 
-        file['nso'] = {"data": 2 * nmo, "description": "number of active spin orbitals"}
+        file["nso"] = {"data": 2 * nmo, "description": "number of active spin orbitals"}
 
-        file['symmetry'] = {
+        file["symmetry"] = {
             "data": [i for i in as_ints.mo_symmetry() for j in range(2)],
-            "description": "symmetry of each spin orbital (Cotton ordering)"
+            "description": "symmetry of each spin orbital (Cotton ordering)",
         }
 
-        file['spin'] = {
+        file["spin"] = {
             "data": [j for i in range(nmo) for j in range(2)],
-            "description": "spin of each spin orbital (0 = alpha, 1 = beta)"
+            "description": "spin of each spin orbital (0 = alpha, 1 = beta)",
         }
 
         scalar_energy = as_ints.frozen_core_energy() + as_ints.scalar_energy() + as_ints.nuclear_repulsion_energy()
-        file['scalar_energy'] = {
+        file["scalar_energy"] = {
             "data": scalar_energy,
-            "description": "scalar energy (sum of nuclear repulsion, frozen core, and scalar contributions"
+            "description": "scalar energy (sum of nuclear repulsion, frozen core, and scalar contributions",
         }
 
         oei_a = [(i * 2, j * 2, as_ints.oei_a(i, j)) for i in range(nmo) for j in range(nmo)]
         oei_b = [(i * 2 + 1, j * 2 + 1, as_ints.oei_b(i, j)) for i in range(nmo) for j in range(nmo)]
 
-        file['oei'] = {"data": oei_a + oei_b, "description": "one-electron integrals as a list of tuples (i,j,<i|h|j>)"}
+        file["oei"] = {"data": oei_a + oei_b, "description": "one-electron integrals as a list of tuples (i,j,<i|h|j>)"}
 
         tei = []
         for i in range(nmo):
@@ -90,12 +90,12 @@ def write_external_active_space_file(as_ints, state_map, mo_space_info, json_fil
                         tei.append((j * 2 + 1, i * 2, l * 2 + 1, k * 2, +as_ints.tei_ab(i, j, k, l)))  # baba
                         tei.append((i * 2 + 1, j * 2 + 1, k * 2 + 1, l * 2 + 1, as_ints.tei_bb(i, j, k, l)))  # bbbb
 
-        file['tei'] = {
+        file["tei"] = {
             "data": tei,
-            "description": "antisymmetrized two-electron integrals as a list of tuples (i,j,k,l,<ij||kl>)"
+            "description": "antisymmetrized two-electron integrals as a list of tuples (i,j,k,l,<ij||kl>)",
         }
 
-        with open(json_file, 'w+') as f:
+        with open(json_file, "w+") as f:
             json.dump(file, f, sort_keys=True, indent=2)
 
         # make_hamiltonian(as_ints,state)
@@ -105,7 +105,7 @@ def make_hamiltonian(as_ints, state_map):
     import itertools
 
     for state, nroots in state_map.items():
-        print(f'\nstate: {state}, nroots: {nroots}')
+        print(f"\nstate: {state}, nroots: {nroots}")
         dets = []
 
         na = state.na()
@@ -124,25 +124,25 @@ def make_hamiltonian(as_ints, state_map):
                     d.set_beta_bit(i, True)
                 dets.append(d)
 
-        print(f'\n\n==> List of FCI determinants <==')
+        print(f"\n\n==> List of FCI determinants <==")
         for d in dets:
-            print(f'{d.str(4)}')
+            print(f"{d.str(4)}")
 
-        scalar_e = as_ints.scalar_energy() + as_ints.nuclear_repulsion_energy() + \
-                   as_ints.frozen_core_energy()
-        print(f'scalar_e = {scalar_e}')
+        scalar_e = as_ints.scalar_energy() + as_ints.nuclear_repulsion_energy() + as_ints.frozen_core_energy()
+        print(f"scalar_e = {scalar_e}")
 
         import numpy as np
+
         ndets = len(dets)
         H = np.ndarray((ndets, ndets))
         for I, detI in enumerate(dets):
             for J, detJ in enumerate(dets):
-                H[I][J] = as_ints.slater_rules(detI,detJ)
+                H[I][J] = as_ints.slater_rules(detI, detJ)
                 # if I == J:
                 #     H[I][J] += scalar_e
-                          
-        print(f'\n==> Active Space Hamiltonian <==\n')
-        print(f'\n{H}')
+
+        print(f"\n==> Active Space Hamiltonian <==\n")
+        print(f"\n{H}")
 
 
 def write_external_rdm_file(active_space_solver, state_weights_map, max_rdm_level):
@@ -162,15 +162,15 @@ def write_external_rdm_file(active_space_solver, state_weights_map, max_rdm_leve
 
     file = {}
 
-    file['nso'] = {"data": 2 * nact, "description": "number of active spin orbitals"}
+    file["nso"] = {"data": 2 * nact, "description": "number of active spin orbitals"}
 
     state_energies_map = active_space_solver.state_energies_map()
     for state, energies in state_energies_map.items():
-        file['energy'] = {"data": energies[0], "description": "energy"}
+        file["energy"] = {"data": energies[0], "description": "energy"}
 
-    file['gamma1'] = {
+    file["gamma1"] = {
         "data": gamma1_a + gamma1_b,
-        "description": "one-body density matrix as a list of tuples (i,j,<i^ j>)"
+        "description": "one-body density matrix as a list of tuples (i,j,<i^ j>)",
     }
 
     gamma2 = []
@@ -185,9 +185,9 @@ def write_external_rdm_file(active_space_solver, state_weights_map, max_rdm_leve
                     gamma2.append((j * 2 + 1, i * 2, l * 2 + 1, k * 2, +g2ab[i, j, k, l]))  # baba
                     gamma2.append((i * 2 + 1, j * 2 + 1, k * 2 + 1, l * 2 + 1, g2bb[i, j, k, l]))  # bbbb
 
-    file['gamma2'] = {
+    file["gamma2"] = {
         "data": gamma2,
-        "description": "two-body density matrix as a list of tuples (i,j,k,l,<i^ j^ l k>)"
+        "description": "two-body density matrix as a list of tuples (i,j,k,l,<i^ j^ l k>)",
     }
 
     if max_rdm_level == 3:
@@ -241,39 +241,27 @@ def write_external_rdm_file(active_space_solver, state_weights_map, max_rdm_leve
                                     (i * 2, j * 2 + 1, k * 2 + 1, l * 2, m * 2 + 1, n * 2 + 1, g3abb[i, j, k, l, m, n])
                                 )
                                 gamma3.append(
-                                    (
-                                        i * 2, j * 2 + 1, k * 2 + 1, m * 2 + 1, l * 2, n * 2 + 1,
-                                        -g3abb[i, j, k, l, m, n]
-                                    )
+                                    (i * 2, j * 2 + 1, k * 2 + 1, m * 2 + 1, l * 2, n * 2 + 1, -g3abb[i, j, k, l, m, n])
                                 )
                                 gamma3.append(
                                     (i * 2, j * 2 + 1, k * 2 + 1, m * 2 + 1, n * 2 + 1, l * 2, g3abb[i, j, k, l, m, n])
                                 )
 
                                 gamma3.append(
-                                    (
-                                        j * 2 + 1, i * 2, k * 2 + 1, l * 2, m * 2 + 1, n * 2 + 1,
-                                        -g3abb[i, j, k, l, m, n]
-                                    )
+                                    (j * 2 + 1, i * 2, k * 2 + 1, l * 2, m * 2 + 1, n * 2 + 1, -g3abb[i, j, k, l, m, n])
                                 )
                                 gamma3.append(
                                     (j * 2 + 1, i * 2, k * 2 + 1, m * 2 + 1, l * 2, n * 2 + 1, g3abb[i, j, k, l, m, n])
                                 )
                                 gamma3.append(
-                                    (
-                                        j * 2 + 1, i * 2, k * 2 + 1, m * 2 + 1, n * 2 + 1, l * 2,
-                                        -g3abb[i, j, k, l, m, n]
-                                    )
+                                    (j * 2 + 1, i * 2, k * 2 + 1, m * 2 + 1, n * 2 + 1, l * 2, -g3abb[i, j, k, l, m, n])
                                 )
 
                                 gamma3.append(
                                     (j * 2 + 1, k * 2 + 1, i * 2, l * 2, m * 2 + 1, n * 2 + 1, g3abb[i, j, k, l, m, n])
                                 )
                                 gamma3.append(
-                                    (
-                                        j * 2 + 1, k * 2 + 1, i * 2, m * 2 + 1, l * 2, n * 2 + 1,
-                                        -g3abb[i, j, k, l, m, n]
-                                    )
+                                    (j * 2 + 1, k * 2 + 1, i * 2, m * 2 + 1, l * 2, n * 2 + 1, -g3abb[i, j, k, l, m, n])
                                 )
                                 gamma3.append(
                                     (j * 2 + 1, k * 2 + 1, i * 2, m * 2 + 1, n * 2 + 1, l * 2, g3abb[i, j, k, l, m, n])
@@ -282,17 +270,22 @@ def write_external_rdm_file(active_space_solver, state_weights_map, max_rdm_leve
                                 # bbb case
                                 gamma3.append(
                                     (
-                                        i * 2 + 1, j * 2 + 1, k * 2 + 1, l * 2 + 1, m * 2 + 1, n * 2 + 1, g3bbb[i, j, k,
-                                                                                                                l, m, n]
+                                        i * 2 + 1,
+                                        j * 2 + 1,
+                                        k * 2 + 1,
+                                        l * 2 + 1,
+                                        m * 2 + 1,
+                                        n * 2 + 1,
+                                        g3bbb[i, j, k, l, m, n],
                                     )
                                 )
 
-        file['gamma3'] = {
+        file["gamma3"] = {
             "data": gamma3,
-            "description": "three-body density matrix as a list of tuples (i,j,k,l,m,n <i^ j^ k^ n m l>)"
+            "description": "three-body density matrix as a list of tuples (i,j,k,l,m,n <i^ j^ k^ n m l>)",
         }
 
-    with open('ref_rdms.json', 'w+') as f:
+    with open("ref_rdms.json", "w+") as f:
         json.dump(file, f, sort_keys=True, indent=2)
 
 

--- a/forte/pymodule.py
+++ b/forte/pymodule.py
@@ -29,9 +29,11 @@
 
 import time
 import os
-import psi4
-import forte
 
+import psi4
+import psi4.driver.p4util as p4util
+
+import forte
 from forte.data import ForteData
 from forte.modules import OptionsFactory, ObjectsFactoryFCIDUMP, ObjectsFactoryPsi4
 from forte.proc.external_active_space_solver import (
@@ -42,20 +44,6 @@ from forte.proc.external_active_space_solver import (
     make_hamiltonian,
 )
 from forte.proc.dsrg import ProcedureDSRG
-
-# import math
-# import warnings
-# import pathlib
-
-# from sys import exit
-# import numpy as np
-
-# import psi4.driver.p4util as p4util
-# from psi4.driver.procrouting import proc_util
-# import forte.proc.fcidump
-
-# from forte.proc.orbital_helpers import ortho_orbs_forte, orbital_projection
-# from forte.proc.orbital_helpers import read_orbitals, dump_orbitals
 
 
 def forte_driver(data: ForteData):

--- a/forte/pymodule.py
+++ b/forte/pymodule.py
@@ -54,41 +54,6 @@ from forte.data import ForteData
 from forte.modules import OptionsFactory, ObjectsFactoryFCIDUMP, ObjectsFactoryPsi4
 
 
-def check_MO_orthonormality(S, Ca):
-    """
-    Return whether the MO overlap matrix is identity or not.
-    S_MO = Ca^T S_SO Ca.
-    The MO overlap is the identity if and only if the orbitals are orthonormal.
-    Most electronic structure methods are derived assuming orthonormal orbitals.
-
-    :param S: a Psi4 Matrix of overlap integrals in the SO basis
-    :param Ca: a Psi4 Matrix that holds orbital coefficients
-
-    :return: S_MO == I
-    """
-    p4print = psi4.core.print_out
-
-    p4print("\n  Checking orbital orthonormality against current geometry ...")
-
-    S = S.clone()
-    S.transform(Ca)  # S = Ca^T S Ca
-
-    # test orbital orthonormality
-    identity = S.clone()
-    identity.identity()
-    S.subtract(identity)
-    absmax = S.absmax()
-
-    if absmax > 1.0e-8:
-        p4print("\n\n  Forte Warning: ")
-        p4print("Input orbitals are NOT from the current geometry!")
-        p4print(f"\n  Max value of MO overlap: {absmax:.15f}\n")
-        return False
-    else:
-        p4print(" Done (OK)\n\n")
-        return True
-
-
 def forte_driver(data: ForteData):
     """
     Driver to perform a Forte calculation using new solvers.
@@ -175,6 +140,7 @@ def run_forte(name, **kwargs):
     >>> energy('forte')
 
     """
+
     # # Start Forte, initialize ambit
     # my_proc_n_nodes = forte.startup()
     # my_proc, n_nodes = my_proc_n_nodes
@@ -195,7 +161,7 @@ def run_forte(name, **kwargs):
         psi4.core.print_out("\n  Forte will use custom integrals")
         data = ObjectsFactoryFCIDUMP(options=kwargs).run(data)
     else:
-        data = ObjectsFactoryPsi4(options=kwargs).run(data)
+        data = ObjectsFactoryPsi4(**kwargs).run(data)
 
     start = time.time()
 

--- a/forte/pymodule.py
+++ b/forte/pymodule.py
@@ -37,7 +37,6 @@ import os
 import numpy as np
 import psi4
 import forte
-from .register_forte_options import *
 import psi4.driver.p4util as p4util
 from psi4.driver.procrouting import proc_util
 import forte.proc.fcidump
@@ -52,6 +51,7 @@ from forte.proc.external_active_space_solver import (
     make_hamiltonian,
 )
 from forte.data import ForteData
+from forte.modules import OptionsFactory
 
 
 def run_psi4_ref(ref_type, molecule, print_warning=False, **kwargs):
@@ -406,39 +406,6 @@ def make_ints_from_fcidump(fcidump, data: ForteData):
     return data
 
 
-def prepare_forte_options(data: ForteData, options_dict=None):
-    """
-    Generate the ForteOptions object
-
-    Parameters
-    ----------
-    data : ForteData
-        A ForteData object
-    options_dict : dict
-        An optional dictionary used to define the options
-    """
-    options = forte.forte_options
-    # if no options_dict is provided then read from psi4
-    if options_dict is None:
-        # Get the option object
-        psi4_options = psi4.core.get_options()
-        psi4_options.set_current_module("FORTE")
-
-        # Get the forte option object
-        options.get_options_from_psi4(psi4_options)
-    else:
-        psi4.core.print_out(
-            f"\n  Forte will use options passed as a dictionary. Option read from psi4 will be ignored\n"
-        )
-        options = forte.ForteOptions()
-        register_forte_options(options)
-        options.set_from_dict(options_dict)
-
-    data.options = options
-
-    return data
-
-
 def prepare_forte_objects(data, name, **kwargs):
     """
     Prepare the ForteIntegrals, SCFInfo, and MOSpaceInfo objects.
@@ -567,7 +534,7 @@ def run_forte(name, **kwargs):
     data = ForteData()
 
     # Build Forte options
-    data = prepare_forte_options(data, kwargs.get("forte_options"))
+    data = OptionsFactory(options=kwargs.get("forte_options")).run(data)
 
     # Print the banner
     forte.banner()
@@ -684,7 +651,7 @@ def gradient_forte(name, **kwargs):
     data = ForteData()
 
     # Build Forte options
-    data = prepare_forte_options(data, kwargs.get("forte_options"))
+    data = OptionsFactory(options=kwargs.get("forte_options")).run(data)
 
     # Print the banner
     forte.banner()

--- a/forte/solvers/input.py
+++ b/forte/solvers/input.py
@@ -1,5 +1,5 @@
 from forte.solvers.solver import Feature, Node
-from forte.data import Data
+from forte.data import ForteData
 
 
 class Input(Node):
@@ -10,9 +10,10 @@ class Input(Node):
     It is used by the function `solver_factory` which fills it with
     an object from a class derived from the Model class.
     """
+
     def __init__(self):
         super().__init__(input_nodes=None, needs=[], provides=[Feature.MODEL])
-        self._data = Data()
+        self._data = ForteData()
 
     def _run(self):
         pass
@@ -33,7 +34,7 @@ class Input(Node):
         gas3=None,
         gas4=None,
         gas5=None,
-        gas6=None
+        gas6=None,
     ):
         """
         Returns a dictionary with the size of each orbital space defined.
@@ -67,25 +68,25 @@ class Input(Node):
         """
         mo_space = {}
         if frozen_docc is not None:
-            mo_space['FROZEN_DOCC'] = frozen_docc
+            mo_space["FROZEN_DOCC"] = frozen_docc
         if restricted_docc is not None:
-            mo_space['RESTRICTED_DOCC'] = restricted_docc
+            mo_space["RESTRICTED_DOCC"] = restricted_docc
         if active is not None:
-            mo_space['ACTIVE'] = active
+            mo_space["ACTIVE"] = active
         if gas1 is not None:
-            mo_space['GAS1'] = gas1
+            mo_space["GAS1"] = gas1
         if gas2 is not None:
-            mo_space['GAS2'] = gas2
+            mo_space["GAS2"] = gas2
         if gas3 is not None:
-            mo_space['GAS3'] = gas3
+            mo_space["GAS3"] = gas3
         if gas4 is not None:
-            mo_space['GAS4'] = gas4
+            mo_space["GAS4"] = gas4
         if gas5 is not None:
-            mo_space['GAS5'] = gas5
+            mo_space["GAS5"] = gas5
         if gas6 is not None:
-            mo_space['GAS6'] = gas6
+            mo_space["GAS6"] = gas6
         if restricted_uocc is not None:
-            mo_space['RESTRICTED_UOCC'] = restricted_uocc
+            mo_space["RESTRICTED_UOCC"] = restricted_uocc
         if frozen_uocc is not None:
-            mo_space['FROZEN_UOCC'] = frozen_uocc
+            mo_space["FROZEN_UOCC"] = frozen_uocc
         return mo_space

--- a/forte/solvers/solver.py
+++ b/forte/solvers/solver.py
@@ -4,7 +4,7 @@ from enum import Enum, auto
 from forte import StateInfo
 from forte.core import flog, increase_log_depth
 from forte.solvers.callback_handler import CallbackHandler
-from forte.data import Data
+from forte.data import ForteData
 from forte.results import Results
 
 import forte
@@ -15,12 +15,13 @@ class Feature(Enum):
     This enum class is used to store all possible Features needed
     or provided by a node in the computational graph
     """
+
     MODEL = auto()
     ORBITALS = auto()
     RDMS = auto()
 
 
-class Node():
+class Node:
     """
     Represents a node part of a computational graph.
 
@@ -31,6 +32,7 @@ class Node():
     The features that are needed must be part of the input node(s).
     This information is used to check the validity of a graph.
     """
+
     def __init__(self, needs, provides, input_nodes=None, data=None):
         """
         Parameters
@@ -48,7 +50,7 @@ class Node():
         input_nodes = [] if input_nodes is None else input_nodes
         self._input_nodes = input_nodes if type(input_nodes) is list else [input_nodes]
         self._check_input()
-        self._data = Data() if data is None else data
+        self._data = ForteData() if data is None else data
 
     @property
     def needs(self):
@@ -75,15 +77,16 @@ class Node():
                     need_met = True
             if not need_met:
                 raise AssertionError(
-                    f'\n\n  ** The computational graph is inconsistent ** \n\n{self.computational_graph()}'
-                    f'\n\n  The solver {self.__class__.__name__} cannot get a feature ({need}) from its input solver: '
-                    + ','.join([input.__class__.__name__ for input in self.input_nodes]) + '\n'
+                    f"\n\n  ** The computational graph is inconsistent ** \n\n{self.computational_graph()}"
+                    f"\n\n  The solver {self.__class__.__name__} cannot get a feature ({need}) from its input solver: "
+                    + ",".join([input.__class__.__name__ for input in self.input_nodes])
+                    + "\n"
                 )
 
     def computational_graph(self):
-        graph = f'{self.__class__.__name__}'
+        graph = f"{self.__class__.__name__}"
         if len(self.input_nodes) > 0:
-            graph += '\n |\n'
+            graph += "\n |\n"
             for input in self.input_nodes:
                 graph += input.computational_graph()
         return graph
@@ -107,6 +110,7 @@ class Solver(Node):
     Solver stores Forte base objects in a data attribute
     and a results object.
     """
+
     def __init__(self, needs, provides, input_nodes=None, options=None, cbh=None):
         """
         Parameters
@@ -129,7 +133,7 @@ class Solver(Node):
         self._executed = False
         self._results = Results()
         # the default psi4 output file
-        self._output_file = 'output.dat'
+        self._output_file = "output.dat"
         # self._output_file = f'output.{time.strftime("%Y-%m-%d-%H:%M:%S")}.dat'
 
     # decorate to increase the log depth
@@ -146,13 +150,13 @@ class Solver(Node):
             A data object
         """
         # log call to run()
-        flog('info', f'{type(self).__name__}: calling run()')
+        flog("info", f"{type(self).__name__}: calling run()")
 
         # call derived class implementation of _run()
         self._run()
 
         # log end of run()
-        flog('info', f'{type(self).__name__}: run() finished executing')
+        flog("info", f"{type(self).__name__}: run() finished executing")
 
         # set executed flag
         self._executed = True
@@ -257,9 +261,9 @@ class Solver(Node):
                 elif isinstance(v, list):
                     parsed_states[k] = v
                 else:
-                    raise ValueError(f'could not parse stats input {states}')
+                    raise ValueError(f"could not parse stats input {states}")
         else:
-            raise ValueError(f'could not parse stats input {states}')
+            raise ValueError(f"could not parse stats input {states}")
         return parsed_states
 
     def make_mo_space_info(self, mo_spaces):
@@ -285,9 +289,10 @@ class Solver(Node):
         Return a ForteOptions object
         """
         import psi4
+
         # Get the option object
         psi4_options = psi4.core.get_options()
-        psi4_options.set_current_module('FORTE')
+        psi4_options.set_current_module("FORTE")
 
         # Get the forte option object
         options = forte.forte_options

--- a/forte/utils/__init__.py
+++ b/forte/utils/__init__.py
@@ -1,3 +1,4 @@
 # utils/__init__.py
 
 from .helpers import psi4_scf, psi4_casscf, psi4_cubeprop, prepare_forte_objects, prepare_ints_rdms
+from .check_mo_orthogonality import check_mo_orthogonality

--- a/forte/utils/__init__.py
+++ b/forte/utils/__init__.py
@@ -1,4 +1,3 @@
 # utils/__init__.py
 
 from .helpers import psi4_scf, psi4_casscf, psi4_cubeprop, prepare_forte_objects, prepare_ints_rdms
-from .check_mo_orthogonality import check_mo_orthogonality

--- a/forte/utils/helpers.py
+++ b/forte/utils/helpers.py
@@ -2,7 +2,7 @@ import psi4
 import forte
 
 
-def psi4_scf(geom, basis, reference, functional='hf', options={}) -> (float, psi4.core.Wavefunction):
+def psi4_scf(geom, basis, reference, functional="hf", options={}) -> (float, psi4.core.Wavefunction):
     """Run a psi4 scf computation and return the energy and the Wavefunction object
 
     Parameters
@@ -29,7 +29,7 @@ def psi4_scf(geom, basis, reference, functional='hf', options={}) -> (float, psi
     mol = psi4.geometry(geom)
 
     # add basis/reference/scf_type to options passed by the user
-    default_options = {'SCF_TYPE': 'PK', 'E_CONVERGENCE': 1.0e-11, 'D_CONVERGENCE': 1.0e-6}
+    default_options = {"SCF_TYPE": "PK", "E_CONVERGENCE": 1.0e-11, "D_CONVERGENCE": 1.0e-6}
 
     # capitalize the options
     options = {k.upper(): v for k, v in options.items()}
@@ -39,13 +39,13 @@ def psi4_scf(geom, basis, reference, functional='hf', options={}) -> (float, psi
     merged_options = {**default_options, **options}
 
     # add the mandatory arguments
-    merged_options['BASIS'] = basis
-    merged_options['REFERENCE'] = reference
+    merged_options["BASIS"] = basis
+    merged_options["REFERENCE"] = reference
 
     psi4.set_options(merged_options)
 
     # pipe output to the file output.dat
-    psi4.core.set_output_file('output.dat', True)
+    psi4.core.set_output_file("output.dat", True)
 
     # run scf and return the energy and a wavefunction object (will work only if pass return_wfn=True)
     E_scf, wfn = psi4.energy(functional, molecule=mol, return_wfn=True)
@@ -74,7 +74,7 @@ def psi4_casscf(geom, basis, reference, restricted_docc, active, options={}) -> 
     mol = psi4.geometry(geom)
 
     # add basis/reference/scf_type to options passed by the user
-    default_options = {'SCF_TYPE': 'pk', 'E_CONVERGENCE': 1.0e-10, 'D_CONVERGENCE': 1.0e-6}
+    default_options = {"SCF_TYPE": "pk", "E_CONVERGENCE": 1.0e-10, "D_CONVERGENCE": 1.0e-6}
 
     # capitalize the options
     options = {k.upper(): v for k, v in options.items()}
@@ -84,24 +84,24 @@ def psi4_casscf(geom, basis, reference, restricted_docc, active, options={}) -> 
     merged_options = {**default_options, **options}
 
     # add the mandatory arguments
-    merged_options['BASIS'] = basis
-    merged_options['REFERENCE'] = reference
-    merged_options['RESTRICTED_DOCC'] = restricted_docc
-    merged_options['ACTIVE'] = active
-    merged_options['MCSCF_MAXITER'] = 100
-    merged_options['MCSCF_E_CONVERGENCE'] = 1.0e-10
-    merged_options['MCSCF_R_CONVERGENCE'] = 1.0e-6
-    merged_options['MCSCF_DIIS_START'] = 20
+    merged_options["BASIS"] = basis
+    merged_options["REFERENCE"] = reference
+    merged_options["RESTRICTED_DOCC"] = restricted_docc
+    merged_options["ACTIVE"] = active
+    merged_options["MCSCF_MAXITER"] = 100
+    merged_options["MCSCF_E_CONVERGENCE"] = 1.0e-10
+    merged_options["MCSCF_R_CONVERGENCE"] = 1.0e-6
+    merged_options["MCSCF_DIIS_START"] = 20
 
     psi4.set_options(merged_options)
 
     # pipe output to the file output.dat
-    psi4.core.set_output_file('output.dat', True)
+    psi4.core.set_output_file("output.dat", True)
 
     # psi4.core.clean()
 
     # run scf and return the energy and a wavefunction object (will work only if pass return_wfn=True)
-    E_scf, wfn = psi4.energy('casscf', molecule=mol, return_wfn=True)
+    E_scf, wfn = psi4.energy("casscf", molecule=mol, return_wfn=True)
     return (E_scf, wfn)
 
 
@@ -118,26 +118,26 @@ def psi4_casscf(geom, basis, mo_spaces):
 
     psi4.set_options(
         {
-            'basis': basis,
-            'scf_type': 'pk',
-            'e_convergence': 1e-13,
-            'd_convergence': 1e-6,
-            'restricted_docc': mo_spaces['RESTRICTED_DOCC'],
-            'active': mo_spaces['ACTIVE'],
-            'mcscf_maxiter': 100,
-            'mcscf_e_convergence': 1.0e-11,
-            'mcscf_r_convergence': 1.0e-6,
-            'mcscf_diis_start': 20
+            "basis": basis,
+            "scf_type": "pk",
+            "e_convergence": 1e-13,
+            "d_convergence": 1e-6,
+            "restricted_docc": mo_spaces["RESTRICTED_DOCC"],
+            "active": mo_spaces["ACTIVE"],
+            "mcscf_maxiter": 100,
+            "mcscf_e_convergence": 1.0e-11,
+            "mcscf_r_convergence": 1.0e-6,
+            "mcscf_diis_start": 20,
         }
     )
-    psi4.core.set_output_file('output.dat', False)
+    psi4.core.set_output_file("output.dat", False)
 
-    Escf, wfn = psi4.energy('casscf', return_wfn=True)
+    Escf, wfn = psi4.energy("casscf", return_wfn=True)
     psi4.core.clean()
     return Escf, wfn
 
 
-def psi4_cubeprop(wfn, path='.', orbs=[], nocc=0, nvir=0, density=False, frontier_orbitals=False, load=False):
+def psi4_cubeprop(wfn, path=".", orbs=[], nocc=0, nvir=0, density=False, frontier_orbitals=False, load=False):
     """
     Run a psi4 cubeprop computation to generate cube files from a given Wavefunction object
     By default this function plots from the HOMO -2 to the LUMO + 2
@@ -161,10 +161,10 @@ def psi4_cubeprop(wfn, path='.', orbs=[], nocc=0, nvir=0, density=False, frontie
     cubeprop_tasks = []
 
     if isinstance(orbs, str):
-        if (orbs == 'frontier_orbitals'):
-            cubeprop_tasks.append('FRONTIER_ORBITALS')
+        if orbs == "frontier_orbitals":
+            cubeprop_tasks.append("FRONTIER_ORBITALS")
     else:
-        cubeprop_tasks.append('ORBITALS')
+        cubeprop_tasks.append("ORBITALS")
         if nocc + nvir > 0:
             na = wfn.nalpha()
             nmo = wfn.nmo()
@@ -174,17 +174,17 @@ def psi4_cubeprop(wfn, path='.', orbs=[], nocc=0, nvir=0, density=False, frontie
         print(f'Preparing cube files for orbitals: {", ".join([str(orb) for orb in orbs])}')
 
     if density:
-        cubeprop_tasks.append('DENSITY')
+        cubeprop_tasks.append("DENSITY")
 
     if not os.path.exists(path):
         os.makedirs(path)
 
-    psi4.set_options({'CUBEPROP_TASKS': cubeprop_tasks, 'CUBEPROP_ORBITALS': orbs, 'CUBEPROP_FILEPATH': path})
+    psi4.set_options({"CUBEPROP_TASKS": cubeprop_tasks, "CUBEPROP_ORBITALS": orbs, "CUBEPROP_FILEPATH": path})
     psi4.cubeprop(wfn)
 
 
 def prepare_forte_objects(
-    wfn, mo_spaces=None, active_space='ACTIVE', core_spaces=['RESTRICTED_DOCC'], localize=False, localize_spaces=[]
+    wfn, mo_spaces=None, active_space="ACTIVE", core_spaces=["RESTRICTED_DOCC"], localize=False, localize_spaces=[]
 ):
     """Take a psi4 wavefunction object and prepare the ForteIntegrals, SCFInfo, and MOSpaceInfo objects
 
@@ -210,16 +210,20 @@ def prepare_forte_objects(
     # fill in the options object
     options = forte.forte_options
 
-    if ('DF' in options.get_str('INT_TYPE')):
+    if "DF" in options.get_str("INT_TYPE"):
         aux_basis = psi4.core.BasisSet.build(
-            wfn.molecule(), 'DF_BASIS_MP2', psi4.core.get_global_option('DF_BASIS_MP2'), 'RIFIT',
-            psi4.core.get_global_option('BASIS'), puream=wfn.basisset().has_puream()
+            wfn.molecule(),
+            "DF_BASIS_MP2",
+            psi4.core.get_global_option("DF_BASIS_MP2"),
+            "RIFIT",
+            psi4.core.get_global_option("BASIS"),
+            puream=wfn.basisset().has_puream(),
         )
-        wfn.set_basisset('DF_BASIS_MP2', aux_basis)
+        wfn.set_basisset("DF_BASIS_MP2", aux_basis)
 
-    if (options.get_str('MINAO_BASIS')):
-        minao_basis = psi4.core.BasisSet.build(wfn.molecule(), 'MINAO_BASIS', options.get_str('MINAO_BASIS'))
-        wfn.set_basisset('MINAO_BASIS', minao_basis)
+    if options.get_str("MINAO_BASIS"):
+        minao_basis = psi4.core.BasisSet.build(wfn.molecule(), "MINAO_BASIS", options.get_str("MINAO_BASIS"))
+        wfn.set_basisset("MINAO_BASIS", minao_basis)
 
     # Prepare base objects
     scf_info = forte.SCFInfo(wfn)
@@ -255,11 +259,11 @@ def prepare_forte_objects(
     as_ints = forte.make_active_space_ints(mo_space_info, ints, active_space, core_spaces)
 
     return {
-        'ints': ints,
-        'as_ints': as_ints,
-        'scf_info': scf_info,
-        'mo_space_info': mo_space_info,
-        'state_weights_map': state_weights_map
+        "ints": ints,
+        "as_ints": as_ints,
+        "scf_info": scf_info,
+        "mo_space_info": mo_space_info,
+        "state_weights_map": state_weights_map,
     }
 
 
@@ -275,11 +279,11 @@ def prepare_ints_rdms(wfn, mo_spaces, rdm_level=3, rdm_type=forte.RDMsType.spin_
 
     forte_objects = prepare_forte_objects(wfn, mo_spaces)
 
-    ints = forte_objects['ints']
-    as_ints = forte_objects['as_ints']
-    scf_info = forte_objects['scf_info']
-    mo_space_info = forte_objects['mo_space_info']
-    state_weights_map = forte_objects['state_weights_map']
+    ints = forte_objects["ints"]
+    as_ints = forte_objects["as_ints"]
+    scf_info = forte_objects["scf_info"]
+    mo_space_info = forte_objects["mo_space_info"]
+    state_weights_map = forte_objects["state_weights_map"]
 
     # build a map {StateInfo: a list of weights} for multi-state computations
     state_weights_map = forte.make_state_weights_map(forte.forte_options, mo_space_info)
@@ -288,7 +292,7 @@ def prepare_ints_rdms(wfn, mo_spaces, rdm_level=3, rdm_type=forte.RDMsType.spin_
     state_map = forte.to_state_nroots_map(state_weights_map)
 
     # create an active space solver object and compute the energy
-    as_solver_type = 'FCI'
+    as_solver_type = "FCI"
     as_solver = forte.make_active_space_solver(
         as_solver_type, state_map, scf_info, mo_space_info, as_ints, forte.forte_options
     )
@@ -305,4 +309,4 @@ def prepare_ints_rdms(wfn, mo_spaces, rdm_level=3, rdm_type=forte.RDMsType.spin_
     semi = forte.SemiCanonical(mo_space_info, ints, forte.forte_options)
     semi.semicanonicalize(rdms, rdm_level)
 
-    return {'reference_energy': Eref, 'mo_space_info': mo_space_info, 'ints': ints, 'rdms': rdms}
+    return {"reference_energy": Eref, "mo_space_info": mo_space_info, "ints": ints, "rdms": rdms}

--- a/tests/methods/df-casscf-2-rdm/input.dat
+++ b/tests/methods/df-casscf-2-rdm/input.dat
@@ -46,19 +46,25 @@ set forte job_type newdriver
 
 # I just want to test the RDMs!
 # - rerun a CASCI, copied from pymodule
-from forte.pymodule import prepare_forte_options, prepare_forte_objects
 
-options = prepare_forte_options()
-ref_wfn, state_weights_map, mo_space_info, scf_info, _ = forte_objects = prepare_forte_objects(options, 'FORTE', ref_wfn=wfn)
-ints = forte.make_ints_from_psi4(ref_wfn, options, mo_space_info)
+from forte.modules import OptionsFactory, ObjectsFactoryFCIDUMP, ObjectsFactoryPsi4
+data = OptionsFactory().run()
+data = ObjectsFactoryPsi4(ref_wfn=wfn).run(data)
 
-state_map = forte.to_state_nroots_map(state_weights_map)
-as_ints = forte.make_active_space_ints(mo_space_info, ints, "ACTIVE", ["RESTRICTED_DOCC"])
-as_solver = forte.make_active_space_solver("FCI", state_map, scf_info, mo_space_info, as_ints, options)
+
+#from forte.pymodule import prepare_forte_options, prepare_forte_objects
+
+#options = prepare_forte_options()
+#ref_wfn, state_weights_map, mo_space_info, scf_info, _ = forte_objects = prepare_forte_objects(options, 'FORTE', ref_wfn=wfn)
+#ints = forte.make_ints_from_psi4(ref_wfn, options, mo_space_info)
+
+state_map = forte.to_state_nroots_map(data.state_weights_map)
+as_ints = forte.make_active_space_ints(data.mo_space_info, data.ints, "ACTIVE", ["RESTRICTED_DOCC"])
+as_solver = forte.make_active_space_solver("FCI", state_map, data.scf_info, data.mo_space_info, as_ints, data.options)
 as_solver.compute_energy()
 
 # - now compute the 1-RDM and test the off-diagonal
-rdms = as_solver.compute_average_rdms(state_weights_map, 1, forte.RDMsType.spin_free)
+rdms = as_solver.compute_average_rdms(data.state_weights_map, 1, forte.RDMsType.spin_free)
 d1 = rdms.SF_G1mat()
 d1.print_out()  # Let's print out and see
 d1.zero_diagonal()

--- a/tests/pytest/active_space_solver/test_fci.py
+++ b/tests/pytest/active_space_solver/test_fci.py
@@ -17,20 +17,20 @@ def test_fci():
     """
 
     # create a molecular model
-    input = solver_factory(molecule=xyz, basis='cc-pVDZ')
+    input = solver_factory(molecule=xyz, basis="cc-pVDZ")
 
     # specify the electronic state and the active orbitals
-    state = input.state(charge=0, multiplicity=1, sym='ag')
+    state = input.state(charge=0, multiplicity=1, sym="ag")
     mo_spaces = input.mo_spaces(active=[1, 0, 0, 0, 0, 1, 0, 0])
 
     # create a HF object
     hf = HF(input, state=state)
     # create a FCI object that grabs the MOs from the HF object (hf)
-    fci = ActiveSpaceSolver(hf, type='FCI', states={state: 2}, mo_spaces=mo_spaces)
+    fci = ActiveSpaceSolver(hf, type="FCI", states={state: 2}, mo_spaces=mo_spaces)
     # run the computation
     fci.run()
     # check the FCI energy
-    assert fci.value('active space energy')[state] == pytest.approx(ref_energy, 1.0e-10)
+    assert fci.value("active space energy")[state] == pytest.approx(ref_energy, 1.0e-10)
 
 
 if __name__ == "__main__":

--- a/tests/pytest/helpers/test_spinorbital.py
+++ b/tests/pytest/helpers/test_spinorbital.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import math
-import pytest
-import psi4
-import forte
-
 
 def test_spinorbital_mp2():
+    import math
+    import pytest
+    import psi4
     import forte
     import forte.utils
     from math import isclose
+
     import numpy as np
 
     geom = """0 1
@@ -21,7 +20,10 @@ def test_spinorbital_mp2():
 
     basis = "6-31g"
     Escf, wfn = forte.utils.psi4_scf(geom, basis, "rhf")
-    data = forte.modules.ObjectsUtilPsi4(ref_wnf=wfn, mo_spaces={"RESTRICTED_DOCC": [5], "ACTIVE": [0]}).run()
+    # having options={} is a hack and should not be required.
+    data = forte.modules.ObjectsUtilPsi4(
+        ref_wfn=wfn, options={}, mo_spaces={"RESTRICTED_DOCC": [5], "ACTIVE": [0]}
+    ).run()
 
     mo_space_info = data.mo_space_info
     core = mo_space_info.corr_absolute_mo("RESTRICTED_DOCC")

--- a/tests/pytest/helpers/test_spinorbital.py
+++ b/tests/pytest/helpers/test_spinorbital.py
@@ -19,24 +19,24 @@ def test_spinorbital_mp2():
     symmetry c1
     """
 
-    basis = '6-31g'
-    Escf, wfn = forte.utils.psi4_scf(geom, basis, 'rhf')
-    forte_objects = forte.utils.prepare_forte_objects(wfn, mo_spaces={'RESTRICTED_DOCC': [5], 'ACTIVE': [0]})
+    basis = "6-31g"
+    Escf, wfn = forte.utils.psi4_scf(geom, basis, "rhf")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=wfn, mo_spaces={"RESTRICTED_DOCC": [5], "ACTIVE": [0]}).run()
 
-    mo_space_info = forte_objects['mo_space_info']
-    core = mo_space_info.corr_absolute_mo('RESTRICTED_DOCC')
-    virt = mo_space_info.corr_absolute_mo('RESTRICTED_UOCC')
+    mo_space_info = data.mo_space_info
+    core = mo_space_info.corr_absolute_mo("RESTRICTED_DOCC")
+    virt = mo_space_info.corr_absolute_mo("RESTRICTED_UOCC")
 
-    ints = forte_objects['ints']
+    ints = data.ints
     H = {
-        'cc': forte.spinorbital_oei(ints, core, core),
-        'cccc': forte.spinorbital_tei(ints, core, core, core, core),
-        'ccvv': forte.spinorbital_tei(ints, core, core, virt, virt)
+        "cc": forte.spinorbital_oei(ints, core, core),
+        "cccc": forte.spinorbital_tei(ints, core, core, core, core),
+        "ccvv": forte.spinorbital_tei(ints, core, core, virt, virt),
     }
 
     Eref_test = ints.nuclear_repulsion_energy()
-    Eref_test += np.einsum('mm->', H['cc'])
-    Eref_test += 0.5 * np.einsum('mnmn->', H['cccc'])
+    Eref_test += np.einsum("mm->", H["cc"])
+    Eref_test += 0.5 * np.einsum("mnmn->", H["cccc"])
     assert math.isclose(Eref_test, -99.97763667846159)
 
     Fc = forte.spinorbital_fock(ints, core, core, core).diagonal()
@@ -48,9 +48,9 @@ def test_spinorbital_mp2():
         for j in range(ncoreso):
             for a in range(nvirtso):
                 for b in range(nvirtso):
-                    d[i][j][a][b] = 1. / (Fc[i] + Fc[j] - Fv[a] - Fv[b])
-    T = {'ccvv': np.einsum("ijab,ijab->ijab", d, H['ccvv'])}
-    E = 0.25 * np.einsum("ijab,ijab->", T['ccvv'], H['ccvv'])
+                    d[i][j][a][b] = 1.0 / (Fc[i] + Fc[j] - Fv[a] - Fv[b])
+    T = {"ccvv": np.einsum("ijab,ijab->ijab", d, H["ccvv"])}
+    E = 0.25 * np.einsum("ijab,ijab->", T["ccvv"], H["ccvv"])
     assert math.isclose(E, -0.13305567213152, abs_tol=1e-09)
 
     psi4.core.clean()

--- a/tests/pytest/modules/test_module.py
+++ b/tests/pytest/modules/test_module.py
@@ -1,0 +1,25 @@
+import forte
+from forte.modules import Sequential, HF, FCI, Ints, Ints2, Localizer, GraphVisualizer
+from forte import ForteData
+
+data = ForteData()
+
+# ints = Ints()
+# hf = HF(ints)
+# graph = GraphVisualizer().visualize(hf)
+# print(graph)
+
+
+ints = Ints()
+ints2 = Ints2()
+ints3 = Ints2()
+seq = Sequential([HF(), Localizer()], [ints, ints2])
+fci = FCI([seq, ints3])
+
+
+graph = GraphVisualizer().visualize(fci)
+print(graph)
+seq.run(data)
+
+print("\n\n")
+Ints().run(data)

--- a/tests/pytest/modules/test_module.py
+++ b/tests/pytest/modules/test_module.py
@@ -4,11 +4,6 @@ from forte import ForteData
 
 data = ForteData()
 
-# ints = Ints()
-# hf = HF(ints)
-# graph = GraphVisualizer().visualize(hf)
-# print(graph)
-
 ints = Ints()
 ints2 = Ints2()
 seq = Sequential([HF(), Localizer()], ints)

--- a/tests/pytest/modules/test_module.py
+++ b/tests/pytest/modules/test_module.py
@@ -9,17 +9,11 @@ data = ForteData()
 # graph = GraphVisualizer().visualize(hf)
 # print(graph)
 
-
 ints = Ints()
 ints2 = Ints2()
-ints3 = Ints2()
-seq = Sequential([HF(), Localizer()], [ints, ints2])
-fci = FCI([seq, ints3])
-
+seq = Sequential([HF(), Localizer()], ints)
+fci = FCI(seq)
 
 graph = GraphVisualizer().visualize(fci)
 print(graph)
-seq.run(data)
-
-print("\n\n")
-Ints().run(data)
+fci.run(data)

--- a/tests/pytest/sparse_ci/srcc/test_ccsd.py
+++ b/tests/pytest/sparse_ci/srcc/test_ccsd.py
@@ -17,24 +17,19 @@ def test_ccsd():
      H 1 1.0
     """
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='DZ', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={})
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="DZ", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn).run()
     calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='cc',
-        max_exc=2,
-        e_convergence=1.0e-11
+        data.as_ints, data.scf_info, data.mo_space_info, cc_type="cc", max_exc=2, e_convergence=1.0e-11
     )
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  HF energy:   {scf_energy}')
-    print(f'  CCSD energy: {energy}')
-    print(f'  E - Eref:    {energy - ref_energy}')
+    print(f"  HF energy:   {scf_energy}")
+    print(f"  CCSD energy: {energy}")
+    print(f"  E - Eref:    {energy - ref_energy}")
 
     assert energy == pytest.approx(ref_energy, 1.0e-11)
 

--- a/tests/pytest/sparse_ci/srcc/test_ccsd_2.py
+++ b/tests/pytest/sparse_ci/srcc/test_ccsd_2.py
@@ -19,29 +19,29 @@ def test_ccsd2():
      H 1 1.0 2 104.5
     """
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='cc-pVDZ', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={})
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="cc-pVDZ", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn).run()
     calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='cc',
+        data.as_ints,
+        data.scf_info,
+        data.mo_space_info,
+        cc_type="cc",
         max_exc=2,
         e_convergence=1.0e-6,
         r_convergence=1.0e-4,
         compute_threshold=1.0e-6,
-        on_the_fly=True
+        on_the_fly=True,
     )
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  HF energy:   {scf_energy}')
-    print(f'  CCSD energy: {energy}')
-    print(f'  E - Eref:    {energy - ref_energy}')
+    print(f"  HF energy:   {scf_energy}")
+    print(f"  CCSD energy: {energy}")
+    print(f"  E - Eref:    {energy - ref_energy}")
 
-    #assert energy == pytest.approx(ref_energy, 1.0e-11)
+    # assert energy == pytest.approx(ref_energy, 1.0e-11)
 
 
 if __name__ == "__main__":

--- a/tests/pytest/sparse_ci/srcc/test_ccsd_3.py
+++ b/tests/pytest/sparse_ci/srcc/test_ccsd_3.py
@@ -19,24 +19,17 @@ def test_ccsd_3():
      H 0.0 0.0 3.0     
     """
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='DZ', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={})
-    calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='cc',
-        max_exc=2,
-        on_the_fly=True
-    )
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="DZ", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn).run()
+    calc_data = scc.run_cc(data.as_ints, data.scf_info, data.mo_space_info, cc_type="cc", max_exc=2, on_the_fly=True)
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  HF energy:   {scf_energy}')
-    print(f'  CCSD energy: {energy}')
-    print(f'  E - Eref:    {energy - ref_energy}')
+    print(f"  HF energy:   {scf_energy}")
+    print(f"  CCSD energy: {energy}")
+    print(f"  E - Eref:    {energy - ref_energy}")
 
     assert energy == pytest.approx(ref_energy, 1.0e-11)
 

--- a/tests/pytest/sparse_ci/srcc/test_ccsdtq.py
+++ b/tests/pytest/sparse_ci/srcc/test_ccsdtq.py
@@ -19,19 +19,17 @@ def test_ccsdtq():
      H 0.0 0.0 3.0     
     """
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='DZ', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={})
-    calc_data = scc.run_cc(
-        forte_objs['as_ints'], forte_objs['scf_info'], forte_objs['mo_space_info'], cc_type='cc', max_exc=4
-    )
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="DZ", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn, mo_spaces={}).run()
+    calc_data = scc.run_cc(data.as_ints, data.scf_info, data.mo_space_info, cc_type="cc", max_exc=4)
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  HF energy:     {scf_energy}')
-    print(f'  CCSDTQ energy: {energy}')
-    print(f'  E - Eref:      {energy - ref_energy}')
+    print(f"  HF energy:     {scf_energy}")
+    print(f"  CCSDTQ energy: {energy}")
+    print(f"  E - Eref:      {energy - ref_energy}")
 
     assert energy == pytest.approx(ref_energy, 1.0e-11)
 

--- a/tests/pytest/sparse_ci/srcc/test_ccsdtq_2.py
+++ b/tests/pytest/sparse_ci/srcc/test_ccsdtq_2.py
@@ -19,24 +19,19 @@ def test_ccsdtq_2():
      H 0.0 0.0 3.0     
     """
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='cc-pVDZ', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={})
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="cc-pVDZ", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn, mo_spaces={}).run()
     calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='cc',
-        max_exc=4,
-        e_convergence=1.0e-12
+        data.as_ints, data.scf_info, data.mo_space_info, cc_type="cc", max_exc=4, e_convergence=1.0e-12
     )
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  HF energy:     {scf_energy}')
-    print(f'  CCSDTQ energy: {energy}')
-    print(f'  E - Eref:      {energy - ref_energy}')
+    print(f"  HF energy:     {scf_energy}")
+    print(f"  CCSDTQ energy: {energy}")
+    print(f"  E - Eref:      {energy - ref_energy}")
 
     assert energy == pytest.approx(ref_energy, 1.0e-11)
 

--- a/tests/pytest/sparse_ci/srcc/test_ccsdtq_3.py
+++ b/tests/pytest/sparse_ci/srcc/test_ccsdtq_3.py
@@ -16,15 +16,15 @@ def test_ccsdtq_3():
 
     geom = "Ne"
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='cc-pVDZ', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={'FROZEN_DOCC': [1, 0, 0, 0, 0, 0, 0, 0]})
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="cc-pVDZ", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn, mo_spaces={"FROZEN_DOCC": [1, 0, 0, 0, 0, 0, 0, 0]}).run()
     calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='cc',
+        data.as_ints,
+        data.scf_info,
+        data.mo_space_info,
+        cc_type="cc",
         max_exc=4,
-        e_convergence=1.0e-12
+        e_convergence=1.0e-12,
     )
 
     psi4.core.clean()

--- a/tests/pytest/sparse_ci/srcc/test_ccsdtqp.py
+++ b/tests/pytest/sparse_ci/srcc/test_ccsdtqp.py
@@ -16,15 +16,10 @@ def test_ccsdtqp():
 
     geom = "Ne"
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='cc-pVDZ', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={'FROZEN_DOCC': [1, 0, 0, 0, 0, 0, 0, 0]})
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="cc-pVDZ", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn, mo_spaces={"FROZEN_DOCC": [1, 0, 0, 0, 0, 0, 0, 0]}).run()
     calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='cc',
-        max_exc=5,
-        e_convergence=1.0e-10
+        data.as_ints, data.scf_info, data.mo_space_info, cc_type="cc", max_exc=5, e_convergence=1.0e-10
     )
 
     psi4.core.clean()

--- a/tests/pytest/sparse_ci/srcc/test_dccsd.py
+++ b/tests/pytest/sparse_ci/srcc/test_dccsd.py
@@ -17,25 +17,25 @@ def test_ccsd():
      H 1 1.0
     """
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='DZ', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={})
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="DZ", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn, mo_spaces={}).run()
     calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='dcc',
+        data.as_ints,
+        data.scf_info,
+        data.mo_space_info,
+        cc_type="dcc",
         max_exc=2,
         e_convergence=1.0e-11,
-        on_the_fly=True
+        on_the_fly=True,
     )
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  HF energy:   {scf_energy}')
-    print(f'  CCSD energy: {energy}')
-    print(f'  E - Eref:    {energy - ref_energy}')
+    print(f"  HF energy:   {scf_energy}")
+    print(f"  CCSD energy: {energy}")
+    print(f"  E - Eref:    {energy - ref_energy}")
 
     assert energy == pytest.approx(ref_energy, 1.0e-11)
 

--- a/tests/pytest/sparse_ci/srcc/test_dccsd_2.py
+++ b/tests/pytest/sparse_ci/srcc/test_dccsd_2.py
@@ -19,24 +19,17 @@ def test_dccsd_2():
      H 0.0 0.0 3.0     
     """
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='DZ', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={})
-    calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='dcc',
-        max_exc=2,
-        on_the_fly=True
-    )
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="DZ", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn, mo_spaces={}).run()
+    calc_data = scc.run_cc(data.as_ints, data.scf_info, data.mo_space_info, cc_type="dcc", max_exc=2, on_the_fly=True)
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  HF energy:   {scf_energy}')
-    print(f'  CCSD energy: {energy}')
-    print(f'  E - Eref:    {energy - ref_energy}')
+    print(f"  HF energy:   {scf_energy}")
+    print(f"  CCSD energy: {energy}")
+    print(f"  E - Eref:    {energy - ref_energy}")
 
     assert energy == pytest.approx(ref_energy, 1.0e-11)
 

--- a/tests/pytest/sparse_ci/srcc/test_dccsdtq.py
+++ b/tests/pytest/sparse_ci/srcc/test_dccsdtq.py
@@ -19,24 +19,17 @@ def test_ccsdtq():
      H 0.0 0.0 3.0
     """
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='DZ', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={})
-    calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='dcc',
-        max_exc=4,
-        on_the_fly=True
-    )
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="DZ", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn, mo_spaces={}).run()
+    calc_data = scc.run_cc(data.as_ints, data.scf_info, data.mo_space_info, cc_type="dcc", max_exc=4, on_the_fly=True)
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  HF energy:     {scf_energy}')
-    print(f'  CCSDTQ energy: {energy}')
-    print(f'  E - Eref:      {energy - ref_energy}')
+    print(f"  HF energy:     {scf_energy}")
+    print(f"  CCSDTQ energy: {energy}")
+    print(f"  E - Eref:      {energy - ref_energy}")
 
     assert energy == pytest.approx(ref_energy, 1.0e-11)
 

--- a/tests/pytest/sparse_ci/srcc/test_duccsd.py
+++ b/tests/pytest/sparse_ci/srcc/test_duccsd.py
@@ -14,24 +14,24 @@ def test_duccsd():
 
     geom = "Ne"
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='cc-pVDZ', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={'FROZEN_DOCC': [1, 0, 0, 0, 0, 0, 0, 0]})
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="cc-pVDZ", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn, mo_spaces={"FROZEN_DOCC": [1, 0, 0, 0, 0, 0, 0, 0]}).run()
     calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='ducc',
+        data.as_ints,
+        data.scf_info,
+        data.mo_space_info,
+        cc_type="ducc",
         max_exc=2,
-        e_convergence=1.0e-10
+        e_convergence=1.0e-10,
     )
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  HF energy:     {scf_energy}')
-    print(f'  DUCCSD energy: {energy}')
-    print(f'  E - Eref:      {energy - ref_energy}')
+    print(f"  HF energy:     {scf_energy}")
+    print(f"  DUCCSD energy: {energy}")
+    print(f"  E - Eref:      {energy - ref_energy}")
 
     assert energy == pytest.approx(ref_energy, 1.0e-11)
 

--- a/tests/pytest/sparse_ci/srcc/test_duccsdt.py
+++ b/tests/pytest/sparse_ci/srcc/test_duccsdt.py
@@ -15,24 +15,19 @@ def test_duccsdt():
 
     geom = "Ne"
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='cc-pVDZ', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={'FROZEN_DOCC': [1, 0, 0, 0, 0, 0, 0, 0]})
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="cc-pVDZ", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn, mo_spaces={"FROZEN_DOCC": [1, 0, 0, 0, 0, 0, 0, 0]}).run()
     calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='ducc',
-        max_exc=3,
-        e_convergence=1.0e-11
+        data.as_ints, data.scf_info, data.mo_space_info, cc_type="ducc", max_exc=3, e_convergence=1.0e-11
     )
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  HF energy:      {scf_energy}')
-    print(f'  DUCCSDT energy: {energy}')
-    print(f'  E - Eref:       {energy - ref_energy}')
+    print(f"  HF energy:      {scf_energy}")
+    print(f"  DUCCSDT energy: {energy}")
+    print(f"  E - Eref:       {energy - ref_energy}")
 
     assert energy == pytest.approx(ref_energy, 1.0e-11)
 

--- a/tests/pytest/sparse_ci/srcc/test_duccsdtq.py
+++ b/tests/pytest/sparse_ci/srcc/test_duccsdtq.py
@@ -16,24 +16,19 @@ def test_duccsdtq():
 
     geom = "Ne"
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='cc-pVDZ', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={'FROZEN_DOCC': [1, 0, 0, 0, 0, 0, 0, 0]})
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="cc-pVDZ", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn, mo_spaces={"FROZEN_DOCC": [1, 0, 0, 0, 0, 0, 0, 0]}).run()
     calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='ducc',
-        max_exc=4,
-        e_convergence=1.0e-11
+        data.as_ints, data.scf_info, data.mo_space_info, cc_type="ducc", max_exc=4, e_convergence=1.0e-11
     )
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  HF energy:       {scf_energy}')
-    print(f'  DUCCSDTQ energy: {energy}')
-    print(f'  E - Eref:        {energy - ref_energy}')
+    print(f"  HF energy:       {scf_energy}")
+    print(f"  DUCCSDTQ energy: {energy}")
+    print(f"  E - Eref:        {energy - ref_energy}")
 
     assert energy == pytest.approx(ref_energy, 1.0e-11)
 

--- a/tests/pytest/sparse_ci/srcc/test_uccsd.py
+++ b/tests/pytest/sparse_ci/srcc/test_uccsd.py
@@ -17,24 +17,19 @@ def test_uccsd():
      H 1 1.0
     """
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='DZ', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={})
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="DZ", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn, mo_spaces={}).run()
     calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='ucc',
-        max_exc=2,
-        e_convergence=1.0e-11
+        data.as_ints, data.scf_info, data.mo_space_info, cc_type="ucc", max_exc=2, e_convergence=1.0e-11
     )
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  HF energy:    {scf_energy}')
-    print(f'  UCCSD energy: {energy}')
-    print(f'  E - Eref:     {energy - ref_energy}')
+    print(f"  HF energy:    {scf_energy}")
+    print(f"  UCCSD energy: {energy}")
+    print(f"  E - Eref:     {energy - ref_energy}")
 
     assert energy == pytest.approx(ref_energy, 1.0e-11)
 

--- a/tests/pytest/sparse_ci/srcc/test_uccsd_2.py
+++ b/tests/pytest/sparse_ci/srcc/test_uccsd_2.py
@@ -16,24 +16,19 @@ def test_uccsd_2():
 
     geom = "Ne"
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='cc-pVDZ', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={'FROZEN_DOCC': [1, 0, 0, 0, 0, 0, 0, 0]})
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="cc-pVDZ", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn, mo_spaces={"FROZEN_DOCC": [1, 0, 0, 0, 0, 0, 0, 0]}).run()
     calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='ucc',
-        max_exc=2,
-        e_convergence=1.0e-10
+        data.as_ints, data.scf_info, data.mo_space_info, cc_type="ucc", max_exc=2, e_convergence=1.0e-10
     )
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  HF energy:    {scf_energy}')
-    print(f'  UCCSD energy: {energy}')
-    print(f'  E - Eref:     {energy - ref_energy}')
+    print(f"  HF energy:    {scf_energy}")
+    print(f"  UCCSD energy: {energy}")
+    print(f"  E - Eref:     {energy - ref_energy}")
 
     assert energy == pytest.approx(ref_energy, 1.0e-11)
 

--- a/tests/pytest/sparse_ci/srcc/test_uccsd_3.py
+++ b/tests/pytest/sparse_ci/srcc/test_uccsd_3.py
@@ -16,9 +16,11 @@ def test_uccsd_3():
 
     psi4.set_options({"FORTE__FROZEN_DOCC": [2]})
     data = forte.modules.OptionsFactory().run()
-    data = forte.modules.ObjectsFactoryFCIDUMP().run(data)
-    as_ints = forte.make_active_space_ints(data.mo_space_info, data.ints, "CORRELATED", [])
-    calc_data = scc.run_cc(as_ints, data.scf_info, data.mo_space_info, cc_type="ucc", max_exc=2, e_convergence=1.0e-10)
+    data = forte.modules.ObjectsFactoryFCIDUMP(file=os.path.dirname(__file__) + "/INTDUMP").run(data)
+    data = forte.modules.ActiveSpaceIntsFactory("CORRELATED", []).run(data)
+    calc_data = scc.run_cc(
+        data.as_ints, data.scf_info, data.mo_space_info, cc_type="ucc", max_exc=2, e_convergence=1.0e-10
+    )
 
     psi4.core.clean()
 

--- a/tests/pytest/sparse_ci/srcc/test_uccsd_3.py
+++ b/tests/pytest/sparse_ci/srcc/test_uccsd_3.py
@@ -14,19 +14,17 @@ def test_uccsd_3():
 
     ref_energy = -107.655681875111
 
-    psi4.set_options({'FORTE__FROZEN_DOCC': [2]})
-    options = forte.prepare_forte_options()
-    forte_objects = forte.prepare_forte_objects_from_fcidump(options, os.path.dirname(__file__))
-    state_weights_map, mo_space_info, scf_info, fcidump = forte_objects
-    ints = forte.make_ints_from_fcidump(fcidump, options, mo_space_info)
-    as_ints = forte.make_active_space_ints(mo_space_info, ints, 'CORRELATED', [])
-    calc_data = scc.run_cc(as_ints, scf_info, mo_space_info, cc_type='ucc', max_exc=2, e_convergence=1.0e-10)
+    psi4.set_options({"FORTE__FROZEN_DOCC": [2]})
+    data = forte.modules.OptionsFactory().run()
+    data = forte.modules.ObjectsFactoryFCIDUMP().run(data)
+    as_ints = forte.make_active_space_ints(data.mo_space_info, data.ints, "CORRELATED", [])
+    calc_data = scc.run_cc(as_ints, data.scf_info, data.mo_space_info, cc_type="ucc", max_exc=2, e_convergence=1.0e-10)
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  UCCSD energy: {energy}')
+    print(f"  UCCSD energy: {energy}")
     assert energy == pytest.approx(ref_energy, 1.0e-9)
 
 

--- a/tests/pytest/sparse_ci/srcc/test_uccsd_4.py
+++ b/tests/pytest/sparse_ci/srcc/test_uccsd_4.py
@@ -18,24 +18,19 @@ def test_uccsd_4():
     symmetry c1
     """
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='sto-3g', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={'frozen_docc': [2]})
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="sto-3g", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn, mo_spaces={"frozen_docc": [2]}).run()
     calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='ucc',
-        max_exc=2,
-        e_convergence=1.0e-10
+        data.as_ints, data.scf_info, data.mo_space_info, cc_type="ucc", max_exc=2, e_convergence=1.0e-10
     )
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  HF energy:    {scf_energy}')
-    print(f'  CCSD energy:  {energy}')
-    print(f'  corr. energy: {energy - scf_energy}')
+    print(f"  HF energy:    {scf_energy}")
+    print(f"  CCSD energy:  {energy}")
+    print(f"  corr. energy: {energy - scf_energy}")
 
     assert energy == pytest.approx(ref_energy, 1.0e-9)
 

--- a/tests/pytest/sparse_ci/srcc/test_uccsd_5.py
+++ b/tests/pytest/sparse_ci/srcc/test_uccsd_5.py
@@ -16,9 +16,11 @@ def test_uccsd_3():
 
     psi4.set_options({"FORTE__FROZEN_DOCC": [2]})
     data = forte.modules.OptionsFactory().run()
-    data = forte.modules.ObjectsFactoryFCIDUMP().run(data)
-    as_ints = forte.make_active_space_ints(data.mo_space_info, data.ints, "CORRELATED", [])
-    calc_data = scc.run_cc(as_ints, data.scf_info, data.mo_space_info, cc_type="ucc", max_exc=2, e_convergence=1.0e-10)
+    data = forte.modules.ObjectsFactoryFCIDUMP(file=os.path.dirname(__file__) + "/INTDUMP").run(data)
+    data = forte.modules.ActiveSpaceIntsFactory("CORRELATED", []).run(data)
+    calc_data = scc.run_cc(
+        data.as_ints, data.scf_info, data.mo_space_info, cc_type="ucc", max_exc=2, e_convergence=1.0e-10
+    )
 
     psi4.core.clean()
 

--- a/tests/pytest/sparse_ci/srcc/test_uccsd_5.py
+++ b/tests/pytest/sparse_ci/srcc/test_uccsd_5.py
@@ -14,19 +14,17 @@ def test_uccsd_3():
 
     ref_energy = -107.655681875111
 
-    psi4.set_options({'FORTE__FROZEN_DOCC': [2]})
-    options = forte.prepare_forte_options()
-    forte_objects = forte.prepare_forte_objects_from_fcidump(options, os.path.dirname(__file__))
-    state_weights_map, mo_space_info, scf_info, fcidump = forte_objects
-    ints = forte.make_ints_from_fcidump(fcidump, options, mo_space_info)
-    as_ints = forte.make_active_space_ints(mo_space_info, ints, 'CORRELATED', [])
-    calc_data = scc.run_cc(as_ints, scf_info, mo_space_info, cc_type='ucc', max_exc=2, e_convergence=1.0e-10)
+    psi4.set_options({"FORTE__FROZEN_DOCC": [2]})
+    data = forte.modules.OptionsFactory().run()
+    data = forte.modules.ObjectsFactoryFCIDUMP().run(data)
+    as_ints = forte.make_active_space_ints(data.mo_space_info, data.ints, "CORRELATED", [])
+    calc_data = scc.run_cc(as_ints, data.scf_info, data.mo_space_info, cc_type="ucc", max_exc=2, e_convergence=1.0e-10)
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  UCCSD energy: {energy}')
+    print(f"  UCCSD energy: {energy}")
     assert energy == pytest.approx(ref_energy, 1.0e-9)
 
 

--- a/tests/pytest/sparse_ci/srcc/test_uccsd_6.py
+++ b/tests/pytest/sparse_ci/srcc/test_uccsd_6.py
@@ -19,26 +19,26 @@ def test_uccsd_6():
      H 0.0 0.0 4.5     
     """
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='sto-3g', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={})
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="sto-3g", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn, mo_spaces={}).run()
     calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='ucc',
+        data.as_ints,
+        data.scf_info,
+        data.mo_space_info,
+        cc_type="ucc",
         max_exc=2,
         e_convergence=1.0e-10,
         linked=False,
-        maxk=1
+        maxk=1,
     )
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  HF energy:    {scf_energy}')
-    print(f'  CCSD energy:  {energy}')
-    print(f'  corr. energy: {energy - scf_energy}')
+    print(f"  HF energy:    {scf_energy}")
+    print(f"  CCSD energy:  {energy}")
+    print(f"  corr. energy: {energy - scf_energy}")
 
     assert energy == pytest.approx(ref_energy, 1.0e-9)
 

--- a/tests/pytest/sparse_ci/srcc/test_uccsd_7.py
+++ b/tests/pytest/sparse_ci/srcc/test_uccsd_7.py
@@ -19,26 +19,26 @@ def test_uccsd_7():
      H 0.0 0.0 4.5     
     """
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='sto-3g', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={})
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="sto-3g", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn, mo_spaces={}).run()
     calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='ucc',
+        data.as_ints,
+        data.scf_info,
+        data.mo_space_info,
+        cc_type="ucc",
         max_exc=3,
         e_convergence=1.0e-10,
         linked=False,
-        maxk=1
+        maxk=1,
     )
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  HF energy:    {scf_energy}')
-    print(f'  CCSD energy:  {energy}')
-    print(f'  corr. energy: {energy - scf_energy}')
+    print(f"  HF energy:    {scf_energy}")
+    print(f"  CCSD energy:  {energy}")
+    print(f"  corr. energy: {energy - scf_energy}")
 
     assert energy == pytest.approx(ref_energy, 1.0e-9)
 

--- a/tests/pytest/sparse_ci/srcc/test_uccsd_8.py
+++ b/tests/pytest/sparse_ci/srcc/test_uccsd_8.py
@@ -19,25 +19,19 @@ def test_uccsd_8():
      H 0.0 0.0 4.5     
     """
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='sto-3g', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={})
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="sto-3g", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn, mo_spaces={}).run()
     calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='ucc',
-        max_exc=2,
-        e_convergence=1.0e-10,
-        linked=False
+        data.as_ints, data.scf_info, data.mo_space_info, cc_type="ucc", max_exc=2, e_convergence=1.0e-10, linked=False
     )
 
     psi4.core.clean()
 
     energy = calc_data[-1][2]
 
-    print(f'  HF energy:    {scf_energy}')
-    print(f'  CCSD energy:  {energy}')
-    print(f'  corr. energy: {energy - scf_energy}')
+    print(f"  HF energy:    {scf_energy}")
+    print(f"  CCSD energy:  {energy}")
+    print(f"  corr. energy: {energy - scf_energy}")
 
     assert energy == pytest.approx(ref_energy, 1.0e-6)
 

--- a/tests/pytest/sparse_ci/srcc/test_uccsdt.py
+++ b/tests/pytest/sparse_ci/srcc/test_uccsdt.py
@@ -16,24 +16,24 @@ def test_uccsdt():
 
     geom = "Ne"
 
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='cc-pVDZ', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={'FROZEN_DOCC': [1, 0, 0, 0, 0, 0, 0, 0]})
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="cc-pVDZ", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn, mo_spaces={"FROZEN_DOCC": [1, 0, 0, 0, 0, 0, 0, 0]}).run()
     calc_data = scc.run_cc(
-        forte_objs['as_ints'],
-        forte_objs['scf_info'],
-        forte_objs['mo_space_info'],
-        cc_type='ucc',
+        data.as_ints,
+        data.scf_info,
+        data.mo_space_info,
+        cc_type="ucc",
         max_exc=3,
-        e_convergence=1.0e-10
+        e_convergence=1.0e-10,
     )
 
     psi4.core.clean()
 
     energy = calc_data[-1][1]
 
-    print(f'  HF energy:     {scf_energy}')
-    print(f'  UCCSDT energy: {energy}')
-    print(f'  E - Eref:      {energy - ref_energy}')
+    print(f"  HF energy:     {scf_energy}")
+    print(f"  UCCSDT energy: {energy}")
+    print(f"  E - Eref:      {energy - ref_energy}")
 
     assert energy == pytest.approx(ref_energy, 1.0e-11)
 

--- a/tests/pytest/sparse_ci/srcc/test_ul-uccsd_1.py
+++ b/tests/pytest/sparse_ci/srcc/test_ul-uccsd_1.py
@@ -15,17 +15,16 @@ def test_ul_uccsd_1():
 
     psi4.set_options(
         {
-            "FORTE__FCIDUMP_FILE": "INTDUMP2",
             "FORTE__FCIDUMP_DOCC": [2],
             "FORTE__FROZEN_DOCC": [0],
         }
     )
 
     data = forte.modules.OptionsFactory().run()
-    data = forte.modules.ObjectsFactoryFCIDUMP().run(data)
-    as_ints = forte.make_active_space_ints(data.mo_space_info, data.ints, "CORRELATED", [])
+    data = forte.modules.ObjectsFactoryFCIDUMP(file=os.path.dirname(__file__) + "/INTDUMP2").run(data)
+    data = forte.modules.ActiveSpaceIntsFactory("CORRELATED", []).run(data)
     calc_data = scc.run_cc(
-        as_ints,
+        data.as_ints,
         data.scf_info,
         data.mo_space_info,
         cc_type="ucc",

--- a/tests/pytest/sparse_ci/srcc/test_ul-uccsd_1.py
+++ b/tests/pytest/sparse_ci/srcc/test_ul-uccsd_1.py
@@ -13,19 +13,26 @@ def test_ul_uccsd_1():
 
     ref_energy = -1.9437216535661626  # from Jonathon
 
-    psi4.set_options({
-        'FORTE__FCIDUMP_FILE': 'INTDUMP2',
-        'FORTE__FCIDUMP_DOCC': [2],
-        'FORTE__FROZEN_DOCC': [0],
-    })
+    psi4.set_options(
+        {
+            "FORTE__FCIDUMP_FILE": "INTDUMP2",
+            "FORTE__FCIDUMP_DOCC": [2],
+            "FORTE__FROZEN_DOCC": [0],
+        }
+    )
 
-    options = forte.prepare_forte_options()
-    forte_objects = forte.prepare_forte_objects_from_fcidump(options, os.path.dirname(__file__))
-    state_weights_map, mo_space_info, scf_info, fcidump = forte_objects
-    ints = forte.make_ints_from_fcidump(fcidump, options, mo_space_info)
-    as_ints = forte.make_active_space_ints(mo_space_info, ints, 'CORRELATED', [])
+    data = forte.modules.OptionsFactory().run()
+    data = forte.modules.ObjectsFactoryFCIDUMP().run(data)
+    as_ints = forte.make_active_space_ints(data.mo_space_info, data.ints, "CORRELATED", [])
     calc_data = scc.run_cc(
-        as_ints, scf_info, mo_space_info, cc_type='ucc', max_exc=2, e_convergence=1.0e-10, linked=False, diis_start=2
+        as_ints,
+        data.scf_info,
+        data.mo_space_info,
+        cc_type="ucc",
+        max_exc=2,
+        e_convergence=1.0e-10,
+        linked=False,
+        diis_start=2,
     )
 
     psi4.core.clean()

--- a/tests/pytest/sparse_ci/test_sparse_ci.py
+++ b/tests/pytest/sparse_ci/test_sparse_ci.py
@@ -17,32 +17,26 @@ def test_sparse_ci():
     # need to clean the options otherwise this job will interfere
     forte.clean_options()
 
-    psi4.geometry("""
+    psi4.geometry(
+        """
      H
      H 1 1.0
-    """)
+    """
+    )
 
-    psi4.set_options({'basis': 'sto-3g'})
-    E_scf, wfn = psi4.energy('scf', return_wfn=True)
+    psi4.set_options({"basis": "sto-3g"})
+    E_scf, wfn = psi4.energy("scf", return_wfn=True)
     na = wfn.nalpha()
     nb = wfn.nbeta()
     nirrep = wfn.nirrep()
     wfn_symmetry = 0
 
-    psi4_options = psi4.core.get_options()
-    psi4_options.set_current_module('FORTE')
-    forte_options.get_options_from_psi4(psi4_options)
+    # Make the integrals
+    data = forte.modules.ObjectsUtilPsi4().run()
+    as_ints = data.as_ints
 
-    # Setup forte and prepare the active space integral class
-    nmopi = wfn.nmopi()
-    point_group = wfn.molecule().point_group().symbol()
-    mo_space_info = forte.make_mo_space_info(nmopi, point_group, forte_options)
-    ints = forte.make_ints_from_psi4(wfn, forte_options, mo_space_info)
-    as_ints = forte.make_active_space_ints(mo_space_info, ints, 'ACTIVE', ['RESTRICTED_DOCC'])
-    as_ints.print()
-
-    print('\n\n  => Sparse FCI Test <=')
-    print('  Number of irreps: {}'.format(nirrep))
+    print("\n\n  => Sparse FCI Test <=")
+    print("  Number of irreps: {}".format(nirrep))
     nmo = wfn.nmo()
     nmopi = [wfn.nmopi()[h] for h in range(nirrep)]
     nmopi_str = [str(wfn.nmopi()[h]) for h in range(nirrep)]
@@ -51,18 +45,18 @@ def test_sparse_ci():
         for i in range(nmopi[h]):
             mo_sym.append(h)
 
-    print('  Number of orbitals per irreps: [{}]'.format(','.join(nmopi_str)))
-    print('  Symmetry of the MOs: ', mo_sym)
+    print("  Number of orbitals per irreps: [{}]".format(",".join(nmopi_str)))
+    print("  Symmetry of the MOs: ", mo_sym)
 
     hf_reference = forte.Determinant()
     hf_reference.create_alfa_bit(0)
     hf_reference.create_beta_bit(0)
-    print('  Hartree-Fock determinant: {}'.format(hf_reference.str(2)))
+    print("  Hartree-Fock determinant: {}".format(hf_reference.str(2)))
 
     # Compute the HF energy
     hf_energy = as_ints.nuclear_repulsion_energy() + as_ints.slater_rules(hf_reference, hf_reference)
-    print('  Nuclear repulsion energy: {}'.format(as_ints.nuclear_repulsion_energy()))
-    print('  Reference energy: {}'.format(hf_energy))
+    print("  Nuclear repulsion energy: {}".format(as_ints.nuclear_repulsion_energy()))
+    print("  Reference energy: {}".format(hf_energy))
 
     # Build a list of determinants
     orblist = [i for i in range(nmo)]
@@ -77,9 +71,9 @@ def test_sparse_ci():
             for b in bstr:
                 d.create_beta_bit(b)
                 sym = sym ^ mo_sym[b]
-            if (sym == wfn_symmetry):
+            if sym == wfn_symmetry:
                 dets.append(d)
-                print('  Determinant {} has symmetry {}'.format(d.str(nmo), sym))
+                print("  Determinant {} has symmetry {}".format(d.str(nmo), sym))
 
     # Build the Hamiltonian matrix using 'slater_rules'
     nfci = len(dets)
@@ -95,7 +89,7 @@ def test_sparse_ci():
     # Find the lowest eigenvalue
     efci = np.linalg.eigh(H)[0][0]
 
-    print('\n  FCI Energy: {}\n'.format(efci))
+    print("\n  FCI Energy: {}\n".format(efci))
 
     assert efci == pytest.approx(ref_fci, 1.0e-9)
 

--- a/tests/pytest/sparse_ci/test_sparse_ci2.py
+++ b/tests/pytest/sparse_ci/test_sparse_ci2.py
@@ -17,31 +17,26 @@ def test_sparse_ci2():
     # need to clean the options otherwise this job will interfere
     forte.clean_options()
 
-    h2o = psi4.geometry("""
+    h2o = psi4.geometry(
+        """
      He
      He 1 1.0
-    """)
+    """
+    )
 
-    psi4.set_options({'basis': 'cc-pVDZ'})
-    _, wfn = psi4.energy('scf', return_wfn=True)
+    psi4.set_options({"basis": "cc-pVDZ"})
+    _, wfn = psi4.energy("scf", return_wfn=True)
     na = wfn.nalpha()
     nb = wfn.nbeta()
     nirrep = wfn.nirrep()
     wfn_symmetry = 0
 
-    psi4_options = psi4.core.get_options()
-    psi4_options.set_current_module('FORTE')
-    forte_options.get_options_from_psi4(psi4_options)
+    # Make the integrals
+    data = forte.modules.ObjectsUtilPsi4().run()
+    as_ints = data.as_ints
 
-    # Setup forte and prepare the active space integral class
-    nmopi = wfn.nmopi()
-    point_group = wfn.molecule().point_group().symbol()
-    mo_space_info = forte.make_mo_space_info(nmopi, point_group, forte_options)
-    ints = forte.make_ints_from_psi4(wfn, forte_options, mo_space_info)
-    as_ints = forte.make_active_space_ints(mo_space_info, ints, 'ACTIVE', ['RESTRICTED_DOCC'])
-
-    print('\n\n  => Sparse FCI Test <=')
-    print('  Number of irreps: {}'.format(nirrep))
+    print("\n\n  => Sparse FCI Test <=")
+    print("  Number of irreps: {}".format(nirrep))
     nmo = wfn.nmo()
     nmopi = [wfn.nmopi()[h] for h in range(nirrep)]
     nmopi_str = [str(wfn.nmopi()[h]) for h in range(nirrep)]
@@ -50,18 +45,18 @@ def test_sparse_ci2():
         for i in range(nmopi[h]):
             mo_sym.append(h)
 
-    print('  Number of orbitals per irreps: [{}]'.format(','.join(nmopi_str)))
-    print('  Symmetry of the MOs: ', mo_sym)
+    print("  Number of orbitals per irreps: [{}]".format(",".join(nmopi_str)))
+    print("  Symmetry of the MOs: ", mo_sym)
 
     hf_reference = forte.Determinant()
     hf_reference.create_alfa_bit(0)
     hf_reference.create_beta_bit(0)
-    print('  Hartree-Fock determinant: {}'.format(hf_reference.str(10)))
+    print("  Hartree-Fock determinant: {}".format(hf_reference.str(10)))
 
     # Compute the HF energy
     hf_energy = as_ints.nuclear_repulsion_energy() + as_ints.slater_rules(hf_reference, hf_reference)
-    print('  Nuclear repulsion energy: {}'.format(as_ints.nuclear_repulsion_energy()))
-    print('  Reference energy: {}'.format(hf_energy))
+    print("  Nuclear repulsion energy: {}".format(as_ints.nuclear_repulsion_energy()))
+    print("  Reference energy: {}".format(hf_energy))
 
     # Build a list of determinants
     orblist = [i for i in range(nmo)]
@@ -76,11 +71,11 @@ def test_sparse_ci2():
             for b in bstr:
                 d.create_beta_bit(b)
                 sym = sym ^ mo_sym[b]
-            if (sym == wfn_symmetry):
+            if sym == wfn_symmetry:
                 dets.append(d)
-                print('  Determinant {} has symmetry {}'.format(d.str(nmo), sym))
+                print("  Determinant {} has symmetry {}".format(d.str(nmo), sym))
 
-    print(f'\n  Size of the derminant basis: {len(dets)}')
+    print(f"\n  Size of the derminant basis: {len(dets)}")
 
     energy, evals, evecs, spin = forte.diag(dets, as_ints, 1, 1, "FULL")
 
@@ -88,7 +83,7 @@ def test_sparse_ci2():
 
     efci = energy[0] + as_ints.nuclear_repulsion_energy()
 
-    print('\n  FCI Energy: {}\n'.format(efci))
+    print("\n  FCI Energy: {}\n".format(efci))
 
     assert efci == pytest.approx(ref_fci, abs=1e-9)
 

--- a/tests/pytest/sparse_ci/test_sparse_operator2.py
+++ b/tests/pytest/sparse_ci/test_sparse_operator2.py
@@ -15,10 +15,10 @@ def test_sparse_operator2():
      H
      H 1 1.0
     """
-    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis='DZ', reference='RHF')
-    forte_objs = forte.utils.prepare_forte_objects(psi4_wfn, mo_spaces={})
+    scf_energy, psi4_wfn = forte.utils.psi4_scf(geom, basis="DZ", reference="RHF")
+    data = forte.modules.ObjectsUtilPsi4(ref_wnf=psi4_wfn).run()
 
-    as_ints = forte_objs['as_ints']
+    as_ints = data.as_ints  # forte_objs["as_ints"]
 
     ham_op = forte.SparseHamiltonian(as_ints)
 


### PR DESCRIPTION
## Description
This is a second attempt at creating a modular Python side code. The old `Node`-based codes is still around but will be soon be replaced by the `Module` system. This PR takes the more pragmatic approach of adapting current code, and slowly porting functionality to the `Module` system.

The new `Module` system works this way. The class `ForteData` holds the forte objects (`MOSpaceInfo`, etc.) and modules implement a function `run()` that takes a `ForteData` object and returns a new one, like this:

```
import forte
from forte.modules import HF, FCI, Ints, GraphVisualizer
from forte import ForteData

data = ForteData()

ints = Ints()
hf = HF(ints)
fci = FCI(hf)
fci.run(data)
```

## User Notes
- [x] Implement the `OptionsFactory` module (creates the option object)
- [x] Implement the `ActiveSpaceIntsFactory` module (creates an `ActiveSpaceIntegral` from forte objects)
- [x] Implement the `ObjectsFactoryFCIDUMP` module (create objects from a INTDUMP/FCIDUMP file)
- [x] Implement the `ObjectsFactoryPsi4` module (create objects from psi4)
- [x] Implements the `ObjectsUtilPsi4` module (one-line convenience function to create objects from psi4)
- [x] Implements the `Sequential` module (for tying up a sequence of modules)

## Checklist
- [x] Documented source code
- [x] Checked for redundant headers
- [x] Checked for consistency in the formatting of the output file
- [x] Ready to go!
