### PR TITLE
Fix bitwise_operations.cc to address return value inconsistency

### DIFF
--- a/forte/sparse_ci/bitwise_operations.hpp
+++ b/forte/sparse_ci/bitwise_operations.hpp
@@ -56,11 +56,7 @@ inline double ui64_bit_parity(uint64_t x) { return 1 - 2 * ((std::popcount(x) & 
 /// @param x the uint64_t integer to test
 /// @return the index of the least significant 1-bit of x, or if x is zero, returns ~0
 inline uint64_t ui64_find_lowest_one_bit(uint64_t x) { 
-    if (auto y = std::countr_zero(x); y == 64) {
-        return ~0;
-    } else {
-        return y;
-    } 
+    return (x == 0) ? ~uint64_t(0) : std::countr_zero(x);
 } 
 
 /// @brief Bit-scan to find next set bit after position pos

--- a/forte/sparse_ci/bitwise_operations.hpp
+++ b/forte/sparse_ci/bitwise_operations.hpp
@@ -55,7 +55,13 @@ inline double ui64_bit_parity(uint64_t x) { return 1 - 2 * ((std::popcount(x) & 
 /// @brief Bit-scan to find next set bit
 /// @param x the uint64_t integer to test
 /// @return the index of the least significant 1-bit of x, or if x is zero, returns ~0
-inline uint64_t ui64_find_lowest_one_bit(uint64_t x) { return std::countr_zero(x); }
+inline uint64_t ui64_find_lowest_one_bit(uint64_t x) { 
+    if (auto y = std::countr_zero(x); y == 64) {
+        return ~0;
+    } else {
+        return y;
+    } 
+} 
 
 /// @brief Bit-scan to find next set bit after position pos
 /// @param x the uint64_t integer to test


### PR DESCRIPTION
## Description
This PR applies a fix to the return value inconsistency in the `ui64_find_lowest_one_bit` method of `bitwise_operations.cc`, and resolves failing test cases in `tests/code/test_uint64.cc`.

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features and included a reference `output.ref` file
- [ ] Removed comments in code and input files
- [ ] Documented source code
- [ ] Checked for redundant headers
- [ ] Checked for consistency in the formatting of the output file
- [ ] Documented new features in the manual
- [x] Ready to go!
