### PR TITLE
Buildconda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,11 @@ endif()
 
 if (ENABLE_ForteTests)
   project (forte_tests)
-  include_directories(${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/catch2/forte/catch2/single_include)
+  include_directories(
+    ${CMAKE_BINARY_DIR}
+    ${CMAKE_BINARY_DIR}/catch2/forte/catch2/single_include
+    ${CMAKE_SOURCE_DIR}
+    )
   add_executable(forte_tests
     tests/code/catch_amalgamated.cpp
     tests/code/test_determinant.cc

--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -1,0 +1,77 @@
+This project incorporates material from the project(s) listed below
+(collectively, "Third Party Code"). Forte is not the original author
+of the Third Party Code. The original copyright notice and license under
+which Fote received such Third Party Code are set out below. This
+Third Party Code is licensed to you under their original license terms
+set forth below.
+
+
+<< 1 >> forte/lib/json/json.hpp
+
+MIT License 
+
+Copyright (c) 2013-2022 Niels Lohmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+<< 2 >> forte/lib/fmt/args.h
+        forte/lib/fmt/chrono.h
+        forte/lib/fmt/color.h
+        forte/lib/fmt/compile.h
+        forte/lib/fmt/core.h
+        forte/lib/fmt/format.h
+        forte/lib/fmt/format-inl.h
+        forte/lib/fmt/os.h
+        forte/lib/fmt/ostream.h
+        forte/lib/fmt/printf.h
+        forte/lib/fmt/ranges.h
+        forte/lib/fmt/std.h
+        forte/lib/fmt/xchar.h
+
+MIT License w/optional exception
+
+Copyright (c) 2012 - present, Victor Zverovich and {fmt} contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--- Optional exception to the license ---
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into a machine-executable object form of such
+source code, you may redistribute such embedded portions in such object form
+without including the above copyright and permission notices.
+

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+@pytest.fixture(scope="function", autouse=True)
+def set_up():
+    import psi4
+    import forte
+
+    forte.clean_options()

--- a/forte/CMakeLists.txt
+++ b/forte/CMakeLists.txt
@@ -317,6 +317,32 @@ install(
     PATTERN "*.py"
     PATTERN "__pycache__" EXCLUDE
     PATTERN "*pyc" EXCLUDE
+    # installs harmless empty dirs for c++ unless excluded below
+    PATTERN "api" EXCLUDE
+    PATTERN "attic" EXCLUDE
+    PATTERN "base_classes" EXCLUDE
+    PATTERN "casscf" EXCLUDE
+    PATTERN "ci_ex_states" EXCLUDE
+    PATTERN "ci_rdm" EXCLUDE
+    PATTERN "cmake" EXCLUDE
+    PATTERN "dmrg" EXCLUDE
+    PATTERN "external" EXCLUDE
+    PATTERN "fci" EXCLUDE
+    PATTERN "genci" EXCLUDE
+    PATTERN "gradient_tpdm" EXCLUDE
+    PATTERN "helpers" EXCLUDE
+    PATTERN "integrals" EXCLUDE
+    PATTERN "lib" EXCLUDE
+    PATTERN "mrdsrg-helper" EXCLUDE
+    PATTERN "mrdsrg-so" EXCLUDE
+    PATTERN "mrdsrg-spin-adapted" EXCLUDE
+    PATTERN "mrdsrg-spin-integrated" EXCLUDE
+    PATTERN "orbital-helpers" EXCLUDE
+    PATTERN "pci" EXCLUDE
+    PATTERN "post_process" EXCLUDE
+    PATTERN "sci" EXCLUDE
+    PATTERN "sparse_ci" EXCLUDE
+    PATTERN "v2rdm" EXCLUDE
   )
 
 install(

--- a/forte/CMakeLists.txt
+++ b/forte/CMakeLists.txt
@@ -24,6 +24,8 @@ option_with_print(ENABLE_GA "Enable Global Arrays" OFF)
 option_with_print(MAX_DET_ORB "Set the maximum number of orbitals in a determinant" OFF)
 option_with_print(ENABLE_CODECOV "Enable compilation with code coverage flags" OFF)
 option_with_print(ENABLE_UNTESTED_CODE "Enable code not covered by code coverage" OFF)
+option_with_default(FORTE_INSTALL_PYMODDIR "Location within CMAKE_INSTALL_PREFIX to which the Python module is installed. Empty string queries Python interpreter. Don't start with '/'" prefix)
+# for trial builds, it's worth using `set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)` or passing it as a `-D`. Saves 75% of build time to not run LTO (added by pybind11) at the link stage.
 
 include(autocmake_omp)  # no longer useful, probably need to copy psi4/external/common/lapack to cmake
 include(autocmake_mpi)  # MPI option A
@@ -259,7 +261,12 @@ sparse_ci/sparse_state.cc
 v2rdm/v2rdm.cc
 )
 
-target_include_directories(_forte PRIVATE .)
+target_include_directories(
+  _forte
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
+  )
 
 target_link_libraries(_forte PRIVATE tgt::MathOpenMP)
 target_link_libraries(_forte PRIVATE psi4::core)
@@ -279,3 +286,55 @@ endif()
 if(ENABLE_GA)
     target_link_libraries(_forte PRIVATE GlobalArrays::ga)
 endif()
+
+
+if (FORTE_INSTALL_PYMODDIR STREQUAL "prefix")
+
+    # Note that this block is *Linux-style* install to `CMAKE_INSTALL_PREFIX` not *Python-style* install to `Python_EXECUTABLE`'s site-packages.
+    execute_process(
+      COMMAND ${Python_EXECUTABLE} -c
+        "import os, sys, sysconfig as s; spdir = s.get_path('platlib'); print(spdir.replace(os.path.commonpath([sys.prefix, spdir]), '').lstrip(os.path.sep));"
+      OUTPUT_VARIABLE FORTE_INSTALL_PYMODDIR
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+endif()
+message(STATUS "Showing option CMAKE_INSTALL_PREFIX/FORTE_INSTALL_PYMODDIR: ${CMAKE_INSTALL_PREFIX}/${FORTE_INSTALL_PYMODDIR}")
+
+install(
+  FILES
+    $<TARGET_FILE:_forte>
+    ../pytest.ini
+  COMPONENT Forte_Python
+  DESTINATION ${FORTE_INSTALL_PYMODDIR}/forte
+  )
+
+install(
+  DIRECTORY
+    "${CMAKE_CURRENT_SOURCE_DIR}/"
+  COMPONENT Forte_Python
+  DESTINATION ${FORTE_INSTALL_PYMODDIR}/forte
+  FILES_MATCHING
+    PATTERN "*.py"
+    PATTERN "__pycache__" EXCLUDE
+    PATTERN "*pyc" EXCLUDE
+  )
+
+install(
+  FILES
+    ../conftest.py
+  COMPONENT Forte_Python
+  DESTINATION ${FORTE_INSTALL_PYMODDIR}/forte/tests
+  )
+
+install(
+  DIRECTORY
+    "${CMAKE_CURRENT_SOURCE_DIR}/../tests/pytest/"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../tests/pytest-methods/"
+  DESTINATION ${FORTE_INSTALL_PYMODDIR}/forte/tests
+  FILES_MATCHING
+    PATTERN "*.py"
+    PATTERN "*.xyz"
+    PATTERN "INTDUMP*"
+    PATTERN "__pycache__" EXCLUDE
+    PATTERN "*pyc" EXCLUDE
+  )

--- a/forte/api/forte_python_module.cc
+++ b/forte/api/forte_python_module.cc
@@ -173,6 +173,7 @@ PYBIND11_MODULE(_forte, m) {
     // This line is how pb11 knows what pieces of ambit have already been exposed,
     // and can be sent Py-side by Forte.
     py::module::import("ambit");
+    py::module::import("psi4");
 
     m.doc() = "pybind11 Forte module"; // module docstring
 

--- a/forte/api/forte_python_module.cc
+++ b/forte/api/forte_python_module.cc
@@ -173,7 +173,6 @@ PYBIND11_MODULE(_forte, m) {
     // This line is how pb11 knows what pieces of ambit have already been exposed,
     // and can be sent Py-side by Forte.
     py::module::import("ambit");
-    py::module::import("psi4");
 
     m.doc() = "pybind11 Forte module"; // module docstring
 

--- a/forte/proc/orbital_helpers.py
+++ b/forte/proc/orbital_helpers.py
@@ -251,7 +251,7 @@ def ortho_orbs_psi4(wfn1, wfn2, semi=True):
 
 
 def projectout(C, CP, S):
-    """
+    r"""
     Project out CP contributions from C (Schmidt orthogonalization):
     Cp = (1 - P) C = C - CP (CP^T S C),
     where P = \sum_{q} |q><q| with q being the new MO of geometry 2.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+minversion = 7.0
+addopts = --import-mode=importlib
+
+testpaths =
+    tests


### PR DESCRIPTION
## Description
Add install target for CMake.

## ~User~ Dev Notes
- [x] lets CMake install compiled and py files together
- [x] if the user doesn't pass an install location with `FORTE_INSTALL_PYMODDIR`, CMake computes one from the active Python. note that this is linux-style install to `CMAKE_INSTALL_PREFIX`, not python-style install to wherever python is active. presumably setup.py handles the py-style case.
- [x] adds install of pytest tests and a conftest.py (to clean btwn tests) and a pytest.ini (to pass importlib to let it find scattered tests (and in future can define test categories here))
- [x] adds some extra include dirs to compilation to find `_version.py` and something in the tests
- [x] the `r"""` corrects a warning Py is being loud about
- [x] the `test_rhf` -> `test_scf` shouldn't be necessary, but it helps in collection if the importlib _isn't_ being picked up

## Checklist
- [ ] Added/updated tests of new features and included a reference `output.ref` file
- [ ] Removed comments in code and input files
- [ ] Documented source code
- [ ] Checked for redundant headers
- [ ] Checked for consistency in the formatting of the output file
- [ ] Documented new features in the manual
- [ ] Ready to go!
