### PR TITLE
Convert header guards to use `#pragma once`

### DIFF
--- a/forte/attic/dwms_mrpt2.h
+++ b/forte/attic/dwms_mrpt2.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _dwms_mrpt2_h_
-#define _dwms_mrpt2_h_
+#pragma once
 
 #include "mrdsrg-spin-integrated/master_mrdsrg.h"
 
@@ -222,5 +221,3 @@ class DWMS_DSRGPT2 {
                       bool pass_process = false);
 };
 } // namespace forte
-
-#endif // DWMS_MRPT2_H

--- a/forte/attic/fci_mo.h
+++ b/forte/attic/fci_mo.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _fci_mo_h_
-#define _fci_mo_h_
+#pragma once
 
 #include <string>
 #include <tuple>
@@ -586,5 +585,3 @@ class FCI_MO : public ActiveSpaceMethod {
                                       const std::vector<std::vector<std::vector<bool>>>& string);
 };
 } // namespace forte
-
-#endif // _fci_mo_h_

--- a/forte/base_classes/active_space_method.h
+++ b/forte/base_classes/active_space_method.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _active_space_method_h_
-#define _active_space_method_h_
+#pragma once
 
 #include <vector>
 #include <unordered_set>
@@ -426,5 +425,3 @@ std::shared_ptr<ActiveSpaceMethod> make_active_space_method(
 //                                                    int max_rdm_level);
 
 } // namespace forte
-
-#endif // _active_space_method_h_

--- a/forte/base_classes/active_space_solver.h
+++ b/forte/base_classes/active_space_solver.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _active_space_solver_h_
-#define _active_space_solver_h_
+#pragma once 
 
 #include <map>
 #include <vector>
@@ -323,5 +322,3 @@ compute_average_state_energy(const std::map<StateInfo, std::vector<double>>& sta
                              const std::map<StateInfo, std::vector<double>>& state_weight_map);
 
 } // namespace forte
-
-#endif // _active_space_solver_h_

--- a/forte/base_classes/dynamic_correlation_solver.h
+++ b/forte/base_classes/dynamic_correlation_solver.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _dynamic_correlation_solver_h_
-#define _dynamic_correlation_solver_h_
+#pragma once 
 
 #include <map>
 #include <memory>
@@ -179,5 +178,3 @@ make_dynamic_correlation_solver(const std::string& type, std::shared_ptr<ForteOp
                                 std::shared_ptr<MOSpaceInfo> mo_space_info);
 
 } // namespace forte
-
-#endif // _dynamic_correlation_solver_h_

--- a/forte/base_classes/forte_options.h
+++ b/forte/base_classes/forte_options.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _forte_options_h_
-#define _forte_options_h_
+#pragma once 
 
 #include <pybind11/pybind11.h>
 
@@ -354,5 +353,3 @@ class ForteOptions {
     std::string group_ = "";
 };
 } // namespace forte
-
-#endif // _forte_options_h_

--- a/forte/base_classes/mo_space_info.h
+++ b/forte/base_classes/mo_space_info.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _mo_space_info_h_
-#define _mo_space_info_h_
+#pragma once 
 
 #include "psi4/libmints/dimension.h"
 
@@ -299,5 +298,3 @@ make_mo_space_info_from_map(const psi::Dimension& nmopi, const std::string& poin
                             const std::vector<size_t>& reorder);
 
 } // namespace forte
-
-#endif // _mo_space_info_h_

--- a/forte/base_classes/orbital_transform.h
+++ b/forte/base_classes/orbital_transform.h
@@ -1,5 +1,4 @@
-#ifndef _orbital_transform_h_
-#define _orbital_transform_h_
+#pragma once 
 
 namespace psi {
 class Matrix;
@@ -50,5 +49,3 @@ make_orbital_transformation(const std::string& type, std::shared_ptr<SCFInfo> sc
                             std::shared_ptr<MOSpaceInfo> mo_space_info);
 
 } // namespace forte
-
-#endif

--- a/forte/base_classes/rdms.h
+++ b/forte/base_classes/rdms.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _rdms_h_
-#define _rdms_h_
+#pragma once 
 
 #include <string>
 #include <vector>
@@ -456,5 +455,3 @@ class RDMsSpinFree : public RDMs {
     ambit::Tensor SF_G3_;
 };
 } // namespace forte
-
-#endif // _rdms_h_

--- a/forte/base_classes/scf_info.h
+++ b/forte/base_classes/scf_info.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _scf_info_h_
-#define _scf_info_h_
+#pragma once 
 
 #include "psi4/libmints/dimension.h"
 
@@ -87,5 +86,3 @@ class SCFInfo {
 };
 
 } // namespace forte
-
-#endif // _scf_info_h_

--- a/forte/base_classes/state_info.h
+++ b/forte/base_classes/state_info.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _state_info_h_
-#define _state_info_h_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -115,5 +114,3 @@ class StateInfo {
 StateInfo make_state_info_from_psi(std::shared_ptr<ForteOptions> options);
 
 } // namespace forte
-
-#endif // _state_info_h_

--- a/forte/casscf/casscf.h
+++ b/forte/casscf/casscf.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _casscf_h_
-#define _casscf_h_
+#pragma once
 
 #include <map>
 
@@ -255,5 +254,3 @@ make_casscf(const std::map<StateInfo, std::vector<double>>& state_weight_map,
             std::shared_ptr<MOSpaceInfo> mo_space_info, std::shared_ptr<ForteIntegrals> ints);
 
 } // namespace forte
-
-#endif // _casscf_h_

--- a/forte/casscf/casscf_orb_grad.h
+++ b/forte/casscf/casscf_orb_grad.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _casscf_orb_grad_h_
-#define _casscf_orb_grad_h_
+#pragma once
 
 #include <map>
 #include <unordered_map>
@@ -370,5 +369,3 @@ class CASSCF_ORB_GRAD {
     double numerical_zero_ = 1.0e-15;
 };
 } // namespace forte
-
-#endif // _casscf_orb_grad_h_

--- a/forte/casscf/cpscf.h
+++ b/forte/casscf/cpscf.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _cpscf_h_
-#define _cpscf_h_
+#pragma once
 
 #include "psi4/libfock/jk.h"
 #include "psi4/libmints/matrix.h"
@@ -132,5 +131,3 @@ class CPSCF_SOLVER {
     CPSCF cpscf_;
 };
 } // namespace forte
-
-#endif // _cpscf_h_

--- a/forte/casscf/mcscf_2step.h
+++ b/forte/casscf/mcscf_2step.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _mcscf_2step_h_
-#define _mcscf_2step_h_
+#pragma once
 
 #include <vector>
 #include <string>
@@ -182,5 +181,3 @@ make_mcscf_two_step(std::shared_ptr<ActiveSpaceSolver> as_solver,
                     std::shared_ptr<ForteIntegrals> ints);
 
 } // namespace forte
-
-#endif // _mcscf_2step_h_

--- a/forte/ci_ex_states/excited_state_solver.h
+++ b/forte/ci_ex_states/excited_state_solver.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _excited_state_solver_h_
-#define _excited_state_solver_h_
+#pragma once
 
 #include "base_classes/active_space_method.h"
 #include "base_classes/rdms.h"
@@ -137,4 +136,4 @@ class ExcitedStateSolver : public ActiveSpaceMethod {
                                        int max_rdm_level, RDMsType rdm_type);
 };
 } // namespace forte
-#endif // _excited_state_solver_h_
+  

--- a/forte/ci_rdm/ci_rdms.h
+++ b/forte/ci_rdm/ci_rdms.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _ci_rdms_h_
-#define _ci_rdms_h_
+#pragma once
 
 #include <functional>
 
@@ -244,5 +243,3 @@ class CI_RDMS {
                  std::vector<double>& tprdm_aab, std::vector<double>& tprdm_abb);
 };
 } // namespace forte
-
-#endif // _ci_rdms_h_

--- a/forte/dmrg/dmrgscf.h
+++ b/forte/dmrg/dmrgscf.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef DMRG_H
-#define DMRG_H
+#pragma once
 
 #include "psi4/libfock/jk.h"
 #include "psi4/libtrans/mospace.h"
@@ -119,5 +118,3 @@ class DMRGSCF : public ActiveSpaceMethod {
                               std::shared_ptr<psi::Matrix> target);
 };
 } // namespace forte
-
-#endif // DMRG_H

--- a/forte/dmrg/dmrgsolver.h
+++ b/forte/dmrg/dmrgsolver.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _dmrgsolver_h_
-#define _dmrgsolver_h_
+#pragma once
 
 #include <filesystem>
 
@@ -146,4 +145,3 @@ class DMRGSolver : public ActiveSpaceMethod {
                                             const int max_rdm_level, RDMsType rdm_type);
 };
 } // namespace forte
-#endif // _dmrgsolver_h_

--- a/forte/external/external_active_space_method.h
+++ b/forte/external/external_active_space_method.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _external_active_space_method_h_
-#define _external_active_space_method_h_
+#pragma once
 
 #include "base_classes/active_space_method.h"
 
@@ -107,5 +106,3 @@ class ExternalActiveSpaceMethod : public ActiveSpaceMethod {
 };
 
 } // namespace forte
-
-#endif // _external_active_space_method_h_

--- a/forte/fci/fci_string_lists.h
+++ b/forte/fci/fci_string_lists.h
@@ -26,6 +26,8 @@
  * @END LICENSE
  */
 
+#pragma once
+
 #ifndef _string_lists_
 #define _string_lists_
 

--- a/forte/fci/fci_string_lists.h
+++ b/forte/fci/fci_string_lists.h
@@ -28,9 +28,6 @@
 
 #pragma once
 
-#ifndef _string_lists_
-#define _string_lists_
-
 #include "psi4/libmints/dimension.h"
 
 #include <map>
@@ -273,5 +270,3 @@ class FCIStringLists {
                    int s);
 };
 } // namespace forte
-
-#endif // _string_lists_

--- a/forte/forte-def.h
+++ b/forte/forte-def.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _forte_def_h_
-#define _forte_def_h_
+#pragma once
 
 // Define OPENMP functions in case they are not available
 #ifdef _OPENMP
@@ -37,5 +36,3 @@
 #define omp_get_thread_num() 0
 #define omp_get_num_threads() 1
 #endif
-
-#endif // _forte_def_h_

--- a/forte/forte.h
+++ b/forte/forte.h
@@ -26,6 +26,8 @@
  * @END LICENSE
  */
 
+#pragma once
+
 #include "base_classes/forte_options.h"
 
 namespace forte {

--- a/forte/gradient_tpdm/backtransform_tpdm.h
+++ b/forte/gradient_tpdm/backtransform_tpdm.h
@@ -25,8 +25,7 @@
  *
  */
 
-#ifndef _backtransform_tpdm_h_
-#define _backtransform_tpdm_h_
+#pragma once
 
 #include <psi4/libtrans/integraltransform.h>
 
@@ -104,4 +103,3 @@ class TPDMBackTransform : public IntegralTransform {
 
 } // namespace psi
 
-#endif

--- a/forte/helpers/blockedtensorfactory.h
+++ b/forte/helpers/blockedtensorfactory.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef BLOCKEDTENSORFACTORY_H
-#define BLOCKEDTENSORFACTORY_H
+#pragma once
 
 /// A class used to create BlockedTensors similar
 /// to matrix factory.
@@ -119,5 +118,3 @@ class BlockedTensorFactory {
     std::map<std::string, std::vector<size_t>> get_mo_to_index() { return molabel_to_index_; }
 };
 } // namespace forte
-
-#endif // BLOCKEDTENSORFACTORY_H

--- a/forte/helpers/combinatorial.h
+++ b/forte/helpers/combinatorial.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _combinatorial_h_
-#define _combinatorial_h_
+#pragma once
 
 #include <cstddef>
 #include <vector>
@@ -48,5 +47,3 @@ namespace forte {
 int permutation_parity(const std::vector<size_t>& p);
 
 } // namespace forte
-
-#endif // _combinatorial_h_

--- a/forte/helpers/cube_file.h
+++ b/forte/helpers/cube_file.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _cube_file_h_
-#define _cube_file_h_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -134,5 +133,3 @@ class CubeFile {
 };
 
 } // namespace forte
-
-#endif // _cube_file_h_

--- a/forte/helpers/determinant_helpers.h
+++ b/forte/helpers/determinant_helpers.h
@@ -1,5 +1,4 @@
-#ifndef _determinant_helpers_h_
-#define _determinant_helpers_h_
+#pragma once
 
 #include <vector>
 
@@ -26,5 +25,3 @@ std::shared_ptr<psi::Matrix> make_hamiltonian_matrix(const std::vector<Determina
                                                      std::shared_ptr<ActiveSpaceIntegrals> as_ints);
 
 } // namespace forte
-
-#endif // _determinant_helpers_h_

--- a/forte/helpers/determinant_helpers.h
+++ b/forte/helpers/determinant_helpers.h
@@ -1,3 +1,31 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Forte: an open-source plugin to Psi4 (https://github.com/psi4/psi4)
+ * that implements a variety of quantum chemistry methods for strongly
+ * correlated electrons.
+ *
+ * Copyright (c) 2012-2023 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ * @END LICENSE
+ */
+
 #pragma once
 
 #include <vector>

--- a/forte/helpers/disk_io.h
+++ b/forte/helpers/disk_io.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _disk_io_h_
-#define _disk_io_h_
+#pragma once
 
 #include <algorithm>
 #include <chrono>
@@ -106,5 +105,3 @@ void read_psi_matrix(const std::string& filename, psi::Matrix& mat);
 // void delete_disk_BT(const std::string& filename);
 
 } // namespace forte
-
-#endif // _disk_io_h_

--- a/forte/helpers/hash_vector.h
+++ b/forte/helpers/hash_vector.h
@@ -27,6 +27,7 @@
  */
 
 #pragma once
+
 #include <cstdint>
 #include <vector>
 #include <algorithm>
@@ -938,5 +939,3 @@ void merge(HashVector<Key, Hash>& hvec, std::vector<Value>& values,
         }
     }
 }
-
-#endif // _hash_vec_h_

--- a/forte/helpers/hash_vector.h
+++ b/forte/helpers/hash_vector.h
@@ -26,9 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _hash_vec_h_
-#define _hash_vec_h_
-
+#pragma once
 #include <cstdint>
 #include <vector>
 #include <algorithm>

--- a/forte/helpers/helpers.h
+++ b/forte/helpers/helpers.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _helpers_h_
-#define _helpers_h_
+#pragma once
 
 #include <algorithm>
 #include <chrono>
@@ -284,5 +283,3 @@ std::vector<std::vector<T>> cartesian_product(const std::vector<std::vector<T>>&
 } // namespace math
 
 } // namespace forte
-
-#endif // _helpers_h_

--- a/forte/helpers/lbfgs/lbfgs.h
+++ b/forte/helpers/lbfgs/lbfgs.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _lbfgs_h_
-#define _lbfgs_h_
+#pragma once
 
 #include <functional>
 #include <vector>
@@ -152,4 +151,3 @@ class LBFGS {
     void resize(int m);
 };
 } // namespace forte
-#endif // LBFGS_H

--- a/forte/helpers/lbfgs/lbfgs_param.h
+++ b/forte/helpers/lbfgs/lbfgs_param.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _lbfgs_param_h_
-#define _lbfgs_param_h_
+#pragma once
 
 #include <stdexcept>
 
@@ -86,5 +85,3 @@ class LBFGS_PARAM {
     double c2;
 };
 } // namespace forte
-
-#endif // lbfgs_param_h

--- a/forte/helpers/lbfgs/rosenbrock.h
+++ b/forte/helpers/lbfgs/rosenbrock.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _rosenbrock_h_
-#define _rosenbrock_h_
+#pragma once
 
 #include "psi4/libmints/vector.h"
 
@@ -62,4 +61,3 @@ class ROSENBROCK {
 /// Test L-BFGS on Rosenbrock function
 double test_lbfgs_rosenbrock(int n, int h0_freq = 0);
 } // namespace forte
-#endif // _rosenbrock_h_

--- a/forte/helpers/memory.h
+++ b/forte/helpers/memory.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _memory_h_
-#define _memory_h_
+#pragma once
 
 namespace forte {
 
@@ -62,5 +61,3 @@ template <typename T> std::pair<double, std::string> to_xb2(size_t nele) {
 }
 
 } // namespace forte
-
-#endif // _memory_h_

--- a/forte/helpers/spinorbital_helpers.h
+++ b/forte/helpers/spinorbital_helpers.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _spinorbital_helpers_h_
-#define _spinorbital_helpers_h_
+#pragma once
 
 #include <vector>
 #include "base_classes/rdms.h"
@@ -94,5 +93,3 @@ std::vector<ambit::Tensor> spinorbital_rdms(std::shared_ptr<RDMs> rdms);
 std::vector<ambit::Tensor> spinorbital_cumulants(std::shared_ptr<RDMs> rdms);
 
 } // namespace forte
-
-#endif // _spinorbital_helpers_h_

--- a/forte/helpers/string_algorithms.h
+++ b/forte/helpers/string_algorithms.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _string_algorithms_h_
-#define _string_algorithms_h_
+#pragma once
 
 #include <sstream>
 #include <string>
@@ -62,5 +61,3 @@ std::vector<std::string>::const_iterator find_case_insensitive(const std::string
                                                                const std::vector<std::string>& vec);
 
 } // namespace forte
-
-#endif // _string_algorithms_h_

--- a/forte/helpers/symmetry.h
+++ b/forte/helpers/symmetry.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _symmetry_h_
-#define _symmetry_h_
+#pragma once
 
 #include <map>
 #include <string>
@@ -76,4 +75,3 @@ class Symmetry {
 };
 
 } // namespace forte
-#endif

--- a/forte/helpers/threading.h
+++ b/forte/helpers/threading.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _threading_h_
-#define _threading_h_
+#pragma once
 
 namespace forte {
 
@@ -39,5 +38,3 @@ namespace forte {
 std::pair<size_t, size_t> thread_range(size_t n, size_t num_thread, size_t tid);
 
 } // namespace forte
-
-#endif

--- a/forte/helpers/timer.h
+++ b/forte/helpers/timer.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _helpers_timer_h_
-#define _helpers_timer_h_
+#pragma once
 
 #include "psi4/libqt/qt.h"
 
@@ -122,5 +121,3 @@ class parallel_timer {
     bool running_ = true;
 };
 } // namespace forte
-
-#endif // _helpers_timer_h_

--- a/forte/integrals/active_space_integrals.h
+++ b/forte/integrals/active_space_integrals.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _active_space_integrals_
-#define _active_space_integrals_
+#pragma once
 
 #include "integrals/integrals.h"
 #include "sparse_ci/determinant.h"
@@ -225,5 +224,3 @@ make_active_space_ints(std::shared_ptr<forte::MOSpaceInfo> mo_space_info,
                        const std::vector<std::string>& core_spaces);
 
 } // namespace forte
-
-#endif // _active_space_integrals_

--- a/forte/integrals/cholesky_integrals.h
+++ b/forte/integrals/cholesky_integrals.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _cholesky_integrals_h_
-#define _cholesky_integrals_h_
+#pragma once
 
 #include "integrals.h"
 
@@ -102,5 +101,3 @@ class CholeskyIntegrals : public Psi4Integrals {
 };
 
 } // namespace forte
-
-#endif // _cholesky_integrals_h_

--- a/forte/integrals/conventional_integrals.h
+++ b/forte/integrals/conventional_integrals.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _conventional_integrals_h_
-#define _conventional_integrals_h_
+#pragma once
 
 #include "integrals.h"
 
@@ -88,5 +87,3 @@ class ConventionalIntegrals : public Psi4Integrals {
 };
 
 } // namespace forte
-
-#endif // _conventional_integrals_h_

--- a/forte/integrals/custom_integrals.h
+++ b/forte/integrals/custom_integrals.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _custom_integrals_h_
-#define _custom_integrals_h_
+#pragma once
 
 #include "integrals.h"
 
@@ -144,5 +143,3 @@ class CustomIntegrals : public ForteIntegrals {
 };
 
 } // namespace forte
-
-#endif // _integrals_h_

--- a/forte/integrals/df_integrals.h
+++ b/forte/integrals/df_integrals.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _df_integrals_h_
-#define _df_integrals_h_
+#pragma once
 
 #include "integrals.h"
 
@@ -94,5 +93,3 @@ class DFIntegrals : public Psi4Integrals {
 };
 
 } // namespace forte
-
-#endif // _df_integrals_h_

--- a/forte/integrals/diskdf_integrals.h
+++ b/forte/integrals/diskdf_integrals.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _diskdf_integrals_h_
-#define _diskdf_integrals_h_
+#pragma once
 
 #include "psi4/lib3index/dfhelper.h"
 #include "integrals.h"
@@ -98,5 +97,3 @@ class DISKDFIntegrals : public Psi4Integrals {
 };
 
 } // namespace forte
-
-#endif // _diskdf_integrals_h_

--- a/forte/integrals/distribute_df_integrals.h
+++ b/forte/integrals/distribute_df_integrals.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _conventional_integrals_h_
-#define _conventional_integrals_h_
+#pragma once
 
 #include "integrals.h"
 
@@ -107,5 +106,3 @@ class DistDFIntegrals : public Psi4Integrals {
 #endif
 
 } // namespace forte
-
-#endif // _conventional_integrals_h_

--- a/forte/integrals/integrals.h
+++ b/forte/integrals/integrals.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _integrals_h_
-#define _integrals_h_
+#pragma once
 
 #include <vector>
 
@@ -650,5 +649,3 @@ class Psi4Integrals : public ForteIntegrals {
 };
 
 } // namespace forte
-
-#endif // _integrals_h_

--- a/forte/integrals/make_integrals.h
+++ b/forte/integrals/make_integrals.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _make_integrals_h_
-#define _make_integrals_h_
+#pragma once
 
 namespace forte {
 /**
@@ -53,5 +52,3 @@ make_custom_forte_integrals(std::shared_ptr<ForteOptions> options,
                             const std::vector<double>& tei_bb);
 
 } // namespace forte
-
-#endif // _make_integrals_h_

--- a/forte/integrals/one_body_integrals.h
+++ b/forte/integrals/one_body_integrals.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _one_body_integrals_
-#define _one_body_integrals_
+#pragma once
 
 #include <vector>
 
@@ -256,5 +255,3 @@ class ActiveMultipoleIntegrals {
     void _test_tensor_dims(ambit::Tensor T);
 };
 } // namespace forte
-
-#endif // _one_body_integrals_

--- a/forte/integrals/paralleldfmo.h
+++ b/forte/integrals/paralleldfmo.h
@@ -26,6 +26,8 @@
  * @END LICENSE
  */
 
+#pragma once
+
 #include "psi4/libmints/basisset.h"
 #include "psi4/psi4-dec.h"
 
@@ -57,5 +59,4 @@ class ParallelDFMO {
     size_t memory_;
     size_t nmo_;
 };
-}
-}
+} // namespace forte

--- a/forte/mrdsrg-helper/cci_solver.cc
+++ b/forte/mrdsrg-helper/cci_solver.cc
@@ -1,3 +1,31 @@
+/*
+ * @BEGIN LICENSE
+ *
+ * Forte: an open-source plugin to Psi4 (https://github.com/psi4/psi4)
+ * that implements a variety of quantum chemistry methods for strongly
+ * correlated electrons.
+ *
+ * Copyright (c) 2012-2023 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ * @END LICENSE
+ */
+
 #include <numeric>
 
 #include "psi4/libmints/molecule.h"
@@ -41,13 +69,12 @@ void ContractedCISolver::compute_Heff() {
 
     auto method_vec = as_solver_->get_method_vec();
     int i_state = 0;
-    for (const auto& state_weights: as_solver_->get_state_weights_list()) {
+    for (const auto& state_weights : as_solver_->get_state_weights_list()) {
         const auto& state = state_weights.first;
         const auto& weights = state_weights.second;
         auto method = method_vec[i_state];
         int nroots = weights.size();
         std::string state_name = state.multiplicity_label() + " " + state.irrep_label();
-
 
         // form the effective Hamiltonian (assume Hermitian)
         print_h2("Building Effective Hamiltonian for " + state_name);

--- a/forte/mrdsrg-helper/cci_solver.h
+++ b/forte/mrdsrg-helper/cci_solver.h
@@ -1,5 +1,32 @@
-#ifndef _cci_solver_h_
-#define _cci_solver_h_
+/*
+ * @BEGIN LICENSE
+ *
+ * Forte: an open-source plugin to Psi4 (https://github.com/psi4/psi4)
+ * that implements a variety of quantum chemistry methods for strongly
+ * correlated electrons.
+ *
+ * Copyright (c) 2012-2023 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ * @END LICENSE
+ */
+
+#pragma once
 
 #include <vector>
 #include "psi4/libmints/matrix.h"
@@ -23,8 +50,8 @@ class ContractedCISolver {
      * @param as_ints active space integrals
      */
     ContractedCISolver(std::shared_ptr<ActiveSpaceSolver> as_solver,
-                       std::shared_ptr<ActiveSpaceIntegrals> as_ints,
-                       int max_rdm_level, int max_body);
+                       std::shared_ptr<ActiveSpaceIntegrals> as_ints, int max_rdm_level,
+                       int max_body);
 
     /// TODO: the as_ints should handle 3-body integrals, as_ints may not be Hermitian
 
@@ -58,5 +85,4 @@ class ContractedCISolver {
     /// eigen vectors
     std::vector<psi::Matrix> evecs_;
 };
-}
-#endif // _cci_solver_h_
+} // namespace forte

--- a/forte/mrdsrg-helper/dsrg_mem.h
+++ b/forte/mrdsrg-helper/dsrg_mem.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _dsrg_mem_h_
-#define _dsrg_mem_h_
+#pragma once
 
 #include <vector>
 #include <string>
@@ -93,5 +92,3 @@ class DSRG_MEM {
     std::map<char, size_t> label_to_size_;
 };
 } // namespace forte
-
-#endif // _dsrg_mem_h_

--- a/forte/mrdsrg-helper/dsrg_source.h
+++ b/forte/mrdsrg-helper/dsrg_source.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _dsrg_source_h_
-#define _dsrg_source_h_
+#pragma once
 
 #include <cmath>
 #include <stdexcept>
@@ -199,5 +198,3 @@ class MP2_SOURCE : public DSRG_SOURCE {
     virtual double compute_renormalized_denominator(const double& D) { return 1.0 / D; }
 };
 } // namespace forte
-
-#endif // DSRG_SOURCE_H

--- a/forte/mrdsrg-helper/dsrg_tensors.h
+++ b/forte/mrdsrg-helper/dsrg_tensors.h
@@ -1,9 +1,35 @@
-#ifndef _dsrg_tensors_h_
-#define _dsrg_tensors_h_
+/*
+ * @BEGIN LICENSE
+ *
+ * Forte: an open-source plugin to Psi4 (https://github.com/psi4/psi4)
+ * that implements a variety of quantum chemistry methods for strongly
+ * correlated electrons.
+ *
+ * Copyright (c) 2012-2023 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ * @END LICENSE
+ */
+
+#pragma once
 
 #include "ambit/tensor.h"
 #include "ambit/blocked_tensor.h"
-
 
 namespace forte {
 
@@ -26,6 +52,4 @@ struct dsrgHeff {
     ambit::Tensor H2aa, H2ab, H2bb;
     ambit::Tensor H3aaa, H3aab, H3abb, H3bbb;
 };
-}
-
-#endif // DSRG_TENSORS_H
+} // namespace forte

--- a/forte/mrdsrg-helper/dsrg_time.h
+++ b/forte/mrdsrg-helper/dsrg_time.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _dsrg_time_h_
-#define _dsrg_time_h_
+#pragma once
 
 #include <vector>
 #include <string>
@@ -91,5 +90,3 @@ class DSRG_TIME {
     bool test_code(const std::string& code);
 };
 } // namespace forte
-
-#endif // DSRG_TIME_H

--- a/forte/mrdsrg-helper/dsrg_transformed.h
+++ b/forte/mrdsrg-helper/dsrg_transformed.h
@@ -1,5 +1,32 @@
-#ifndef _DSRG_TRANSFORMED_H_
-#define _DSRG_TRANSFORMED_H_
+/*
+ * @BEGIN LICENSE
+ *
+ * Forte: an open-source plugin to Psi4 (https://github.com/psi4/psi4)
+ * that implements a variety of quantum chemistry methods for strongly
+ * correlated electrons.
+ *
+ * Copyright (c) 2012-2023 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ * @END LICENSE
+ */
+
+#pragma once
 
 #include "ambit/tensor.h"
 
@@ -32,4 +59,3 @@ class DressedQuantity {
     ambit::Tensor bbb_;
 };
 } // namespace forte
-#endif // DSRG_TRANSFORMED_H

--- a/forte/mrdsrg-helper/run_dsrg.h
+++ b/forte/mrdsrg-helper/run_dsrg.h
@@ -1,5 +1,32 @@
-#ifndef _run_dsrg_h_
-#define _run_dsrg_h_
+/*
+ * @BEGIN LICENSE
+ *
+ * Forte: an open-source plugin to Psi4 (https://github.com/psi4/psi4)
+ * that implements a variety of quantum chemistry methods for strongly
+ * correlated electrons.
+ *
+ * Copyright (c) 2012-2023 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ * @END LICENSE
+ */
+
+#pragma once
 
 #include <memory>
 
@@ -75,5 +102,3 @@ std::unique_ptr<SADSRG> make_sadsrg_method(std::shared_ptr<RDMs> rdms,
                                            std::shared_ptr<MOSpaceInfo> mo_space_info);
 
 } // namespace forte
-
-#endif // RUN_DSRG_H

--- a/forte/mrdsrg-so/mrdsrg_so.h
+++ b/forte/mrdsrg-so/mrdsrg_so.h
@@ -288,5 +288,3 @@ class MRDSRG_SO : public DynamicCorrelationSolver {
     double frozen_core_energy;
 };
 } // namespace forte
-
-#endif // _mrdsrg_so_h_

--- a/forte/mrdsrg-so/mrdsrg_so.h
+++ b/forte/mrdsrg-so/mrdsrg_so.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _mrdsrg_so_h_
-#define _mrdsrg_so_h_
+#pragma once
 
 #include <cmath>
 

--- a/forte/mrdsrg-so/so-mrdsrg.h
+++ b/forte/mrdsrg-so/so-mrdsrg.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _so_mrdsrg_h_
-#define _so_mrdsrg_h_
+#pragma once
 
 #include <fstream>
 

--- a/forte/mrdsrg-so/so-mrdsrg.h
+++ b/forte/mrdsrg-so/so-mrdsrg.h
@@ -212,4 +212,3 @@ class SOMRDSRG : public DynamicCorrelationSolver {
 };
 } // namespace forte
 
-#endif // _so_mrdsrg_h_

--- a/forte/mrdsrg-spin-adapted/dsrg_mrpt.h
+++ b/forte/mrdsrg-spin-adapted/dsrg_mrpt.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _dsrg_mrpt_h_
-#define _dsrg_mrpt_h_
+#pragma once
 
 #include <cmath>
 
@@ -336,5 +335,3 @@ class DSRG_MRPT : public DynamicCorrelationSolver {
     void print_cumulant_summary();
 };
 } // namespace forte
-
-#endif // DSRG_MRPT_H

--- a/forte/mrdsrg-spin-adapted/sa_dsrgpt.h
+++ b/forte/mrdsrg-spin-adapted/sa_dsrgpt.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _sa_dsrgpt_h_
-#define _sa_dsrgpt_h_
+#pragma once
 
 #include "sadsrg.h"
 
@@ -87,5 +86,3 @@ class SA_DSRGPT : public SADSRG {
     void renormalize_integrals(bool add);
 };
 } // namespace forte
-
-#endif // _sa_dsrgpt_h_

--- a/forte/mrdsrg-spin-adapted/sa_mrdsrg.h
+++ b/forte/mrdsrg-spin-adapted/sa_mrdsrg.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _sa_mrdsrg_h_
-#define _sa_mrdsrg_h_
+#pragma once
 
 #include "psi4/libdiis/diismanager.h"
 #include "psi4/libpsi4util/PsiOutStream.h"
@@ -198,5 +197,3 @@ class SA_MRDSRG : public SADSRG {
     void compute_mbar_ldsrg2(const ambit::BlockedTensor& M, int max_level, int ind);
 };
 } // namespace forte
-
-#endif // _sa_mrdsrg_h_

--- a/forte/mrdsrg-spin-adapted/sa_mrpt2.h
+++ b/forte/mrdsrg-spin-adapted/sa_mrpt2.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _sa_mrpt2_h_
-#define _sa_mrpt2_h_
+#pragma once
 
 #include "sa_dsrgpt.h"
 
@@ -136,5 +135,3 @@ class SA_MRPT2 : public SA_DSRGPT {
                                                               size_t max_size);
 };
 } // namespace forte
-
-#endif // _sa_mrpt2_h_

--- a/forte/mrdsrg-spin-adapted/sa_mrpt3.h
+++ b/forte/mrdsrg-spin-adapted/sa_mrpt3.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _sa_mrpt3_h_
-#define _sa_mrpt3_h_
+#pragma once
 
 #include "sa_dsrgpt.h"
 
@@ -85,5 +84,3 @@ class SA_MRPT3 : public SA_DSRGPT {
                             const std::vector<int>& max_levels) override;
 };
 } // namespace forte
-
-#endif // _sa_mrpt3_h_

--- a/forte/mrdsrg-spin-adapted/sadsrg.h
+++ b/forte/mrdsrg-spin-adapted/sadsrg.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _sadsrg_h_
-#define _sadsrg_h_
+#pragma once
 
 #include "ambit/blocked_tensor.h"
 
@@ -469,7 +468,7 @@ class SADSRG : public DynamicCorrelationSolver {
     /// Print the contents with padding: <text> <padding with dots>
     void print_contents(const std::string& str, size_t size = 45);
     /// Print done and timing
-    void print_done(double t, const std::string& done="Done");
+    void print_done(double t, const std::string& done = "Done");
 
     // ==> common amplitudes analysis and printing <==
 
@@ -502,5 +501,3 @@ class SADSRG : public DynamicCorrelationSolver {
     }
 };
 } // namespace forte
-
-#endif // SADSRG_H

--- a/forte/mrdsrg-spin-integrated/dsrg_mrpt2.h
+++ b/forte/mrdsrg-spin-integrated/dsrg_mrpt2.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _dsrg_mrpt2_h_
-#define _dsrg_mrpt2_h_
+#pragma once
 
 #include <iostream>
 #include <fstream>
@@ -598,5 +597,3 @@ class DSRG_MRPT2 : public MASTER_DSRG {
                      ambit::Tensor& L3bbb);
 };
 } // namespace forte
-
-#endif // _dsrg_mrpt2_h_

--- a/forte/mrdsrg-spin-integrated/dsrg_mrpt3.h
+++ b/forte/mrdsrg-spin-integrated/dsrg_mrpt3.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _dsrg_mrpt3_h_
-#define _dsrg_mrpt3_h_
+#pragma once
 
 #include "master_mrdsrg.h"
 
@@ -274,5 +273,3 @@ class DSRG_MRPT3 : public MASTER_DSRG {
     std::array<double, 3> Mbar0_pt2c_;
 };
 } // namespace forte
-
-#endif // _dsrg_mrpt3_h_

--- a/forte/mrdsrg-spin-integrated/master_mrdsrg.h
+++ b/forte/mrdsrg-spin-integrated/master_mrdsrg.h
@@ -1,5 +1,4 @@
-#ifndef _master_mrdsrg_h_
-#define _master_mrdsrg_h_
+#pragma once
 
 #include "ambit/blocked_tensor.h"
 
@@ -487,5 +486,3 @@ class MASTER_DSRG : public DynamicCorrelationSolver {
     void H2_G2_C2(BlockedTensor& H2, BlockedTensor& G2, const double& alpha, BlockedTensor& C2);
 };
 } // namespace forte
-
-#endif // MASTER_MRDSRG_H

--- a/forte/mrdsrg-spin-integrated/mcsrgpt2_mo.h
+++ b/forte/mrdsrg-spin-integrated/mcsrgpt2_mo.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _mcsrgpt2_mo_h_
-#define _mcsrgpt2_mo_h_
+#pragma once
 
 #include <cmath>
 #include <vector>
@@ -312,5 +311,3 @@ class MCSRGPT2_MO {
     }
 };
 } // namespace forte
-
-#endif // _mcsrgpt2_mo_h_

--- a/forte/mrdsrg-spin-integrated/mrdsrg.h
+++ b/forte/mrdsrg-spin-integrated/mrdsrg.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _mrdsrg_h_
-#define _mrdsrg_h_
+#pragma once
 
 #include "master_mrdsrg.h"
 
@@ -447,5 +446,3 @@ class MRSRG_Print {
     std::vector<double> energies_;
 };
 } // namespace forte
-
-#endif // _mrdsrg_h_

--- a/forte/mrdsrg-spin-integrated/three_dsrg_mrpt2.h
+++ b/forte/mrdsrg-spin-integrated/three_dsrg_mrpt2.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _three_dsrg_mrpt2_h_
-#define _three_dsrg_mrpt2_h_
+#pragma once
 
 #include "master_mrdsrg.h"
 
@@ -267,5 +266,3 @@ class THREE_DSRG_MRPT2 : public MASTER_DSRG {
     static bool have_mpi_;
 };
 } // namespace forte
-
-#endif // _three_dsrg_mrpt2_h_

--- a/forte/orbital-helpers/ao_helper.h
+++ b/forte/orbital-helpers/ao_helper.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _atomic_orbital_h_
-#define _atomic_orbital_h_
+#pragma once
 
 #include "psi4/psi4-dec.h"
 #include "psi4/lib3index/denominator.h"
@@ -81,5 +80,3 @@ class AtomicOrbitalHelper {
     ~AtomicOrbitalHelper();
 };
 } // namespace forte
-
-#endif

--- a/forte/orbital-helpers/aosubspace.h
+++ b/forte/orbital-helpers/aosubspace.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _aosubspace_h_
-#define _aosubspace_h_
+#pragma once
 
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/basisset.h"
@@ -247,5 +246,3 @@ std::shared_ptr<psi::Matrix> make_aosubspace_projector(psi::SharedWavefunction w
                                                        std::shared_ptr<ForteOptions> options,
                                                        const pybind11::dict& atom_normals);
 } // namespace forte
-
-#endif // _aosubspace_h_

--- a/forte/orbital-helpers/ci-no/ci-no.h
+++ b/forte/orbital-helpers/ci-no/ci-no.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _ci_no_h_
-#define _ci_no_h_
+#pragma once
 
 #include "psi4/psi4-dec.h"
 #include "psi4/libmints/molecule.h"
@@ -151,5 +150,3 @@ class CINO : public OrbitalTransform {
 };
 std::string dimension_to_string(psi::Dimension dim);
 } // namespace forte
-
-#endif // _ci_no_h_

--- a/forte/orbital-helpers/ci-no/mrci-no.h
+++ b/forte/orbital-helpers/ci-no/mrci-no.h
@@ -25,8 +25,7 @@
  *
  * @END LICENSE
  */
-#ifndef _mrci_no_h_
-#define _mrci_no_h_
+#pragma once
 
 #include "base_classes/orbital_transform.h"
 
@@ -139,5 +138,3 @@ class MRCINO : public OrbitalTransform {
             no_U);
 };
 } // namespace forte
-
-#endif // MRCISNO_H

--- a/forte/orbital-helpers/fragment_projector.h
+++ b/forte/orbital-helpers/fragment_projector.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _fragment_projector_h_
-#define _fragment_projector_h_
+#pragma once
 
 #include "psi4/libmints/molecule.h"
 #include "psi4/libmints/matrix.h"
@@ -93,4 +92,3 @@ std::pair<std::shared_ptr<psi::Matrix>, int>
 make_fragment_projector(psi::SharedWavefunction ref_wfn);
 
 } // namespace forte
-#endif // _fragment_projector_h_

--- a/forte/orbital-helpers/iao_builder.h
+++ b/forte/orbital-helpers/iao_builder.h
@@ -25,8 +25,7 @@
  * @END LICENSE
  */
 
-#ifndef IAO_BUILDER_H
-#define IAO_BUILDER_H
+#pragma once
 
 #include <map>
 
@@ -149,5 +148,3 @@ class IAOBuilder {
 };
 
 } // namespace forte
-
-#endif

--- a/forte/orbital-helpers/localize.h
+++ b/forte/orbital-helpers/localize.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _localize_h_
-#define _localize_h_
+#pragma once
 
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libmints/local.h"
@@ -66,5 +65,3 @@ class Localize : public OrbitalTransform {
     std::string local_method_;
 };
 } // namespace forte
-
-#endif

--- a/forte/orbital-helpers/mp2_nos.h
+++ b/forte/orbital-helpers/mp2_nos.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _mp2_nos_h_
-#define _mp2_nos_h_
+#pragma once
 
 #include "psi4/libmints/wavefunction.h"
 
@@ -99,5 +98,3 @@ class MP2_NOS : public OrbitalTransform {
     void compute_df_rmp2_1rdm_vv(ambit::BlockedTensor& D1);
 };
 } // namespace forte
-
-#endif // _mp2_nos_h_

--- a/forte/orbital-helpers/mrpt2_nos.h
+++ b/forte/orbital-helpers/mrpt2_nos.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _mrpt2_nos_h_
-#define _mrpt2_nos_h_
+#pragma once
 
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/vector.h"
@@ -65,5 +64,3 @@ class MRPT2_NOS : public OrbitalTransform {
     void suggest_active_space(const psi::Vector& D1c_evals, const psi::Vector& D1v_evals);
 };
 } // namespace forte
-
-#endif // _mrpt2_nos_h_

--- a/forte/orbital-helpers/orbital_embedding.h
+++ b/forte/orbital-helpers/orbital_embedding.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _orbital_embedding_h_
-#define _orbital_embedding_h_
+#pragma once
 
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/wavefunction.h"
@@ -46,5 +45,3 @@ std::shared_ptr<MOSpaceInfo> make_embedding(psi::SharedWavefunction ref_wfn,
                                             std::shared_ptr<MOSpaceInfo> mo_space_info);
 
 } // namespace forte
-
-#endif // _orbital_embedding_h_

--- a/forte/orbital-helpers/orbitaloptimizer.h
+++ b/forte/orbital-helpers/orbitaloptimizer.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _orbital_optimizer_h_
-#define _orbital_optimizer_h_
+#pragma once
 
 #include "ambit/blocked_tensor.h"
 #include "base_classes/rdms.h"
@@ -286,5 +285,3 @@ class PostCASSCFOrbitalOptimizer : public OrbitalOptimizer {
     virtual void form_fock_intermediates();
 };
 } // namespace forte
-
-#endif // _orbital_optimizer_h_

--- a/forte/orbital-helpers/pao_builder.h
+++ b/forte/orbital-helpers/pao_builder.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _pao_builder_h_
-#define _pao_builder_h_
+#pragma once
 
 #include "psi4/libmints/matrix.h"
 #include "psi4/libmints/basisset.h"
@@ -105,4 +104,3 @@ class PAObuilder {
 };
 
 } // namespace forte
-#endif // _pao_builder_h_

--- a/forte/orbital-helpers/semi_canonicalize.h
+++ b/forte/orbital-helpers/semi_canonicalize.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _semi_canonicalize_h_
-#define _semi_canonicalize_h_
+#pragma once
 
 #include <tuple>
 
@@ -150,5 +149,3 @@ class SemiCanonical {
     bool fix_orbital_success_;
 };
 } // namespace forte
-
-#endif // _semi_canonicalize_h_

--- a/forte/orbital-helpers/unpaired_density.h
+++ b/forte/orbital-helpers/unpaired_density.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _updensity_h_
-#define _updensity_h_
+#pragma once
 
 #include "psi4/libmints/wavefunction.h"
 #include "psi4/libmints/local.h"
@@ -57,5 +56,3 @@ class UPDensity {
     std::shared_ptr<psi::Matrix> Ubs_;
 };
 } // namespace forte
-
-#endif

--- a/forte/pci/pci.h
+++ b/forte/pci/pci.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _pci_h_
-#define _pci_h_
+#pragma once
 
 #include <fstream>
 #include <functional>
@@ -354,5 +353,3 @@ class ProjectorCI : public SelectedCIMethod {
     void sortHashVecByCoefficient(det_hashvec& dets_hashvec, std::vector<double>& C);
 };
 } // namespace forte
-
-#endif // _pci_h_

--- a/forte/pci/pci_sigma.h
+++ b/forte/pci/pci_sigma.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _pci_sigma_h_
-#define _pci_sigma_h_
+#pragma once
 
 #include "sparse_ci/sigma_vector.h"
 
@@ -142,4 +141,3 @@ class PCISigmaVector : public SigmaVector {
         const std::pair<double, double>& max_coupling);
 };
 } // namespace forte
-#endif // _pci_sigma_h_

--- a/forte/post_process/spin_corr.h
+++ b/forte/post_process/spin_corr.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _spin_corr_h_
-#define _spin_corr_h_
+#pragma once
 
 #include <fstream>
 #include <iomanip>

--- a/forte/post_process/spin_corr.h
+++ b/forte/post_process/spin_corr.h
@@ -76,5 +76,3 @@ void perform_spin_analysis(std::shared_ptr<RDMs> rdms, std::shared_ptr<ForteOpti
                            std::shared_ptr<ActiveSpaceIntegrals> as_ints);
 
 } // namespace forte
-
-#endif // _spin_corr_h_

--- a/forte/sci/aci.h
+++ b/forte/sci/aci.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _aci_h_
-#define _aci_h_
+#pragma once
 
 #include <fstream>
 #include <iomanip>
@@ -364,5 +363,3 @@ class AdaptiveCI : public SelectedCIMethod {
 };
 
 } // namespace forte
-
-#endif // _aci_h_

--- a/forte/sci/asci.h
+++ b/forte/sci/asci.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _as_ci_h_
-#define _as_ci_h_
+#pragma once
 
 #include "sci/sci.h"
 #include "sparse_ci/sparse_ci_solver.h"
@@ -186,5 +185,3 @@ class ASCI : public SelectedCIMethod {
 };
 
 } // namespace forte
-
-#endif // _as_ci_h_

--- a/forte/sci/detci.h
+++ b/forte/sci/detci.h
@@ -1,5 +1,32 @@
-#ifndef _detci_h_
-#define _detci_h_
+/*
+ * @BEGIN LICENSE
+ *
+ * Forte: an open-source plugin to Psi4 (https://github.com/psi4/psi4)
+ * that implements a variety of quantum chemistry methods for strongly
+ * correlated electrons.
+ *
+ * Copyright (c) 2012-2023 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ * @END LICENSE
+ */
+
+#pragma once
 
 #include "ci_rdm/ci_rdms.h"
 #include "base_classes/mo_space_info.h"
@@ -181,5 +208,3 @@ class DETCI : public ActiveSpaceMethod {
                            std::shared_ptr<psi::Vector> sigma) override;
 };
 } // namespace forte
-
-#endif // _detci_h_

--- a/forte/sci/mrpt2.h
+++ b/forte/sci/mrpt2.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _mrpt2_h_
-#define _mrpt2_h_
+#pragma once
 
 #include "base_classes/mo_space_info.h"
 #include "sparse_ci/determinant.h"
@@ -79,5 +78,3 @@ class MRPT2 {
     double energy_kernel(int bin, int nbin, int root);
 };
 } // namespace forte
-
-#endif // _mrpt2_h_

--- a/forte/sci/sci.h
+++ b/forte/sci/sci.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _sci_h_
-#define _sci_h_
+#pragma once
 
 #include <memory>
 #include <vector>
@@ -218,5 +217,3 @@ class SelectedCIMethod {
     ambit::Tensor trdm_bbb_;
 };
 } // namespace forte
-
-#endif // _sci_h_

--- a/forte/sci/tdci.h
+++ b/forte/sci/tdci.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _tdci_h_
-#define _tdci_h_
+#pragma once
 
 #include <fstream>
 #include <iomanip>
@@ -160,5 +159,3 @@ class TDCI {
 };
 
 } // namespace forte
-
-#endif // _tdci_h_

--- a/forte/sparse_ci/bitwise_operations.hpp
+++ b/forte/sparse_ci/bitwise_operations.hpp
@@ -1,5 +1,33 @@
-#ifndef _bitwise_operations_hpp_
-#define _bitwise_operations_hpp_
+/*
+ * @BEGIN LICENSE
+ *
+ * Forte: an open-source plugin to Psi4 (https://github.com/psi4/psi4)
+ * that implements a variety of quantum chemistry methods for strongly
+ * correlated electrons.
+ *
+ * Copyright (c) 2012-2023 by its authors (see COPYING, COPYING.LESSER,
+ * AUTHORS).
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ * @END LICENSE
+ */
+
+#pragma once
 
 #include <bit>
 #include <cstdint>
@@ -137,5 +165,3 @@ inline double ui64_sign_reverse(uint64_t x, int n) {
     mask = ui64_bit_count(mask);         // count bits in between
     return (mask % 2 == 0) ? 1.0 : -1.0; // compute sign
 }
-
-#endif // _bitwise_operations_hpp_

--- a/forte/sparse_ci/ci_reference.h
+++ b/forte/sparse_ci/ci_reference.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _ci_reference_h_
-#define _ci_reference_h_
+#pragma once
 
 #include "integrals/active_space_integrals.h"
 #include "sparse_ci/determinant.h"
@@ -177,5 +176,3 @@ class CI_Reference {
     std::vector<std::vector<int>> gas_electrons();
 };
 } // namespace forte
-
-#endif // _ci_reference_h_

--- a/forte/sparse_ci/ci_spin_adaptation.h
+++ b/forte/sparse_ci/ci_spin_adaptation.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _spin_adaptation_h_
-#define _spin_adaptation_h_
+#pragma once
 
 #include <memory>
 #include <vector>
@@ -234,5 +233,3 @@ class SpinAdapter {
     auto make_determinant_occupations(int N, int twoS) -> std::vector<String>;
 };
 } // namespace forte
-
-#endif // _spin_adaptation_h_

--- a/forte/sparse_ci/configuration.hpp
+++ b/forte/sparse_ci/configuration.hpp
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _configuration_h_
-#define _configuration_h_
+#pragma once
 
 namespace forte {
 
@@ -202,5 +201,3 @@ std::string str(const ConfigurationImpl<N>& d, int n = ConfigurationImpl<N>::nbi
 }
 
 } // namespace forte
-
-#endif // _configuration_h_

--- a/forte/sparse_ci/determinant.h
+++ b/forte/sparse_ci/determinant.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _determinant_h_
-#define _determinant_h_
+#pragma once
 
 #include <unordered_map>
 
@@ -49,5 +48,3 @@ template <typename T = double>
 using det_hash = std::unordered_map<Determinant, T, Determinant::Hash>;
 using det_hash_it = std::unordered_map<Determinant, double, Determinant::Hash>::iterator;
 } // namespace forte
-
-#endif // _determinant_h_

--- a/forte/sparse_ci/determinant.hpp
+++ b/forte/sparse_ci/determinant.hpp
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _determinant_hpp_
-#define _determinant_hpp_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -871,5 +870,3 @@ template <size_t N> double spin2(const DeterminantImpl<N>& lhs, const Determinan
 }
 
 } // namespace forte
-
-#endif // _determinant_hpp_

--- a/forte/sparse_ci/determinant_functions.hpp
+++ b/forte/sparse_ci/determinant_functions.hpp
@@ -1,5 +1,4 @@
-#ifndef _determinant_functions_hpp_
-#define _determinant_functions_hpp_
+#pragma once
 
 #include <string>
 #include <cstddef>
@@ -36,5 +35,3 @@ void enforce_spin_completeness(std::vector<Determinant>& det_space, int nmo);
 std::vector<Determinant> find_minimum_spin_complete(std::vector<Determinant>& det_space, int nmo);
 
 } // namespace forte
-
-#endif // _determinant_functions_hpp_

--- a/forte/sparse_ci/determinant_hashvector.h
+++ b/forte/sparse_ci/determinant_hashvector.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _determinant_hashvector_h_
-#define _determinant_hashvector_h_
+#pragma once
 
 #include <memory>
 
@@ -139,5 +138,3 @@ class DeterminantHashVec {
     det_hashvec wfn_;
 };
 } // namespace forte
-
-#endif // _determinant_hashvector_h_

--- a/forte/sparse_ci/determinant_substitution_lists.h
+++ b/forte/sparse_ci/determinant_substitution_lists.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _determinant_substitution_lists_h_
-#define _determinant_substitution_lists_h_
+#pragma once
 
 #include "integrals/active_space_integrals.h"
 #include "sparse_ci/determinant_hashvector.h"
@@ -123,5 +122,3 @@ class DeterminantSubstitutionLists {
     bool quiet_ = true;
 };
 } // namespace forte
-
-#endif // _determinant_substitution_lists_h_

--- a/forte/sparse_ci/sigma_vector.h
+++ b/forte/sparse_ci/sigma_vector.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _sigma_vector_h_
-#define _sigma_vector_h_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -139,5 +138,3 @@ std::shared_ptr<SigmaVector> make_sigma_vector(const std::vector<Determinant>& s
                                                size_t max_memory, SigmaVectorType sigma_type);
 
 } // namespace forte
-
-#endif // _sigma_vector_h_

--- a/forte/sparse_ci/sigma_vector_dynamic.h
+++ b/forte/sparse_ci/sigma_vector_dynamic.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _sigma_vector_dynamic_h_
-#define _sigma_vector_dynamic_h_
+#pragma once
 
 #include "sigma_vector.h"
 #include "sorted_string_list.h"
@@ -128,5 +127,3 @@ class SigmaVectorDynamic : public SigmaVector {
     void compute_abab_coupling(const String& detIa, const std::vector<double>& b);
 };
 } // namespace forte
-
-#endif // _sigma_vector_dynamic_h_

--- a/forte/sparse_ci/sigma_vector_full.h
+++ b/forte/sparse_ci/sigma_vector_full.h
@@ -27,8 +27,7 @@
  * @END LICENSE
  */
 
-#ifndef _sigma_vector_full_h_
-#define _sigma_vector_full_h_
+#pragma once
 
 #include "sigma_vector.h"
 
@@ -51,5 +50,3 @@ class SigmaVectorFull : public SigmaVector {
 };
 
 } // namespace forte
-
-#endif // _sigma_vector_full_h_

--- a/forte/sparse_ci/sigma_vector_sparse_list.h
+++ b/forte/sparse_ci/sigma_vector_sparse_list.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _sigma_vector_sparse_list_h_
-#define _sigma_vector_sparse_list_h_
+#pragma once
 
 #include "sigma_vector.h"
 
@@ -117,5 +116,3 @@ class SigmaVectorSparseList : public SigmaVector {
 };
 
 } // namespace forte
-
-#endif // _sigma_vector_sparse_list_h_

--- a/forte/sparse_ci/sorted_string_list.h
+++ b/forte/sparse_ci/sorted_string_list.h
@@ -26,9 +26,7 @@
  *
  * @END LICENSE
  */
-
-#ifndef _sorted_string_list_h_
-#define _sorted_string_list_h_
+#pragma once
 
 #include "determinant.h"
 #include "sparse_ci/determinant_hashvector.h"
@@ -63,5 +61,3 @@ class SortedStringList {
     std::unordered_map<String, std::pair<size_t, size_t>, String::Hash> first_string_range_;
 };
 } // namespace forte
-
-#endif // _sigma_vector_direct_h_

--- a/forte/sparse_ci/sparse_ci_solver.h
+++ b/forte/sparse_ci/sparse_ci_solver.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _sparse_ci_h_
-#define _sparse_ci_h_
+#pragma once
 
 #include "psi4/libmints/dimension.h"
 #include "sparse_ci/determinant_hashvector.h"
@@ -235,5 +234,3 @@ class SparseCISolver {
     std::vector<std::vector<std::pair<size_t, double>>> user_guess_;
 };
 } // namespace forte
-
-#endif // _sparse_ci_h_

--- a/forte/sparse_ci/sparse_exp.h
+++ b/forte/sparse_ci/sparse_exp.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _sparse_exp_h_
-#define _sparse_exp_h_
+#pragma once
 
 #include "integrals/active_space_integrals.h"
 #include "helpers/timer.h"
@@ -96,5 +95,3 @@ class SparseExp {
 };
 
 } // namespace forte
-
-#endif // _sparse_exp_h_

--- a/forte/sparse_ci/sparse_fact_exp.h
+++ b/forte/sparse_ci/sparse_fact_exp.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _sparse_fact_exp_h_
-#define _sparse_fact_exp_h_
+#pragma once
 
 #include "integrals/active_space_integrals.h"
 #include "helpers/timer.h"
@@ -107,5 +106,3 @@ class SparseFactExp {
 };
 
 } // namespace forte
-
-#endif // _sparse_fact_exp_h_

--- a/forte/sparse_ci/sparse_hamiltonian.h
+++ b/forte/sparse_ci/sparse_hamiltonian.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _sparse_hamiltonian_h_
-#define _sparse_hamiltonian_h_
+#pragma once
 
 #include "integrals/active_space_integrals.h"
 #include "helpers/timer.h"
@@ -88,5 +87,3 @@ class SparseHamiltonian {
 };
 
 } // namespace forte
-
-#endif // _sparse_hamiltonian_h_

--- a/forte/sparse_ci/sparse_initial_guess.h
+++ b/forte/sparse_ci/sparse_initial_guess.h
@@ -1,5 +1,32 @@
-#ifndef _sparse_initial_guess_h_
-#define _sparse_initial_guess_h_
+/*
+ * @BEGIN LICENSE
+ *
+ * Forte: an open-source plugin to Psi4 (https://github.com/psi4/psi4)
+ * that implements a variety of quantum chemistry methods for strongly
+ * correlated electrons.
+ *
+ * Copyright (c) 2012-2023 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ * @END LICENSE
+ */
+
+#pragma once
 
 #include <vector>
 // #include "sparse_ci/determinant.h"
@@ -53,5 +80,3 @@ sparse_mat find_initial_guess_csf(std::shared_ptr<psi::Vector> diag, size_t num_
                                   size_t multiplicity, bool print);
 
 } // namespace forte
-
-#endif // _sparse_initial_guess_h_

--- a/forte/sparse_ci/sparse_operator.h
+++ b/forte/sparse_ci/sparse_operator.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _sparse_operator_h_
-#define _sparse_operator_h_
+#pragma once
 
 #include <vector>
 #include <unordered_map>
@@ -130,5 +129,3 @@ class SparseOperator {
 };
 
 } // namespace forte
-
-#endif // _sparse_operator_h_

--- a/forte/sparse_ci/sparse_state_vector.h
+++ b/forte/sparse_ci/sparse_state_vector.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _sparse_state_vector_h_
-#define _sparse_state_vector_h_
+#pragma once
 
 #include <vector>
 #include <unordered_map>
@@ -101,5 +100,3 @@ StateVector apply_operator(SparseOperator& sop, const StateVector& state0,
                            double screen_thresh = 1.0e-12);
 
 } // namespace forte
-
-#endif // _sparse_state_vector_h_

--- a/forte/sparse_ci/sq_operator.h
+++ b/forte/sparse_ci/sq_operator.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _sq_operator_h_
-#define _sq_operator_h_
+#pragma once
 
 #include <vector>
 
@@ -118,5 +117,3 @@ class SQOperator {
 };
 
 } // namespace forte
-
-#endif // _sq_operator_h_

--- a/forte/v2rdm/v2rdm.h
+++ b/forte/v2rdm/v2rdm.h
@@ -26,8 +26,7 @@
  * @END LICENSE
  */
 
-#ifndef _v2rdm_h_
-#define _v2rdm_h_
+#pragma once
 
 #include <map>
 #include "psi4/libmints/wavefunction.h"

--- a/forte/v2rdm/v2rdm.h
+++ b/forte/v2rdm/v2rdm.h
@@ -122,5 +122,3 @@ class V2RDM : public psi::Wavefunction {
     void write_density_to_file();
 };
 } // namespace forte
-
-#endif // V2RDM_H

--- a/forte/version.h.in
+++ b/forte/version.h.in
@@ -1,7 +1,32 @@
-#ifndef VERSION_H
-#define VERSION_H
+/*
+ * @BEGIN LICENSE
+ *
+ * Forte: an open-source plugin to Psi4 (https://github.com/psi4/psi4)
+ * that implements a variety of quantum chemistry methods for strongly
+ * correlated electrons.
+ *
+ * Copyright (c) 2012-2023 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ * @END LICENSE
+ */
+
+#pragma once
 
 #define GIT_BRANCH "@GIT_BRANCH@"
 #define GIT_COMMIT_HASH "@GIT_COMMIT_HASH@"
-
-#endif

--- a/tests/code/test_determinant.hpp
+++ b/tests/code/test_determinant.hpp
@@ -1,5 +1,32 @@
-#ifndef _test_determinant_
-#define _test_determinant_
+/*
+ * @BEGIN LICENSE
+ *
+ * Forte: an open-source plugin to Psi4 (https://github.com/psi4/psi4)
+ * that implements a variety of quantum chemistry methods for strongly
+ * correlated electrons.
+ *
+ * Copyright (c) 2012-2023 by its authors (see COPYING, COPYING.LESSER, AUTHORS).
+ *
+ * The copyrights for code used from other parties are included in
+ * the corresponding files.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ * @END LICENSE
+ */
+
+#pragma once
 
 #include <cstddef>
 #include <vector>
@@ -359,5 +386,3 @@ template <size_t N> void test_determinantimpl_count_functions() {
         REQUIRE(d.npair() == npair);
     }
 }
-
-#endif // _test_determinant_


### PR DESCRIPTION
## Description
A brief description of the goals accomplished by this PR

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features and included a reference `output.ref` file
- [ ] Removed comments in code and input files
- [ ] Documented source code
- [ ] Checked for redundant headers
- [ ] Checked for consistency in the formatting of the output file
- [ ] Documented new features in the manual
- [ ] Ready to go!
