### PR TITLE
Add genuine analytic DF-MCSCF gradients

### DIFF
--- a/docs/source/methods/mcscf.rst
+++ b/docs/source/methods/mcscf.rst
@@ -257,7 +257,7 @@ computation with two doubly occupied orbitals frozen ::
   
 
 To override this behavior and freeze the core orbitals in the MCSCF procedure, the user can set the option
-:code:`MCSCF_FREEZE_CORE` to :code:`True`.
+:code:`MCSCF_IGNORE_FROZEN_ORBS` to :code:`False`.
 This might be necessary in certain cases, if orbital rotations involving core orbitals cause convergence issues.
 The following input (see :code:`tests/manual/mcscf-5/input.dat`) performs an MCSCF calculation on CO molecule and
 freezes the 1s orbital of the carbon and oxygen atoms
@@ -277,7 +277,7 @@ freezes the 1s orbital of the carbon and oxygen atoms
       mcscf_e_convergence  8
       mcscf_g_convergence  6
       mcscf_micro_maxiter  4
-      mcscf_freeze_core    true  # enables freezing the MCSCF core orbitals
+      mcscf_ignore_frozen_orbs false  # enables freezing the MCSCF core orbitals
     }
 
     energy('forte')
@@ -321,17 +321,17 @@ The maximum number of macro iterations.
 
 **MCSCF_MICRO_MAXITER**
 
-The maximum number of micro iterations.
-
-* Type: int
-* Default: 40
-
-**MCSCF_MICRO_MINITER**
-
-The minimum number of micro iterations.
+The maximum number of micro iterations (orbital optimization) for a given CI.
 
 * Type: int
 * Default: 6
+
+**MCSCF_MCI_MAXITER**
+
+The maximum number of micro CI iterations in every macro iteration.
+
+* Type: int
+* Default: 12
 
 **MCSCF_E_CONVERGENCE**
 
@@ -389,14 +389,6 @@ For example, 1 means do DIIS every iteration and 2 is for every other iteration,
 * Type: int
 * Default: 1
 
-**MCSCF_CI_SOLVER**
-
-Which active space solver to be used.
-
-* Type: string
-* Options: CAS, FCI, ACI, PCI
-* Default: CAS
-
 **MCSCF_DEBUG_PRINTING**
 
 Whether to enable debug printing.
@@ -422,6 +414,14 @@ Turn off orbital optimization procedure if true.
 **MCSCF_DIE_IF_NOT_CONVERGED**
 
 Stop Forte if MCSCF did not converge.
+
+* Type: Boolean
+* Default: True
+
+**MCSCF_IGNORE_FROZEN_ORBS**
+
+Whether to ignore frozen orbitals in the input file or not.
+By default, all orbitals will be optimized in MCSCF.
 
 * Type: Boolean
 * Default: True
@@ -458,6 +458,22 @@ This option is useful when doing core-excited state computations.
 
 * Type: array
 * Default: No Default
+
+**MCSCF_ORB_ORTHO_TRANS**
+
+Ways to compute the orthogonal transformation U from orbital rotation R
+
+* Type: string
+* Options: CAYLEY, POWER, PADE
+* Default: CAYLEY
+
+**MCSCF_DF_TEIALG**
+
+Algorithm to build (pu|xy) integrals in DF-MCSCF.
+Use (Q|pu) if True; Otherwise use JK build for every xy pair
+
+* Type: Boolean
+* Fefault: True
 
 CPSCF Options
 ~~~~~~~~~~~~~

--- a/forte/helpers/helpers.cc
+++ b/forte/helpers/helpers.cc
@@ -149,6 +149,10 @@ std::pair<double, std::string> to_xb(size_t nele, size_t type_size) {
 }
 
 void matrix_transpose_in_place(std::vector<double>& data, const size_t m, const size_t n) {
+    matrix_transpose_in_place(data.data(), m, n);
+}
+
+void matrix_transpose_in_place(double* data, const size_t m, const size_t n) {
     int nthreads = std::min(omp_get_max_threads(), int(m > n ? n : m));
     std::vector<double> tmp(nthreads * (m > n ? m : n));
     auto tmp_begin = tmp.begin();

--- a/forte/helpers/helpers.h
+++ b/forte/helpers/helpers.h
@@ -197,6 +197,7 @@ void apply_permutation_in_place(std::vector<T>& vec, const std::vector<std::size
  * Also see https://github.com/bryancatanzaro/inplace
  */
 void matrix_transpose_in_place(std::vector<double>& data, const size_t m, const size_t n);
+void matrix_transpose_in_place(double* data, const size_t m, const size_t n);
 
 void push_to_psi4_env_globals(double value, const std::string& label);
 

--- a/forte/integrals/integrals.cc
+++ b/forte/integrals/integrals.cc
@@ -488,6 +488,27 @@ void ForteIntegrals::print_ints() {
     }
 }
 
+std::shared_ptr<psi::Matrix> ForteIntegrals::Ca_SO2AO(std::shared_ptr<psi::Matrix> Ca_SO) const {
+    auto aotoso = wfn_->aotoso();
+    auto nao = nso_;
+
+    auto Ca_ao = std::make_shared<psi::Matrix>("Ca_AO", nao, nmo_);
+
+    // Transform from the SO to the AO basis
+    for (int h = 0, index = 0; h < nirrep_; ++h) {
+        auto nso = nsopi_[h];
+        if (nso == 0)
+            continue;
+
+        for (int i = 0, nmo_this = nmopi_[h]; i < nmo_this; ++i) {
+            // notes: LDA value is nso (not nao, see libqt/blas_intfc23.cc)
+            C_DGEMV('N', nao, nso, 1.0, aotoso->pointer(h)[0], nso, &Ca_SO->pointer(h)[0][i],
+                    nmo_this, 0.0, &Ca_ao->pointer()[0][index++], nmo_);
+        }
+    }
+    return Ca_ao;
+}
+
 void ForteIntegrals::rotate_orbitals(std::shared_ptr<psi::Matrix> Ua,
                                      std::shared_ptr<psi::Matrix> Ub, bool re_transform) {
     // 1. Rotate the orbital coefficients and store them in the ForteIntegral object

--- a/forte/integrals/integrals.h
+++ b/forte/integrals/integrals.h
@@ -391,6 +391,8 @@ class ForteIntegrals {
 
     /// Orbital coefficients in AO x MO basis where MO is Pitzer order
     virtual std::shared_ptr<psi::Matrix> Ca_AO() const = 0;
+    /// Transform SO orbital coefficients to AO x MO basis where MO is Pitzer order
+    std::shared_ptr<psi::Matrix> Ca_SO2AO(std::shared_ptr<psi::Matrix> Ca_SO) const;
 
     /// Obtain AO dipole integrals [X, Y, Z]
     /// Each direction is a std::shared_ptr<psi::Matrix> of dimension nao * nao

--- a/forte/integrals/integrals_psi4_interface.cc
+++ b/forte/integrals/integrals_psi4_interface.cc
@@ -376,26 +376,7 @@ void Psi4Integrals::rotate_mos() {
     wfn_->epsilon_b()->copy(eps_a_new);
 }
 
-std::shared_ptr<psi::Matrix> Psi4Integrals::Ca_AO() const {
-    auto aotoso = wfn_->aotoso();
-    auto nao = nso_;
-
-    auto Ca_ao = std::make_shared<psi::Matrix>("Ca_AO", nao, nmo_);
-
-    // Transform from the SO to the AO basis
-    for (int h = 0, index = 0; h < nirrep_; ++h) {
-        auto nso = nsopi_[h];
-        if (nso == 0)
-            continue;
-
-        for (int i = 0, nmo_this = nmopi_[h]; i < nmo_this; ++i) {
-            // notes: LDA value is nso (not nao, see libqt/blas_intfc23.cc)
-            C_DGEMV('N', nao, nso, 1.0, aotoso->pointer(h)[0], nso, &Ca_->pointer(h)[0][i],
-                    nmo_this, 0.0, &Ca_ao->pointer()[0][index++], nmo_);
-        }
-    }
-    return Ca_ao;
-}
+std::shared_ptr<psi::Matrix> Psi4Integrals::Ca_AO() const { return Ca_SO2AO(Ca_); }
 
 void Psi4Integrals::build_multipole_ints_ao() {
     std::shared_ptr<psi::BasisSet> basisset = wfn_->basisset();

--- a/forte/mcscf/mcscf_2step.cc
+++ b/forte/mcscf/mcscf_2step.cc
@@ -205,7 +205,7 @@ double MCSCF_2STEP::compute_energy() {
     if (no_orb_opt) {
         energy_ = e_c;
         pass_energy_to_psi4();
-        if (der_type_ == "FIRST") {
+        if (der_type_ == "FIRST" and options_->get_str("CORRELATION_SOLVER") == "NONE") {
             cas_grad.compute_nuclear_gradient();
         }
         return energy_;
@@ -465,7 +465,7 @@ double MCSCF_2STEP::compute_energy() {
             throw_convergence_error();
 
         // for nuclear gradient
-        if (der_type_ == "FIRST") {
+        if (der_type_ == "FIRST" and options_->get_str("CORRELATION_SOLVER") == "NONE") {
             // TODO: remove this re-diagonalization if CI transformation is impelementd
             if (not is_single_reference()) {
                 diagonalize_hamiltonian(

--- a/forte/mcscf/mcscf_2step.cc
+++ b/forte/mcscf/mcscf_2step.cc
@@ -168,8 +168,8 @@ double MCSCF_2STEP::compute_energy() {
     };
 
     // prepare for orbital gradients
-    const bool freeze_core = options_->get_bool("MCSCF_FREEZE_CORE");
-    MCSCF_ORB_GRAD cas_grad(options_, mo_space_info_, ints_, freeze_core);
+    const bool ignore_frozen = options_->get_bool("MCSCF_IGNORE_FROZEN_ORBS");
+    MCSCF_ORB_GRAD cas_grad(options_, mo_space_info_, ints_, ignore_frozen);
     auto nrot = cas_grad.nrot();
     auto dG = std::make_shared<psi::Vector>("dG", nrot);
 
@@ -446,9 +446,7 @@ double MCSCF_2STEP::compute_energy() {
 
             // if we do not freeze the core, we need to set the inactive_mix flag to make sure
             // the core orbitals are canonicalized together with the active orbitals
-            if (not freeze_core) {
-                inactive_mix = true;
-            }
+            inactive_mix = ignore_frozen;
 
             psi::outfile->Printf("\n  Canonicalizing final MCSCF orbitals");
             SemiCanonical semi(mo_space_info_, ints_, options_, inactive_mix, active_mix);

--- a/forte/mcscf/mcscf_2step.cc
+++ b/forte/mcscf/mcscf_2step.cc
@@ -442,7 +442,7 @@ double MCSCF_2STEP::compute_energy() {
             ints_->set_fock_matrix(F, F);
 
             // if we do not freeze orbitals, we need to set the inactive_mix flag to make sure
-            // the frozen and active core/virtual orbitals are canonicalized together.
+            // the frozen and non-frozen core/virtual orbitals are canonicalized together.
             auto inactive_mix = ignore_frozen;
 
             if (!ignore_frozen)

--- a/forte/mcscf/mcscf_2step.cc
+++ b/forte/mcscf/mcscf_2step.cc
@@ -441,12 +441,13 @@ double MCSCF_2STEP::compute_energy() {
             auto F = cas_grad.fock(rdms);
             ints_->set_fock_matrix(F, F);
 
-            auto inactive_mix = options_->get_bool("SEMI_CANONICAL_MIX_INACTIVE");
-            auto active_mix = options_->get_bool("SEMI_CANONICAL_MIX_ACTIVE");
+            // if we do not freeze orbitals, we need to set the inactive_mix flag to make sure
+            // the frozen and active core/virtual orbitals are canonicalized together.
+            auto inactive_mix = ignore_frozen;
 
-            // if we do not freeze the core, we need to set the inactive_mix flag to make sure
-            // the core orbitals are canonicalized together with the active orbitals
-            inactive_mix = ignore_frozen;
+            if (!ignore_frozen)
+                inactive_mix = options_->get_bool("SEMI_CANONICAL_MIX_INACTIVE");
+            auto active_mix = options_->get_bool("SEMI_CANONICAL_MIX_ACTIVE");
 
             psi::outfile->Printf("\n  Canonicalizing final MCSCF orbitals");
             SemiCanonical semi(mo_space_info_, ints_, options_, inactive_mix, active_mix);

--- a/forte/mcscf/mcscf_orb_grad.cc
+++ b/forte/mcscf/mcscf_orb_grad.cc
@@ -529,8 +529,7 @@ void MCSCF_ORB_GRAD::build_tei_df() {
 
     auto puxy = psi::linalg::doublet(B, Baa, true, false); // (nmo * nactv) * (nactv * nactv)
     auto puxy_ptr = puxy->get_pointer();
-    for (const auto& label_mos_pair : label_to_mos_) {
-        const auto& [p_label, p_mos] = label_mos_pair;
+    for (const auto& [p_label, p_mos] : label_to_mos_) {
         std::string block = p_label + "aaa";
         auto& data = V_.block(block).data();
         for (size_t p = 0, psize = p_mos.size(), nactv2 = nactv_ * nactv_; p < psize; ++p) {

--- a/forte/mcscf/mcscf_orb_grad.h
+++ b/forte/mcscf/mcscf_orb_grad.h
@@ -61,7 +61,7 @@ class MCSCF_ORB_GRAD {
      */
     MCSCF_ORB_GRAD(std::shared_ptr<ForteOptions> options,
                    std::shared_ptr<MOSpaceInfo> mo_space_info, std::shared_ptr<ForteIntegrals> ints,
-                   bool freeze_core);
+                   bool ignore_frozen);
 
     /// Evaluate the energy and orbital gradient
     double evaluate(std::shared_ptr<psi::Vector> x, std::shared_ptr<psi::Vector> g,
@@ -163,8 +163,8 @@ class MCSCF_ORB_GRAD {
     /// The number of frozen-core orbitals
     size_t nfrzc_;
 
-    /// Freeze core or not
-    bool freeze_core_ = false;
+    /// Ignore frozen orbitals in the input
+    bool ignore_frozen_ = true;
 
     /// List of core MOs (Absolute)
     std::vector<size_t> core_mos_;
@@ -313,8 +313,11 @@ class MCSCF_ORB_GRAD {
     void dump_tpdm_iwl();
     /// Dump the Hartree-Fock MO 2-RDM to file using IWL
     void dump_tpdm_iwl_hf();
-    /// Dump 2-RDM to file for DF-MCSCF
+    /// Dump AO 2-RDM to file for DF-MCSCF
     void dump_tpdm_df();
+    /// Dump the Hartree-Fock AO 2-RDM to file for DF-MCSCF
+    void dump_tpdm_df_hf(std::shared_ptr<psi::Matrix> Jm12, std::shared_ptr<psi::Matrix> d3,
+                         std::shared_ptr<psi::Matrix> d2);
 
     /// Are there any frozen orbitals?
     bool is_frozen_orbs_;

--- a/forte/mcscf/mcscf_orb_grad.h
+++ b/forte/mcscf/mcscf_orb_grad.h
@@ -313,6 +313,8 @@ class MCSCF_ORB_GRAD {
     void dump_tpdm_iwl();
     /// Dump the Hartree-Fock MO 2-RDM to file using IWL
     void dump_tpdm_iwl_hf();
+    /// Dump 2-RDM to file for DF-MCSCF
+    void dump_tpdm_df();
 
     /// Are there any frozen orbitals?
     bool is_frozen_orbs_;

--- a/forte/mcscf/mcscf_orb_grad.h
+++ b/forte/mcscf/mcscf_orb_grad.h
@@ -37,6 +37,7 @@
 #include "psi4/libdiis/diismanager.h"
 #include "psi4/libfock/jk.h"
 #include "psi4/libmints/matrix.h"
+#include "psi4/lib3index/dfhelper.h"
 
 #include "ambit/blocked_tensor.h"
 
@@ -59,8 +60,8 @@ class MCSCF_ORB_GRAD {
      *   See J. Chem. Phys. 142, 224103 (2015) and Theor. Chem. Acc. 97, 88-95 (1997)
      */
     MCSCF_ORB_GRAD(std::shared_ptr<ForteOptions> options,
-                    std::shared_ptr<MOSpaceInfo> mo_space_info,
-                    std::shared_ptr<ForteIntegrals> ints, bool freeze_core);
+                   std::shared_ptr<MOSpaceInfo> mo_space_info, std::shared_ptr<ForteIntegrals> ints,
+                   bool freeze_core);
 
     /// Evaluate the energy and orbital gradient
     double evaluate(std::shared_ptr<psi::Vector> x, std::shared_ptr<psi::Vector> g,
@@ -123,6 +124,13 @@ class MCSCF_ORB_GRAD {
 
     /// The JK object of Psi4
     std::shared_ptr<psi::JK> JK_;
+
+    /// The DFHelper object of Psi4
+    std::shared_ptr<psi::DFHelper> df_helper_;
+
+    /// Algorithm for computing (pu|xy) integrals
+    enum TEIALG { JK, DF };
+    TEIALG tei_alg_ = JK;
 
     // => MO spaces related <=
 
@@ -257,7 +265,8 @@ class MCSCF_ORB_GRAD {
     void build_mo_integrals();
 
     /// Build two-electron integrals
-    void build_tei_from_ao();
+    void build_tei_jk();
+    void build_tei_df();
 
     /// Fill two-electron integrals for custom integrals
     void fill_tei_custom(ambit::BlockedTensor V);

--- a/forte/mcscf/mcscf_orb_grad_deriv.cc
+++ b/forte/mcscf/mcscf_orb_grad_deriv.cc
@@ -665,6 +665,8 @@ void MCSCF_ORB_GRAD::dump_tpdm_df_hf(std::shared_ptr<psi::Matrix> Jm12,
         auto q_mos = label_to_mos_[block.substr(2, 1)];
         auto np = p_mos.size();
         auto nq = q_mos.size();
+        if (np == 0 or nq == 0)
+            continue;
         auto Cp = Csub(p_mos);
         auto Cq = Csub(q_mos);
         df_helper_->add_space("p", Cp);
@@ -715,6 +717,8 @@ void MCSCF_ORB_GRAD::dump_tpdm_df_hf(std::shared_ptr<psi::Matrix> Jm12,
         auto np = label_to_mos_[bp].size();
         auto nq = label_to_mos_[bq].size();
         auto npq = np * nq;
+        if (npq == 0)
+            continue;
 
         auto Cp = Csub(label_to_mos_[bp]);
         auto Cq = (bp == bq ? Cp : Csub(label_to_mos_[bq]));
@@ -739,7 +743,10 @@ void MCSCF_ORB_GRAD::dump_tpdm_df_hf(std::shared_ptr<psi::Matrix> Jm12,
     // 2-index 2-RDM
     auto d2ptr = d2->get_pointer();
     for (const std::string& block : D3.block_labels()) {
-        double* D3ptr = D3.block(block).data().data();
+        auto D3sub = D3.block(block);
+        if (D3sub.numel() == 0)
+            continue;
+        double* D3ptr = D3sub.data().data();
         double* C3ptr = C3.block(block).data().data();
         auto factor = (block.substr(1, 1) == block.substr(2, 1) ? 1.0 : 2.0);
         auto k = C3.block(block).dim(1) * C3.block(block).dim(2);

--- a/forte/mcscf/mcscf_orb_grad_deriv.cc
+++ b/forte/mcscf/mcscf_orb_grad_deriv.cc
@@ -185,6 +185,12 @@ void MCSCF_ORB_GRAD::setup_grad_frozen() {
     label_to_mos_["m"] = adocc_mos;
     label_to_mos_["e"] = auocc_mos;
 
+    BlockedTensor::add_mo_space("m", "m,n", adocc_mos, NoSpin);
+    BlockedTensor::add_mo_space("e", "e,f", auocc_mos, NoSpin);
+    BlockedTensor::add_composite_mo_space("O", "k,l", {"f", "m"});
+    BlockedTensor::add_composite_mo_space("V", "c,d", {"e", "u"});
+    BlockedTensor::add_composite_mo_space("H", "g,h", {"f", "m", "e", "u"});
+
     // build HF Fock matrix, assuming MCSCF initial orbitals are from HF
     auto Cdocc = C_subset("C_DOCC", C0_, psi::Dimension(nirrep_), hf_ndoccpi_);
 
@@ -613,160 +619,562 @@ void MCSCF_ORB_GRAD::dump_tpdm_df_hf(std::shared_ptr<psi::Matrix> Jm12,
     /**
      * Implementation notes
      * contribution to total Lagrangian: z_{pq} * [2 * (pq|ii) - (pi|iq)]
-     * D3^{Q}_{ii} <- 2 * z_{pq} * C3^{Q}_{pq}
-     * D3^{Q}_{pq} <- 2 * z_{pq} * C3^{Q}_{ii}
-     * D3^{Q}_{pi} <- -z_{pq} * C3^{Q}_{iq}
-     * D3^{Q}_{iq} <- -z_{pq} * C3^{Q}_{pi}
+     * D3^{Q}_{ii} <- z_{pq} * C3^{Q}_{pq}           term 1
+     * D3^{Q}_{pq} <- z_{pq} * C3^{Q}_{ii}           term 2
+     * D3^{Q}_{pi} <- -0.5 * z_{pq} * C3^{Q}_{iq}    term 3
+     * D3^{Q}_{iq} <- -0.5 * z_{pq} * C3^{Q}_{pi}    term 4
+     * will be scaled by 2 at the end of dump_tpdm_df()
      *
-     * nonzero pq blocks: "f,c", "v,u", "c,v"
+     * D2^{PQ} = z_{pq} * ( 2 * C^{P}_{pq} * C^{Q}_{ii} - C^{P}_{pi} * C^{Q}_{iq} )
      */
     auto naux = df_helper_->get_naux();
+    std::vector<size_t> aux_mos(naux);
+    std::iota(aux_mos.begin(), aux_mos.end(), 0);
+    BlockedTensor::add_mo_space("L", "K,L", aux_mos, NoSpin);
 
-    // Z matrix without symmetry blocks
-    auto Z = std::make_shared<psi::Matrix>("Z C1", nmo_, nmo_);
-    for (size_t p = 0; p < nmo_; ++p) {
-        auto [hp, ip] = mos_rel_[p];
-        for (size_t q = p + 1; q < nmo_; ++q) {
-            auto [hq, iq] = mos_rel_[q];
-            if (hp != hq)
-                continue;
-            Z->set(p, q, Z_->get(hp, ip, iq));
-            Z->set(q, p, Z_->get(hp, iq, ip));
-        }
-    }
+    auto nf = label_to_mos_["f"].size();
+    auto nm = label_to_mos_["m"].size();
+    auto nso2 = nso_ * nso_;
 
     // HF orbital coefficients without symmetry
     auto C_nosym = ints_->Ca_SO2AO(C0_);
     auto Csub = [&](const std::vector<size_t>& p_mos) {
         auto np = p_mos.size();
-        auto Cp = std::make_shared<psi::Matrix>("Cp", nso_, np);
+        auto Cp = std::make_shared<psi::Matrix>("Csub", nso_, np);
         for (size_t p = 0; p < np; ++p) {
             Cp->set_column(0, p, C_nosym->get_column(0, p_mos[p]));
         }
         return Cp;
     };
 
-    // compute C^{P}_{pq} = (P|Q)^{-1/2} B^{Q}_{pq} integrals in ambit form
-    std::map<std::string, std::shared_ptr<psi::Matrix>> C3ints;
-    std::vector<double> C3Q(naux); // sum_{i} C^{Q}_{ii}
+    ///////////////////////////////////////////////////////////////
 
-    // DFHelper to get B^{P}_{pq} = (P|Q)^{-1/2} (Q|pq) integrals in MO basis
-    auto C3ints_helper = [&](const std::vector<size_t>& p_mos, const std::vector<size_t>& q_mos) {
+    auto nd = hf_docc_mos_.size();
+    auto no = nd - nfrzc_;
+    auto Zt = ambit::Tensor::build(CoreTensor, "Zt", {nmo_, nmo_});
+    Zt.iterate([&](const std::vector<size_t>& i, double& value) {
+        auto [hp, ip] = mos_rel_[i[0]];
+        auto [hq, iq] = mos_rel_[i[1]];
+        if (hp == hq) {
+            value = Z_->get(hp, ip, iq);
+        }
+    });
+
+    auto It = ambit::Tensor::build(CoreTensor, "I", {nd, nd});
+    It.iterate([&](const std::vector<size_t>& i, double& value) {
+        if (i[0] == i[1])
+            value = 1.0;
+    });
+
+    auto Cdocc = Csub(hf_docc_mos_);
+    df_helper_->add_space("ALL", C_nosym);
+    df_helper_->add_space("DOCC", Cdocc);
+    df_helper_->add_transformation("A", "ALL", "ALL", "Qpq");
+    df_helper_->add_transformation("B", "DOCC", "ALL", "Qpq");
+    df_helper_->add_transformation("C", "DOCC", "DOCC", "Qpq");
+    df_helper_->transform();
+
+    auto A = df_helper_->get_tensor("A");
+    auto C3pq = ambit::Tensor::build(CoreTensor, "C3pq", {naux, nmo_, nmo_});
+    C_DGEMM('N', 'N', naux, nmo_ * nmo_, naux, 1.0, Jm12->get_pointer(), naux, A->get_pointer(),
+            nmo_ * nmo_, 0.0, C3pq.data().data(), nmo_ * nmo_);
+
+    A = df_helper_->get_tensor("B");
+    auto C3ip = ambit::Tensor::build(CoreTensor, "C3ip", {naux, nd, nmo_});
+    C_DGEMM('N', 'N', naux, nd * nmo_, naux, 1.0, Jm12->get_pointer(), naux, A->get_pointer(),
+            nd * nmo_, 0.0, C3ip.data().data(), nd * nmo_);
+
+    A = df_helper_->get_tensor("C");
+    auto C3ij = ambit::Tensor::build(CoreTensor, "C3ij", {naux, nd, nd});
+    C_DGEMM('N', 'N', naux, nd * nd, naux, 1.0, Jm12->get_pointer(), naux, A->get_pointer(),
+            nd * nd, 0.0, C3ij.data().data(), nd * nd);
+
+    df_helper_->clear_all();
+
+    auto D3pq = ambit::Tensor::build(CoreTensor, "D3pq", {naux, nmo_, nmo_});
+    auto D3ip = ambit::Tensor::build(CoreTensor, "D3ip", {naux, nd, nmo_});
+    auto D3pi = ambit::Tensor::build(CoreTensor, "D3pi", {naux, nmo_, nd});
+    auto D3ij = ambit::Tensor::build(CoreTensor, "D3ij", {naux, nd, nd});
+    D3ij("Qij") += C3pq("Qpq") * Zt("pq") * It("ij");
+    D3pq("Qpq") += Zt("pq") * C3ij("Qij") * It("ij");
+    D3ip("Qiq") -= 0.5 * C3ip("Qip") * Zt("pq");
+    D3pi("Qpi") -= 0.5 * C3ip("Qiq") * Zt("pq");
+
+    auto D3pq_copy = D3pq.clone();
+    for (size_t Q = 0; Q < naux; ++Q) {
+        for (size_t i = 0; i < nd; ++i) {
+            size_t ni = hf_docc_mos_[i];
+            for (size_t j = 0; j < nd; ++j) {
+                size_t nj = hf_docc_mos_[j];
+                D3pq_copy.data()[Q * nmo_ * nmo_ + ni * nmo_ + nj] +=
+                    D3ij.data()[Q * nd * nd + i * nd + j];
+            }
+            for (size_t p = 0; p < nmo_; ++p) {
+                D3pq_copy.data()[Q * nmo_ * nmo_ + ni * nmo_ + p] +=
+                    D3ip.data()[Q * nd * nmo_ + i * nmo_ + p];
+                D3pq_copy.data()[Q * nmo_ * nmo_ + p * nmo_ + ni] +=
+                    D3pi.data()[Q * nd * nmo_ + p * nd + i];
+            }
+        }
+    }
+    // D3pq_copy.print();
+
+    auto D2RS_tmp = ambit::Tensor::build(CoreTensor, "D2RS tmp", {naux, naux});
+    D2RS_tmp("RS") += 2.0 * Zt("pq") * C3pq("Rpq") * C3ij("Sij") * It("ij");
+    D2RS_tmp("RS") -= Zt("pq") * C3ip("Rip") * C3ip("Siq");
+    auto D2RS = ambit::Tensor::build(CoreTensor, "D2RS", {naux, naux});
+    D2RS("RS") += 0.5 * D2RS_tmp("RS");
+    D2RS("RS") += 0.5 * D2RS_tmp("SR");
+
+    // D2RS("RS") = D2RS_tmp("RS");
+
+    // D2RS.print();
+
+    auto Ct = ambit::Tensor::build(CoreTensor, "Ct", {nso_, nmo_});
+    Ct.iterate(
+        [&](const std::vector<size_t>& i, double& value) { value = C_nosym->get(i[0], i[1]); });
+    auto Cd = ambit::Tensor::build(CoreTensor, "Ct", {nso_, nd});
+    Cd.iterate(
+        [&](const std::vector<size_t>& i, double& value) { value = Cdocc->get(i[0], i[1]); });
+
+    auto D3ao = ambit::Tensor::build(CoreTensor, "D3ao", {naux, nso_, nso_});
+    D3ao("QMN") += D3ij("Qij") * Cd("Mi") * Cd("Nj");
+    D3ao("QMN") += D3pq("Qpq") * Ct("Mp") * Ct("Nq");
+    D3ao("QMN") += D3ip("Qip") * Cd("Mi") * Ct("Np");
+    D3ao("QMN") += D3ip("Qip") * Cd("Ni") * Ct("Mp");
+
+    auto D3ao_copy = D3ao.clone();
+    D3ao_copy("QMN") = D3pq_copy("Qpq") * Ct("Mp") * Ct("Nq");
+    D3ao_copy("QMN") -= D3ao("QMN");
+    psi::outfile->Printf("\n QMN DIFF = %20.15f", D3ao_copy.norm());
+
+    // D3ao.print();
+
+    auto d2tmp = std::make_shared<psi::Matrix>("d2tmp", naux, naux);
+    C_DCOPY(naux * naux, D2RS.data().data(), 1, d2tmp->get_pointer(), 1);
+    auto d3tmp = std::make_shared<psi::Matrix>("d3tmp", naux, nso_ * nso_);
+    C_DCOPY(naux * nso_ * nso_, D3ao.data().data(), 1, d3tmp->get_pointer(), 1);
+
+    // d2->add(d2tmp);
+    // d3->add(d3tmp);
+
+    ///////////////////////////////////////////////////////////////
+
+    // Z matrix without symmetry
+    auto Z = ambit::BlockedTensor::build(CoreTensor, "Z", {"fm", "OV", "eu"});
+    for (const std::string& block : Z.block_labels()) {
+        const auto& p_mos = label_to_mos_[block.substr(0, 1)];
+        const auto& q_mos = label_to_mos_[block.substr(1, 1)];
+        Z.block(block).iterate([&](const std::vector<size_t>& i, double& value) {
+            auto [hp, ip] = mos_rel_[p_mos[i[0]]];
+            auto [hq, iq] = mos_rel_[q_mos[i[1]]];
+            if (hp == hq)
+                value = Z_->get(hp, ip, iq);
+        });
+    }
+    // auto Zsub = [&](const std::vector<size_t>& p_mos, const std::vector<size_t>& q_mos) {
+    //     auto np = p_mos.size();
+    //     auto nq = q_mos.size();
+    //     auto Z = ambit::Tensor::build(CoreTensor, "Zsub", {np, nq});
+    //     Z.iterate([&](const std::vector<size_t>& i, double& value) {
+    //         auto [hp, ip] = mos_rel_[p_mos[i[0]]];
+    //         auto [hq, iq] = mos_rel_[q_mos[i[1]]];
+    //         if (hp == hq)
+    //             value = Z_->get(hp, ip, iq);
+    //     });
+    //     return Z;
+    // };
+
+    // 3-index integrals C^{P}_{pq} = (P|Q)^{-1/2} B^{Q}_{pq}
+    auto C3 = ambit::BlockedTensor::build(CoreTensor, "C3", {"LOH", "Leu"});
+    for (const std::string& block : C3.block_labels()) {
+        auto p_mos = label_to_mos_[block.substr(1, 1)];
+        auto q_mos = label_to_mos_[block.substr(2, 1)];
+        auto np = p_mos.size();
+        auto nq = q_mos.size();
         auto Cp = Csub(p_mos);
         auto Cq = Csub(q_mos);
         df_helper_->add_space("p", Cp);
         df_helper_->add_space("q", Cq);
         df_helper_->add_transformation("B", "p", "q", "Qpq");
         df_helper_->transform();
-        auto C3 = psi::linalg::doublet(Jm12, df_helper_->get_tensor("B"));
+        auto B = df_helper_->get_tensor("B");
+        double* C3ptr = C3.block(block).data().data();
+        C_DGEMM('N', 'N', naux, np * nq, naux, 1.0, Jm12->get_pointer(), naux, B->get_pointer(),
+                np * nq, 0.0, C3ptr, np * nq);
         df_helper_->clear_all();
-        return C3;
-    };
+    }
 
-    // 3-index 2-RDMs
-    std::map<std::string, std::shared_ptr<psi::Matrix>> D3map;
+    // identity matrix
+    auto I = ambit::BlockedTensor::build(CoreTensor, "I", {"OO"});
+    I.iterate([&](const std::vector<size_t>& i, const std::vector<SpinType>&, double& value) {
+        if (i[0] == i[1])
+            value = 1.0;
+    });
 
-    auto i_mos = label_to_mos_["m"];
-    auto ni = i_mos.size();
+    // 3-index 2-RDM
+    auto D3 = ambit::BlockedTensor::build(CoreTensor, "D3", {"LfH", "Lmm", "LmV", "Leu"});
 
-    for (std::string pq : {"mf", "eu", "me"}) {
-        auto p_mos = label_to_mos_[pq.substr(0, 1)];
-        auto q_mos = label_to_mos_[pq.substr(1, 1)];
-        auto np = p_mos.size();
-        auto nq = q_mos.size();
-        if (np == 0 or nq == 0)
-            continue;
+    D3["Lkl"] += 2.0 * Z["gh"] * C3["Lgh"] * I["kl"];
+    D3["Lgh"] += Z["gh"] * C3["Lkl"] * I["kl"];
 
-        std::string ip = "m" + pq.substr(0, 1);
-        std::string iq = "m" + pq.substr(1, 1);
-        auto pq_stride = np * nq;
-        auto ip_stride = ni * np;
-        auto iq_stride = ni * nq;
+    // Z occ/vir contribution
+    D3["Lkl"] -= 0.5 * C3["Llc"] * Z["kc"];
+    D3["Llk"] -= 0.5 * C3["Llc"] * Z["kc"];
 
-        // prepare C3ints and D3
-        for (std::string block : {pq, std::string("mm"), ip, iq}) {
-            if (C3ints.find(block) == C3ints.end()) {
-                auto mos1 = label_to_mos_[block.substr(0, 1)];
-                auto mos2 = label_to_mos_[block.substr(1, 1)];
-                C3ints[block] = C3ints_helper(mos1, mos2);
-                D3map[block] =
-                    std::make_shared<psi::Matrix>("D3" + block, naux, mos1.size() * mos2.size());
-                if (block == "mm") {
-                    for (size_t Q = 0; Q < naux; ++Q) {
-                        for (size_t i = 0; i < ni; ++i) {
-                            C3Q[Q] += C3ints["mm"]->get(Q, i * ni + i);
-                        }
-                    }
-                }
-            }
-        }
+    D3["Lkc"] -= 0.5 * C3["Lkl"] * Z["lc"];
 
-        // prepare Z_{pq}
-        auto z = std::make_shared<psi::Matrix>("z_pq", np, nq);
-        for (size_t p = 0; p < np; ++p) {
-            for (size_t q = 0; q < nq; ++q) {
-                z->set(p, q, Z->get(p_mos[p], q_mos[q]));
-            }
-        }
-        double* z_ptr = z->get_pointer();
+    // Z frozen-core/active occ contribution
+    D3["LIk"] -= 0.5 * C3["Lkm"] * Z["Im"];
+    D3["Lmk"] -= 0.5 * C3["LIk"] * Z["Im"];
+    D3["LkI"] -= 0.5 * C3["Lkm"] * Z["Im"];
+    D3["Lkm"] -= 0.5 * C3["LIk"] * Z["Im"];
+
+    // Z active vir/frozen-vir contribution
+    D3["LkA"] -= 0.5 * C3["Lke"] * Z["eA"];
+    D3["Lke"] -= 0.5 * C3["LkA"] * Z["eA"];
+
+    // D3["Lkh"] -= 0.5 * C3["Lkg"] * Z["gh"];
+    // D3["Lkh"] -= 0.5 * C3["LIk"] * Z["Ih"];
+    // D3["Lgk"] -= 0.5 * C3["Lkh"] * Z["gh"];
+    // D3ip("Qiq") -= 0.5 * C3ip("Qip") * Zt("pq");
+    // D3pi("Qpi") -= 0.5 * C3ip("Qiq") * Zt("pq");
+
+    // D3.print();
+
+    // back-transform 3-index 2-RDMs
+    auto d3ptr = d3->get_pointer();
+    for (const std::string& block : D3.block_labels()) {
+        auto bp = block.substr(1, 1);
+        auto bq = block.substr(2, 1);
+        auto np = label_to_mos_[bp].size();
+        auto nq = label_to_mos_[bq].size();
+        auto npq = np * nq;
+
+        auto Cp = Csub(label_to_mos_[bp]);
+        auto Cq = (bp == bq ? Cp : Csub(label_to_mos_[bq]));
+        auto half_trans = std::make_shared<psi::Matrix>("half trans " + block, nso_, nq);
+        double* D3_ptr = D3.block(block).data().data();
+        double* Cp_ptr = Cp->get_pointer();
+        double* Cq_ptr = Cq->get_pointer();
+        double* ht_ptr = half_trans->get_pointer();
 
         for (size_t Q = 0; Q < naux; ++Q) {
-            auto gii = C_DDOT(np * nq, z_ptr, 1, C3ints[pq]->get_pointer() + Q * pq_stride, 1);
-            for (size_t i = 0; i < ni; ++i) {
-                D3map["mm"]->add(i, i, 2 * gii);
+            C_DGEMM('N', 'N', nso_, nq, np, 1.0, Cp_ptr, np, D3_ptr + Q * npq, nq, 0.0, ht_ptr, nq);
+            C_DGEMM('N', 'T', nso_, nso_, nq, 1.0, ht_ptr, nq, Cq_ptr, nq, 1.0, d3ptr + Q * nso2,
+                    nso_);
+            if (bp != bq) {
+                matrix_transpose_in_place(ht_ptr, nso_, nq);
+                C_DGEMM('N', 'N', nso_, nso_, nq, 1.0, Cq_ptr, nq, ht_ptr, nso_, 1.0,
+                        d3ptr + Q * nso2, nso_);
             }
-
-            C_DAXPY(np * nq, 2 * C3Q[Q], z_ptr, 1, D3map[pq]->get_pointer() + Q * pq_stride, 1);
-
-            C_DGEMM('N', 'N', ni, nq, np, -1.0, C3ints[ip]->get_pointer() + Q * ip_stride, np,
-                    z_ptr, nq, 1.0, D3map[iq]->get_pointer() + Q * iq_stride, nq);
-
-            C_DGEMM('N', 'N', ni, np, nq, -1.0, C3ints[iq]->get_pointer() + Q * iq_stride, nq,
-                    z_ptr, np, 1.0, D3map[ip]->get_pointer() + Q * ip_stride, np);
         }
     }
 
     // 2-index 2-RDM
-    for (const auto& kv : D3map) {
-        auto [block, D3] = kv;
-        outfile->Printf("\n D3 block %s", block.c_str());
-        auto C3 = C3ints[block];
-        double factor = (block.substr(0, 1) == block.substr(1, 1) ? 1.0 : 2.0);
-        auto k = C3->ncol();
-        C_DGEMM('N', 'T', naux, naux, k, factor, C3->get_pointer(), k, D3->get_pointer(), k, 1.0,
-                d2->get_pointer(), naux);
+    auto d2ptr = d2->get_pointer();
+    for (const std::string& block : D3.block_labels()) {
+        double* D3ptr = D3.block(block).data().data();
+        double* C3ptr = C3.block(block).data().data();
+        auto factor = (block.substr(1, 1) == block.substr(2, 1) ? 1.0 : 2.0);
+        auto k = C3.block(block).dim(1) * C3.block(block).dim(2);
+        C_DGEMM('N', 'T', naux, naux, k, factor, C3ptr, k, D3ptr, k, 1.0, d2ptr, naux);
     }
 
-    // back-transform 3-index 2-RDM to AO basis
-    for (const auto& kv : D3map) {
-        auto [block, D3] = kv;
-        auto bp = block.substr(0, 1);
-        auto bq = block.substr(1, 1);
-        auto p_mos = label_to_mos_[bp];
-        auto q_mos = label_to_mos_[bq];
-        auto np = p_mos.size();
-        auto nq = q_mos.size();
-        auto pq_stride = np * nq;
-        auto ss_stride = nso_ * nso_;
+    // // C^{P}_{pq} = (P|Q)^{-1/2} B^{Q}_{pq} integrals in ambit form
+    // auto C3ints_helper = [&](const std::vector<size_t>& p_mos, const std::vector<size_t>& q_mos)
+    // {
+    //     auto Cp = Csub(p_mos);
+    //     auto Cq = Csub(q_mos);
+    //     df_helper_->add_space("p", Cp);
+    //     df_helper_->add_space("q", Cq);
+    //     df_helper_->add_transformation("B", "p", "q", "Qpq");
+    //     df_helper_->transform();
+    //     // auto C3 = psi::linalg::doublet(Jm12, df_helper_->get_tensor("B"));
+    //     auto np = p_mos.size();
+    //     auto nq = q_mos.size();
+    //     auto C3 = ambit::Tensor::build(CoreTensor, "C3sub", {naux, np, nq});
+    //     auto B = df_helper_->get_tensor("B");
+    //     C_DGEMM('N', 'N', naux, np * nq, naux, 1.0, Jm12->get_pointer(), naux, B->get_pointer(),
+    //             np * nq, 0.0, C3.data().data(), np * nq);
+    //     df_helper_->clear_all();
+    //     return C3;
+    // };
 
-        auto Cp = Csub(p_mos);
-        auto Cq = Csub(q_mos);
-        auto half_trans = std::make_shared<psi::Matrix>(block + "half trans", nso_, nq);
+    // // precompute sum_{i} C^{Q}_{ii}
+    // auto C3oo = C3ints_helper(hf_docc_mos_, hf_docc_mos_);
+    // auto C3Q = ambit::Tensor::build(CoreTensor, "C3Q", {naux});
+    // auto Ioo = ambit::Tensor::build(CoreTensor, "Ioo", {nd, nd});
+    // for (size_t i = 0; i < nd; ++i) {
+    //     Ioo.data()[i * nd + i] = 1.0;
+    // }
+    // C3Q("Q") = C3oo("Qij") * Ioo("ij");
 
-        for (size_t Q = 0; Q < naux; ++Q) {
-            C_DGEMM('N', 'N', nso_, nq, np, 1.0, Cp->get_pointer(), np,
-                    D3->get_pointer() + Q * pq_stride, nq, 0.0, half_trans->get_pointer(), nq);
-            C_DGEMM('N', 'T', nso_, nso_, nq, 1.0, half_trans->get_pointer(), nq, Cq->get_pointer(),
-                    nq, 1.0, d3->get_pointer() + Q * ss_stride, nso_);
+    // // intermediate of sum_{pq} C^{Q}_{pq} Z_{pq}
+    // auto D3Q = ambit::Tensor::build(CoreTensor, "D3Q", {naux});
 
-            if (bp != bq) {
-                matrix_transpose_in_place(half_trans->get_pointer(), nso_, nq);
-                C_DGEMM('N', 'N', nso_, nso_, nq, 1.0, Cq->get_pointer(), nq,
-                        half_trans->get_pointer(), nso_, 1.0, d3->get_pointer() + Q * ss_stride,
-                        nso_);
-            }
-        }
-    }
+    // // 3-index 2-RDMs from Z occupied - virtual block
+    // auto Zov = Zsub(hf_docc_mos_, hf_uocc_mos_);
+    // auto C3ov = C3ints_helper(hf_docc_mos_, hf_uocc_mos_);
+    // auto D3oo = ambit::Tensor::build(CoreTensor, "D3oo", C3oo.dims());
+    // auto D3ov = ambit::Tensor::build(CoreTensor, "D3ov", C3ov.dims());
+    // D3Q("Q") += 2.0 * C3ov("Qia") * Zov("ia");
+    // D3ov("Qia") += C3Q("Q") * Zov("ia");
+    // D3oo("Qji") -= 0.5 * C3ov("Qib") * Zov("jb");
+    // D3oo("Qij") -= 0.5 * C3ov("Qib") * Zov("jb");
+    // D3ov("Qib") -= 0.5 * C3oo("Qij") * Zov("jb");
+
+    // // 3-index 2-RDMs from Z frozen docc - active docc block
+    // auto Zfm = Zsub(label_to_mos_["f"], label_to_mos_["m"]);
+    // auto C3fm = C3ints_helper(label_to_mos_["f"], label_to_mos_["m"]);
+    // auto D3fm = ambit::Tensor::build(CoreTensor, "D3fm", C3fm.dims());
+    // D3Q("Q") += 2.0 * C3fm("QIk") * Zfm("Ik");
+    // D3fm("QIk") += C3Q("Q") * Zfm("QIk");
+
+    // auto Zue = Zsub(label_to_mos_["u"], label_to_mos_["e"]); // frozen uocc - active uocc
+
+    // D3oo("Qij") += 2.0 * C3ov("Qkb") * Zov("kb") * Ioo("ij");
+
+    // // 3-index 2-RDMs
+    // // std::map<std::string, std::shared_ptr<psi::Matrix>> D3map;
+    // std::map<std::string, ambit::Tensor> D3map;
+
+    // // compute C^{P}_{pq} = (P|Q)^{-1/2} B^{Q}_{pq} integrals in ambit form
+    // // std::map<std::string, std::shared_ptr<psi::Matrix>> C3ints;
+    // std::map<std::string, ambit::Tensor> C3ints;
+
+    // for (const std::string& block : {"ff", "fm", "fe", "fu", "mm", "me", "mu", "eu"}) {
+    //     auto p_mos = label_to_mos_[block.substr(0, 1)];
+    //     auto q_mos = label_to_mos_[block.substr(1, 1)];
+    //     auto np = p_mos.size();
+    //     auto nq = q_mos.size();
+    //     if (np == 0 or nq == 0)
+    //         continue;
+
+    //     C3ints[block] = C3ints_helper(p_mos, q_mos);
+    //     C3ints[block].set_name("C3" + block);
+    //     // D3map[block] = std::make_shared<psi::Matrix>("D3" + block, naux, np * nq);
+    //     D3map[block] = ambit::Tensor::build(CoreTensor, "D3" + block, {naux, np, nq});
+    // }
+
+    // // precompute sum_{i} C^{Q}_{ii}
+    // // std::vector<double> C3Q(naux, 0.0);
+    // // for (const std::string& block : {"f", "m"}) {
+    // //     const auto& C3 = C3ints[block + block];
+    // //     for (size_t Q = 0; Q < naux; ++Q) {
+    // //         for (size_t i = 0, size = label_to_mos_[block].size(); i < size; ++i) {
+    // //             C3Q[Q] += C3->get(i, i);
+    // //         }
+    // //     }
+    // // }
+
+    // // compute 3-index 2-RDMs
+    // // for terms 1 and 2, we loop over upper triangle blocks of Z
+    // // for terms 3 and 4, we loop over upper triangle blocks of D3
+
+    // // precompute sum_{i} C^{Q}_{ii}
+    // auto C3Q = ambit::Tensor::build(CoreTensor, "C3Q", {naux});
+    // for (const std::string& block : {"f", "m"}) {
+    //     const auto& C3 = C3ints[block + block];
+    //     auto I = ambit::Tensor::build(CoreTensor, "I" + block + block, {C3.dim(1), C3.dim(2)});
+    //     I.iterate([&](const std::vector<size_t>& i, double& value) {
+    //         if (i[0] == i[1])
+    //             value = 1.0;
+    //     });
+    //     C3Q("Q") += C3("Qij") * I("ij");
+    // }
+
+    // // DOCC diagonal contribution of 3-index 2-RDMs
+    // auto D3Q = ambit::Tensor::build(CoreTensor, "D3Q", {naux});
+
+    // // loop over nonzero Z blocks, upper triangle
+    // for (const std::string& block : {"fm", "fe", "fu", "me", "mu", "eu"}) {
+    //     auto bp = block.substr(0, 1);
+    //     auto bq = block.substr(1, 1);
+    //     auto np = label_to_mos_[bp].size();
+    //     auto nq = label_to_mos_[bq].size();
+    //     if (np == 0 or nq == 0)
+    //         continue;
+
+    //     // auto npq = np * nq;
+    //     // auto bfp = "f" + bp, bmp = "m" + bp, bpm = bp + "m";
+    //     // auto bfq = "f" + bq, bmq = "m" + bq;
+    //     // auto nfp = nf * np, nmp = nm * np;
+    //     // auto nfq = nf * nq, nmq = nm * nq;
+
+    //     auto Zpq = Zsub(label_to_mos_[bp], label_to_mos_[bq]);
+
+    //     // D3^{Q}_{ii} <- C3^{Q}_{pq} * ( z_{pq} + z_{qp} ) for p < q
+    //     D3Q("Q") += 2.0 * C3ints[block]("Qpq") * Zpq("pq");
+
+    //     // D3^{Q}_{pq} <- z_{pq} * C3^{Q}_{ii}
+    //     D3map[block]("Qpq") += Zpq("pq") * C3Q("Q");
+
+    //     // // D3^{Q}_{iq} <- -0.5 * C3^{Q}_{ip} * ( z_{pq} + z_{qp} ) for p < q
+    //     // D3map[bfq]("Qiq") -= 0.5 * C3ints[bfp]("Qip") * Zpq("pq");
+    //     // D3map[bfp]("Qip") -= (bp == "f" ? 1 : 0.5) * C3ints[bfq]("Qiq") * Zpq("pq");
+
+    //     // // special case for frozen-core i index ("mf", "ef", "uf" blocks are not available)
+    //     // if (bp == "f") {
+    //     //     D3map[bmq]("Qiq") -= 0.5 * C3ints[bpm]("Qpi") * Zpq("pq");
+    //     //     D3map[bpm]("Qpi") -= 0.5 * C3ints[bmq]("Qiq") * Zpq("pq");
+
+    //     // } else {
+    //     //     D3map[bmq]("Qiq") -= 0.5 * C3ints[bmp]("Qip") * Zpq("pq");
+    //     //     D3map[bmp]("Qip") -= 0.5 * C3ints[bmq]("Qiq") * Zpq("pq");
+    //     // }
+
+    //     // // D3^{Q}_{pi} <- -0.5 * C3^{Q}_{iq} * ( z_{pq} + z_{qp} ) for p < q
+    // }
+    // for (const std::string& block : {"f", "m"}) {
+    //     const auto& D3 = D3map[block + block];
+    //     auto I = ambit::Tensor::build(CoreTensor, "I" + block + block, {D3.dim(1), D3.dim(2)});
+    //     I.iterate([&](const std::vector<size_t>& i, double& value) {
+    //         if (i[0] == i[1])
+    //             value = 1.0;
+    //     });
+    //     D3("Qij") += D3Q("Q") * I("ij");
+    // }
+
+    // for (const std::string& block : {"ff", "fm", "fe", "fu", "mm", "me", "mu"}) {
+    //     if (D3map.find(block) == D3map.end())
+    //         continue;
+    //     auto bi = block.substr(0, 1);
+    //     auto bq = block.substr(1, 1);
+
+    //     auto factor = (bi == bq ? 1.0 : 0.5);
+
+    //     for (const std::string& bp : {"f", "m", "e", "u"}) {
+    //         auto bip = bi + bp;
+    //         std::string ip = "ip";
+    //         if (C3ints.find(bip) == C3ints.end()) {
+    //             bip = bp + bi;
+    //             ip = "pi";
+    //         }
+    //         D3map[block]("Qiq") -= factor * C3ints[bip]("Q" + ip) * Zblocks[bp + bq]("pq");
+    //     }
+
+    //     if (block == "fm") {
+    //         for (const std::string& bp : {"f", "m", "e", "u"}) {
+    //             auto bqp = bq + bp;
+    //             std::string qp = "qp";
+    //             if (C3ints.find(bqp) == C3ints.end()) {
+    //                 bqp = bp + bq;
+    //                 qp = "pq";
+    //             }
+    //             D3map[block]("Qiq") -= 0.5 * C3ints[bqp]("Q" + qp) * Zblocks[bp + bi]("pi");
+    //         }
+    //     }
+    // }
+
+    // for (const auto& pair : D3map) {
+    //     const auto& [block, D3] = pair;
+    //     D3.print();
+    // }
+
+    // // back-transform 3-index 2-RDMs
+    // auto d3_tmp = std::make_shared<psi::Matrix>("d3_tmp", naux, nso_ * nso_);
+    // double* d3ptr = d3_tmp->get_pointer();
+    // for (auto& block_matrix : D3map) {
+    //     auto& [block, D3] = block_matrix;
+    //     auto bp = block.substr(0, 1);
+    //     auto bq = block.substr(1, 1);
+    //     auto np = label_to_mos_[bp].size();
+    //     auto nq = label_to_mos_[bq].size();
+    //     auto npq = np * nq;
+
+    //     auto Cp = Csub(label_to_mos_[bp]);
+    //     auto Cq = (bp == bq ? Cp : Csub(label_to_mos_[bq]));
+    //     auto half_trans = std::make_shared<psi::Matrix>("half trans " + block, nso_, nq);
+    //     double* D3_ptr = D3.data().data();
+    //     double* Cp_ptr = Cp->get_pointer();
+    //     double* Cq_ptr = Cq->get_pointer();
+    //     double* ht_ptr = half_trans->get_pointer();
+
+    //     for (size_t Q = 0; Q < naux; ++Q) {
+    //         C_DGEMM('N', 'N', nso_, nq, np, 1.0, Cp_ptr, np, D3_ptr + Q * npq, nq, 0.0, ht_ptr,
+    //         nq); C_DGEMM('N', 'T', nso_, nso_, nq, 1.0, ht_ptr, nq, Cq_ptr, nq, 1.0, d3ptr + Q *
+    //         nso2,
+    //                 nso_);
+    //         if (bp != bq) {
+    //             matrix_transpose_in_place(ht_ptr, nso_, nq);
+    //             C_DGEMM('N', 'N', nso_, nso_, nq, 1.0, Cq_ptr, nq, ht_ptr, nso_, 1.0,
+    //                     d3ptr + Q * nso2, nso_);
+    //         }
+    //     }
+    // }
+
+    // d3_tmp->subtract(d3tmp);
+    // d3_tmp->print();
+    // psi::outfile->Printf("\n D3 diff = %20.15f", d3_tmp->rms());
+
+    // for (std::string pq : {"mf", "eu", "me"}) {
+    //     auto p_mos = label_to_mos_[pq.substr(0, 1)];
+    //     auto q_mos = label_to_mos_[pq.substr(1, 1)];
+    //     auto np = p_mos.size();
+    //     auto nq = q_mos.size();
+    //     if (np == 0 or nq == 0)
+    //         continue;
+
+    //     std::string ip = "i" + pq.substr(0, 1);
+    //     std::string iq = "i" + pq.substr(1, 1);
+    //     auto pq_stride = np * nq;
+    //     auto ip_stride = ni * np;
+    //     auto iq_stride = ni * nq;
+
+    //     // prepare C3ints and D3
+    //     for (std::string block : {pq, std::string("ii"), ip, iq}) {
+    //         if (C3ints.find(block) == C3ints.end()) {
+    //             auto mos1 = label_to_mos_[block.substr(0, 1)];
+    //             auto mos2 = label_to_mos_[block.substr(1, 1)];
+    //             C3ints[block] = C3ints_helper(mos1, mos2);
+    //             D3map[block] =
+    //                 std::make_shared<psi::Matrix>("D3" + block, naux, mos1.size() * mos2.size());
+    //             if (block == "ii") {
+    //                 for (size_t Q = 0; Q < naux; ++Q) {
+    //                     for (size_t i = 0; i < ni; ++i) {
+    //                         C3Q[Q] += C3ints["ii"]->get(Q, i * ni + i);
+    //                     }
+    //                 }
+    //             }
+    //         }
+    //     }
+
+    //     // prepare Z_{pq}
+    //     auto z = std::make_shared<psi::Matrix>("z_pq", np, nq);
+    //     for (size_t p = 0; p < np; ++p) {
+    //         for (size_t q = 0; q < nq; ++q) {
+    //             z->set(p, q, Z->get(p_mos[p], q_mos[q]));
+    //         }
+    //     }
+    //     double* z_ptr = z->get_pointer();
+
+    //     for (size_t Q = 0; Q < naux; ++Q) {
+    //         auto gii = C_DDOT(np * nq, z_ptr, 1, C3ints[pq]->get_pointer() + Q * pq_stride, 1);
+    //         for (size_t i = 0; i < ni; ++i) {
+    //             D3map["ii"]->add(i, i, gii);
+    //         }
+
+    //         C_DAXPY(np * nq, C3Q[Q], z_ptr, 1, D3map[pq]->get_pointer() + Q * pq_stride, 1);
+
+    //         C_DGEMM('N', 'N', ni, nq, np, -0.5, C3ints[ip]->get_pointer() + Q * ip_stride, np,
+    //                 z_ptr, nq, 1.0, D3map[iq]->get_pointer() + Q * iq_stride, nq);
+
+    //         C_DGEMM('N', 'N', ni, np, nq, -0.5, C3ints[iq]->get_pointer() + Q * iq_stride, nq,
+    //                 z_ptr, np, 1.0, D3map[ip]->get_pointer() + Q * ip_stride, np);
+    //     }
+    // }
+
+    // // 2-index 2-RDM
+    // for (const auto& kv : D3map) {
+    //     auto [block, D3] = kv;
+    //     outfile->Printf("\n D3 block %s", block.c_str());
+    //     auto C3 = C3ints[block];
+    //     double factor = (block.substr(0, 1) == block.substr(1, 1) ? 1.0 : 2.0);
+    //     auto k = C3->ncol();
+    //     C_DGEMM('N', 'T', naux, naux, k, factor, C3->get_pointer(), k, D3->get_pointer(), k, 1.0,
+    //             d2->get_pointer(), naux);
+    // }
 }
 
 void MCSCF_ORB_GRAD::dump_tpdm_iwl() {

--- a/forte/options.yaml
+++ b/forte/options.yaml
@@ -53,6 +53,10 @@ Driver:
     default: "SS"
     choices: ["SS", "SA", "MS", "DWMS"]
     help: "The type of computation"
+  MCSCF_REFERENCE:
+    type: bool
+    default: True
+    help: "Whether to use MCSCF reference in Forte or not"
   NEL:
     type: int
     default: None
@@ -1359,10 +1363,6 @@ MCSCF:
     type: int
     default: 1
     help: "How often to solve CI?\n< 1: do CI in the first macro iteration ONLY\n= n: do CI every n macro iteration"
-  MCSCF_REFERENCE:
-    type: bool
-    default: True
-    help: "Force to use MCSCF reference in Forte"
   MCSCF_DF_TEIALG:
     type: bool
     default: True

--- a/forte/options.yaml
+++ b/forte/options.yaml
@@ -1363,10 +1363,10 @@ MCSCF:
     type: bool
     default: True
     help: "Run a FCI followed by MCSCF computation?"
-  MCSCF_FREEZE_CORE:
+  MCSCF_IGNORE_FROZEN_ORBS:
     type: bool
-    default: False
-    help: "Freeze core orbitals in MCSCF?"
+    default: True
+    help: "Ignore frozen orbitals in the input file for MCSCF or not"
   MCSCF_MULTIPLICITY:
     type: int
     default: 0

--- a/forte/options.yaml
+++ b/forte/options.yaml
@@ -1362,7 +1362,11 @@ MCSCF:
   MCSCF_REFERENCE:
     type: bool
     default: True
-    help: "Run a FCI followed by MCSCF computation?"
+    help: "Force to use MCSCF reference in Forte"
+  MCSCF_DF_TEIALG:
+    type: bool
+    default: True
+    help: "Algorithm to build (pu|xy) integrals in DF-MCSCF. Use (Q|pu) if True; Otherwise use JK build for every xy pair"
   MCSCF_IGNORE_FROZEN_ORBS:
     type: bool
     default: True

--- a/forte/pymodule.py
+++ b/forte/pymodule.py
@@ -189,14 +189,14 @@ def energy_forte(name, **kwargs):
         psi4.core.print_out("\n\n  Skipping MCSCF computation. Using HF or orbitals passed via ref_wfn\n")
     else:
         active_space_solver_type = data.options.get_str("ACTIVE_SPACE_SOLVER")
-        mcscf_freeze_core = data.options.get_bool("MCSCF_FREEZE_CORE")
+        mcscf_ignore_frozen = data.options.get_bool("MCSCF_IGNORE_FROZEN_ORBS")
 
-        # freeze core orbitals check
-        frozen_docc_set = data.mo_space_info.size("FROZEN_DOCC") > 0
-        if not mcscf_freeze_core and frozen_docc_set and data.options.get_str("CORRELATION_SOLVER") == "NONE":
-            msg = "\n  WARNING: By default, Forte will not freeze core orbitals in MCSCF,\n  unless the option MCSCF_FREEZE_CORE is set to True.\n"
-            msg += f"\n  Your input file specifies the FROZEN_DOCC array ({data.mo_space_info.size('FROZEN_DOCC')} MOs) in the\n  MO_SPACE_INFO block, but the option MCSCF_FREEZE_CORE is set to False.\n"
-            msg += "\n  If you want to freeze the core orbitals in MCSCF, set MCSCF_FREEZE_CORE to True,\n  otherwise change the FROZEN_DOCC array to zero(s) and update the RESTRICTED_DOCC array.\n"
+        # freeze core/virtual orbitals check
+        frozen_set = data.mo_space_info.size("FROZEN_DOCC") > 0 or data.mo_space_info.size("FROZEN_UOCC") > 0
+        if mcscf_ignore_frozen and frozen_set and data.options.get_str("CORRELATION_SOLVER") == "NONE":
+            msg = "\n  WARNING: By default, Forte will not freeze core/virtual orbitals in MCSCF,\n  unless the option MCSCF_IGNORE_FROZEN_ORBS is set to False.\n"
+            msg += f"\n  Your input file specifies the FROZEN_DOCC ({data.mo_space_info.size('FROZEN_DOCC')} MOs) / FROZEN_UOCC ({data.mo_space_info.size('FROZEN_UOCC')} MOs) arrays in the\n  MO_SPACE_INFO block, but the option MCSCF_IGNORE_FROZEN_ORBS is set to True.\n"
+            msg += "\n  If you want to freeze the core/virtual orbitals in MCSCF, set MCSCF_IGNORE_FROZEN_ORBS to False,\n  otherwise change the FROZEN_DOCC/FROZEN_UOCC arrays to zero(s) and update the RESTRICTED_DOCC/RESTRICTED_UOCC arrays.\n"
             print(msg)
             psi4.core.print_out(msg)
 
@@ -294,7 +294,7 @@ def gradient_forte(name, **kwargs):
         OrbitalTransformation(orb_type, job_type != "NONE").run(data)
 
     active_space_solver_type = data.options.get_str("ACTIVE_SPACE_SOLVER")
-    mcscf_freeze_core = data.options.get_bool("MCSCF_FREEZE_CORE")
+    mcscf_ignore_frozen = data.options.get_bool("MCSCF_IGNORE_FROZEN_ORBS")
     data = MCSCF(active_space_solver_type).run(data)
     energy = data.results.value("energy")
 

--- a/tests/manual/mcscf-5/input.dat
+++ b/tests/manual/mcscf-5/input.dat
@@ -26,8 +26,8 @@ set forte {
   mcscf_e_convergence  8  # energy convergence of the MCSCF iterations
   mcscf_g_convergence  6  # gradient convergence of the MCSCF iterations
   mcscf_micro_maxiter  4  # do at most 4 micro iterations per macro iteration
-  mcscf_freeze_core    true  # enables freezing the MCSCF core orbitals
+  mcscf_ignore_frozen_orbs false  # enables freezing the MCSCF core orbitals
 }
 
 energy('forte')
-compare_values(-112.871834862958, variable("CURRENT ENERGY"), 11, "MCSCF energy")
+compare_values(-112.871834862958, variable("CURRENT ENERGY"), 8, "MCSCF energy")

--- a/tests/methods/aci_scf-1/input.dat
+++ b/tests/methods/aci_scf-1/input.dat
@@ -41,7 +41,7 @@ set forte{
    int_type                conventional
    sigma                   0.0
    gamma                   0.0
-   mcscf_freeze_core       true
+   mcscf_ignore_frozen_orbs false
    mcscf_do_diis           false
 }
 

--- a/tests/methods/casscf-3/input.dat
+++ b/tests/methods/casscf-3/input.dat
@@ -30,7 +30,7 @@ set forte {
   active                [3, 0, 1, 2]
   mcscf_e_convergence   1e-10
   mcscf_g_convergence   1e-6
-  mcscf_freeze_core     true
+  mcscf_ignore_frozen_orbs false
 }
 
 mcscf_forte = energy('forte')

--- a/tests/methods/casscf-5/input.dat
+++ b/tests/methods/casscf-5/input.dat
@@ -30,7 +30,7 @@ set forte {
    root_sym                0
    nroot                   1
    multiplicity            1
-   mcscf_freeze_core       true
+   mcscf_ignore_frozen_orbs false
 }
 
 energy('forte')

--- a/tests/methods/casscf-6/input.dat
+++ b/tests/methods/casscf-6/input.dat
@@ -20,7 +20,7 @@ set forte{
    frozen_docc             [1,0,0,0]
    restricted_docc         [1,0,1,1]
    active                  [2,0,0,0]
-   mcscf_freeze_core       true
+   mcscf_ignore_frozen_orbs false
 }
 
 energy('forte')

--- a/tests/methods/casscf-fcidump-1/input.dat
+++ b/tests/methods/casscf-fcidump-1/input.dat
@@ -24,7 +24,7 @@ set forte {
   frozen_uocc        [0,0,0,0]
   restricted_docc    [2,0,0,0]
   active             [2,0,2,2]
-  mcscf_freeze_core true
+  mcscf_ignore_frozen_orbs false
   e_convergence      8
   r_convergence      8
 }

--- a/tests/methods/casscf-gradient-2/input.dat
+++ b/tests/methods/casscf-gradient-2/input.dat
@@ -33,7 +33,7 @@ set forte{
   mcscf_g_convergence 1e-12
   mcscf_e_convergence 1e-12
   cpscf_convergence    1e-10
-  mcscf_freeze_core   true
+  mcscf_ignore_frozen_orbs false
 }
 
 grad = gradient('forte')

--- a/tests/methods/casscf-gradient-3/input.dat
+++ b/tests/methods/casscf-gradient-3/input.dat
@@ -48,7 +48,7 @@ set forte{
   mcscf_maxiter       100
   mcscf_g_convergence 1e-10
   mcscf_e_convergence 1e-12
-  mcscf_freeze_core   true
+  mcscf_ignore_frozen_orbs false
   cpscf_convergence    1e-10
 }
 

--- a/tests/methods/casscf-opt-3/input.dat
+++ b/tests/methods/casscf-opt-3/input.dat
@@ -22,7 +22,7 @@ set globals{
 set forte{
   active_space_solver     fci
   frozen_docc             [1,0,0,0]
-  mcscf_freeze_core      true
+  mcscf_ignore_frozen_orbs false
 }
 
 Eopt = optimize('forte')

--- a/tests/methods/df-casscf-1/input.dat
+++ b/tests/methods/df-casscf-1/input.dat
@@ -40,7 +40,7 @@ set forte{
   mcscf_maxiter          25
   mcscf_e_convergence    7
   mcscf_g_convergence    7
-  mcscf_freeze_core      true
+  mcscf_ignore_frozen_orbs false
   print                   0
 }
 Ecas_1 = energy('forte')

--- a/tests/methods/df-casscf-gradient-1/input.dat
+++ b/tests/methods/df-casscf-gradient-1/input.dat
@@ -1,0 +1,54 @@
+# A test of analytic DF-CASSCF gradients on N2
+
+import forte
+
+ref_grad = psi4.Matrix.from_list([
+    [ 0.0000000000,  0.0000000000,  0.4930152443],
+    [-0.0000000000,  0.0000000000, -0.4930152443]
+])
+ref_grad_fc = psi4.Matrix.from_list([
+    [ 0.0000000000, -0.0000000000,  0.4931039074],
+    [-0.0000000000,  0.0000000000, -0.4931039074]
+])
+
+molecule N2{
+N
+N 1 1.0
+}
+
+set globals {
+  scf_type             df
+  reference            rhf
+  e_convergence        10
+  d_convergence        8
+  maxiter              100
+  basis                cc-pvdz
+  df_basis_mp2         cc-pvdz-jkfit
+  df_basis_scf         cc-pvdz-jkfit
+  docc                 [3,0,0,0,0,2,1,1]
+}
+
+set forte{
+  int_type             df
+  active_space_solver  fci
+  restricted_docc      [2,0,0,0,0,2,0,0]
+  active               [1,0,1,1,0,1,1,1]
+  e_convergence        12
+  mcscf_maxiter       100
+  mcscf_g_convergence 1e-12
+  mcscf_e_convergence 1e-12
+  cpscf_convergence   1e-12
+  mcscf_ignore_frozen_orbs false
+}
+
+#set gradient_write true
+#set findif points 5
+grad = gradient('forte')
+compare_matrices(ref_grad, grad, 8, "DF-CASSCF(6,6)/cc-pVDZ/AE gradient on N2")
+
+set forte{
+  frozen_docc          [1,0,0,0,0,1,0,0]
+  restricted_docc      [1,0,0,0,0,1,0,0]
+}
+grad = gradient('forte')
+compare_matrices(ref_grad_fc, grad, 8, "DF-CASSCF(6,6)/cc-pVDZ/FC gradient on N2")

--- a/tests/methods/df-casscf-gradient-1/output.ref
+++ b/tests/methods/df-casscf-gradient-1/output.ref
@@ -1,0 +1,1722 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.10a1.dev48 
+
+                         Git: Rev {master} 1813c0c dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide,
+    M. F. Herbst, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Thursday, 05 September 2024 04:04AM
+
+    Process ID: 12513
+    Host:       Chenyangs-MacBook-Pro.local
+    PSIDATADIR: /Users/york/src/psi4-build/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+# A test of analytic DF-CASSCF gradients on N2
+
+import forte
+
+ref_grad = psi4.Matrix.from_list([
+    [ 0.0000000000,  0.0000000000,  0.4930152443],
+    [-0.0000000000,  0.0000000000, -0.4930152443]
+])
+ref_grad_fc = psi4.Matrix.from_list([
+    [ 0.0000000000, -0.0000000000,  0.4931039074],
+    [-0.0000000000,  0.0000000000, -0.4931039074]
+])
+
+molecule N2{
+N
+N 1 1.0
+}
+
+set globals {
+  scf_type             df
+  reference            rhf
+  e_convergence        10
+  d_convergence        8
+  maxiter              100
+  basis                cc-pvdz
+  df_basis_mp2         cc-pvdz-jkfit
+  df_basis_scf         cc-pvdz-jkfit
+  docc                 [3,0,0,0,0,2,1,1]
+}
+
+set forte{
+  int_type             df
+  active_space_solver  fci
+  restricted_docc      [2,0,0,0,0,2,0,0]
+  active               [1,0,1,1,0,1,1,1]
+  e_convergence        12
+  mcscf_maxiter       100
+  mcscf_g_convergence 1e-12
+  mcscf_e_convergence 1e-12
+  cpscf_convergence   1e-12
+  mcscf_ignore_frozen_orbs false
+}
+
+#set gradient_write true
+#set findif points 5
+grad = gradient('forte')
+compare_matrices(ref_grad, grad, 8, "DF-CASSCF(6,6)/cc-pVDZ/AE gradient on N2")
+
+set forte{
+  frozen_docc          [1,0,0,0,0,1,0,0]
+  restricted_docc      [1,0,0,0,0,1,0,0]
+}
+grad = gradient('forte')
+compare_matrices(ref_grad_fc, grad, 8, "DF-CASSCF(6,6)/cc-pVDZ/FC gradient on N2")
+--------------------------------------------------------------------------
+
+Scratch directory: /Users/york/scratch/psi4/
+gradient() will perform analytic gradient computation.
+
+  Forte
+  ----------------------------------------------------------------------------
+  A suite of quantum chemistry methods for strongly correlated electrons
+
+    git branch: dfmcscf_grad - git commit: 320e18ba
+
+  Developed by:
+    Francesco A. Evangelista, Chenyang Li, Kevin P. Hannon,
+    Jeffrey B. Schriber, Tianyuan Zhang, Chenxi Cai,
+    Nan He, Nicholas Stair, Shuhe Wang, Renke Huang
+  ----------------------------------------------------------------------------
+
+
+  Preparing forte objects from a Psi4 Wavefunction object
+  No reference wave function provided for Forte. Computing SCF orbitals using Psi4 ...
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  5, 4, 3
+    Auxiliary basis highest AM E, G, H:  6, 5, 4
+    Onebody   basis highest AM E, G, H:  6, 5, 4
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on Chenyangs-MacBook-Pro.local
+*** at Thu Sep  5 04:04:49 2024
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry N          line   168 file /Users/york/src/psi4-build/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         N            0.000000000000     0.000000000000    -0.500000000000    14.003074004430
+         N            0.000000000000     0.000000000000     0.500000000000    14.003074004430
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      2.40770  C =      2.40770 [cm^-1]
+  Rotational constants: A = ************  B =  72181.15232  C =  72181.15232 [MHz]
+  Nuclear repulsion =   25.929683322829987
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 28
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry N          line   171 file /Users/york/src/psi4-build/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: CC-PVDZ-JKFIT
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 48
+    Number of basis functions: 140
+    Number of Cartesian functions: 162
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 8.5752098786E-03.
+  Reciprocal condition number of the overlap matrix is 2.9332613017E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag         7       7 
+     B1g        1       1 
+     B2g        3       3 
+     B3g        3       3 
+     Au         1       1 
+     B1u        7       7 
+     B2u        3       3 
+     B3u        3       3 
+   -------------------------
+    Total      28      28
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -109.50010367949019   -1.09500e+02   0.00000e+00 
+   @DF-RHF iter   1:  -108.64688940446088    8.53214e-01   6.63039e-02 DIIS/ADIIS
+   @DF-RHF iter   2:  -108.91340512996361   -2.66516e-01   1.62149e-02 DIIS/ADIIS
+   @DF-RHF iter   3:  -108.92943887410331   -1.60337e-02   1.03694e-03 DIIS/ADIIS
+   @DF-RHF iter   4:  -108.92956078123147   -1.21907e-04   2.16559e-04 DIIS/ADIIS
+   @DF-RHF iter   5:  -108.92956651876540   -5.73753e-06   1.87200e-05 DIIS
+   @DF-RHF iter   6:  -108.92956655142635   -3.26609e-08   7.47392e-07 DIIS
+   @DF-RHF iter   7:  -108.92956655146612   -3.97762e-11   9.92034e-08 DIIS
+   @DF-RHF iter   8:  -108.92956655146688   -7.53175e-13   6.61492e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag   -15.655988     1B1u  -15.649496     2Ag    -1.544209  
+       2B1u   -0.741102     1B2u   -0.653686     1B3u   -0.653686  
+       3Ag    -0.633585  
+
+    Virtual:                                                              
+
+       1B2g    0.230627     1B3g    0.230627     3B1u    0.616590  
+       4Ag     0.785928     2B3u    0.841040     2B2u    0.841040  
+       5Ag     1.006309     2B2g    1.077606     2B3g    1.077606  
+       4B1u    1.298255     6Ag     1.729597     1B1g    1.729597  
+       5B1u    1.767463     3B2u    1.994670     3B3u    1.994670  
+       6B1u    2.371054     1Au     2.371054     7Ag     2.953970  
+       3B2g    3.109175     3B3g    3.109175     7B1u    3.597508  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    NA   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+  @DF-RHF Final Energy:  -108.92956655146688
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             25.9296833228299874
+    One-Electron Energy =                -198.6549980288319261
+    Two-Electron Energy =                  63.7957481545350547
+    Total Energy =                       -108.9295665514668769
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000           -0.0000000           -0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on Chenyangs-MacBook-Pro.local at Thu Sep  5 04:04:49 2024
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.00 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+
+  Read options for space RESTRICTED_DOCC
+  Read options for space ACTIVE
+  Read options for space RESTRICTED_DOCC
+
+  ==> MO Space Information <==
+
+  -------------------------------------------------------------------------
+                       Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u   Sum
+  -------------------------------------------------------------------------
+    FROZEN_DOCC         0     0     0     0     0     0     0     0     0
+    RESTRICTED_DOCC     2     0     0     0     0     2     0     0     4
+    GAS1                1     0     1     1     0     1     1     1     6
+    GAS2                0     0     0     0     0     0     0     0     0
+    GAS3                0     0     0     0     0     0     0     0     0
+    GAS4                0     0     0     0     0     0     0     0     0
+    GAS5                0     0     0     0     0     0     0     0     0
+    GAS6                0     0     0     0     0     0     0     0     0
+    RESTRICTED_UOCC     4     1     2     2     1     4     2     2    18
+    FROZEN_UOCC         0     0     0     0     0     0     0     0     0
+    Total               7     1     3     3     1     7     3     3    28
+  -------------------------------------------------------------------------   => Loading Basis Set <=
+
+    Name: CC-PVDZ-JKFIT
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1-2 entry N          line   171 file /Users/york/src/psi4-build/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: MINAO_BASIS
+    atoms 1-2 entry N          line    71 file /Users/york/src/psi4-build/stage/share/psi4/basis/sto-3g.gbs 
+
+
+  State Singlet (Ms = 0) Ag GAS min: 0 0 0 0 0 0 ; GAS max: 12 0 0 0 0 0 ; weights:
+      1.000000000000
+  Forte will use psi4 integrals
+
+  ==> Primary Basis Set Summary <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 28
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+
+  JK created using MemDF integrals
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.391 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               400
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: CC-PVDZ-JKFIT
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 48
+    Number of basis functions: 140
+    Number of Cartesian functions: 162
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+
+
+  ==> Integral Transformation <==
+
+  Number of molecular orbitals:                         28
+  Number of correlated molecular orbitals:              28
+  Number of frozen occupied orbitals:                    0
+  Number of frozen unoccupied orbitals:                  0
+  Two-electron integral type:              Density fitting
+
+
+  Computing density fitted integrals
+
+  Number of auxiliary basis functions:  140
+  Need 878.08 KB to store DF integrals
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.438 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> DFHelper <==
+    NBF:                              28
+    NAux:                            140
+    Schwarz Cutoff:                1E-12
+    Mask sparsity (%):                 0
+    DFH Avail. Memory [GiB]:       0.438
+    OpenMP threads:                    1
+    Algorithm:                     STORE
+    AO Core:                        True
+    MO Core:                       False
+    Hold Metric:                   False
+    Metric Power:                 -0.500
+    Fitting Condition:             1E-10
+    Q Shell Max:                       7
+
+
+
+  Transforming DF Integrals
+  Timing for density-fitting transformation:                  0.003 s.
+
+  Timing for freezing core and virtual orbitals:              0.000 s.
+  Timing for computing density-fitted integrals:              0.015 s.
+
+  ==> Primary Basis Set Summary <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 28
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+
+  JK created using MemDF integrals
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.391 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               400
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: CC-PVDZ-JKFIT
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 48
+    Number of basis functions: 140
+    Number of Cartesian functions: 162
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+
+
+  ==> Integral Transformation <==
+
+  Number of molecular orbitals:                         28
+  Number of correlated molecular orbitals:              28
+  Number of frozen occupied orbitals:                    0
+  Number of frozen unoccupied orbitals:                  0
+  Two-electron integral type:              Density fitting
+
+
+  Computing density fitted integrals
+
+  Number of auxiliary basis functions:  140
+  Need 878.08 KB to store DF integrals
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.438 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> DFHelper <==
+    NBF:                              28
+    NAux:                            140
+    Schwarz Cutoff:                1E-12
+    Mask sparsity (%):                 0
+    DFH Avail. Memory [GiB]:       0.438
+    OpenMP threads:                    1
+    Algorithm:                     STORE
+    AO Core:                        True
+    MO Core:                       False
+    Hold Metric:                   False
+    Metric Power:                 -0.500
+    Fitting Condition:             1E-10
+    Q Shell Max:                       7
+
+
+
+  Transforming DF Integrals
+  Timing for density-fitting transformation:                  0.003 s.
+
+  Timing for freezing core and virtual orbitals:              0.000 s.
+  Timing for computing density-fitted integrals:              0.017 s.
+
+          -----------------------------------------------------------
+                  Multi-Configurational Self Consistent Field
+                Two-Step Approximate Second-Order AO Algorithm
+            written by Chenyang Li, Kevin P. Hannon, and Shuhe Wang
+          -----------------------------------------------------------
+
+
+  ==> MCSCF Calculation Information <==
+
+    --------------------------------------------------------
+    Print level                                      Default
+    Integral type                                         DF
+    CI solver type                                       FCI
+    Final orbital type                             CANONICAL
+    Derivative type                                    FIRST
+    Optimize orbitals                                   TRUE
+    Include internal rotations                         FALSE
+    Debug printing                                     FALSE
+    Energy convergence                             1.000e-12
+    Gradient convergence                           1.000e-12
+    Max value for rotation                         2.000e-01
+    Max number of macro iter.                            100
+    Max number of micro iter. for orbitals                 6
+    Max number of micro iter. for CI                      12
+    DIIS start                                            15
+    Min DIIS vectors                                       3
+    Max DIIS vectors                                       8
+    Frequency of DIIS extrapolation                        1
+    --------------------------------------------------------
+
+  ==> Independent Orbital Rotations <==
+
+    ORBITAL SPACES                        Ag    B1g    B2g    B3g     Au    B1u    B2u    B3u
+    -----------------------------------------------------------------------------------------
+             ACTIVE / RESTRICTED_DOCC      2      0      0      0      0      2      0      0
+    RESTRICTED_UOCC /          ACTIVE      4      0      2      2      0      4      2      2
+    RESTRICTED_UOCC / RESTRICTED_DOCC      8      0      0      0      0      8      0      0
+    -----------------------------------------------------------------------------------------
+
+  DF-MCSCF adopts integrals from DFHelper of Psi4.
+
+
+  ==> String Lists <==
+
+    --------------------------------------------------------
+    number of alpha electrons                              3
+    number of beta electrons                               3
+    number of alpha strings                               20
+    number of beta strings                                20
+    --------------------------------------------------------
+
+  ==> FCI Solver <==
+
+    --------------------------------------------------------
+    Spin adapt                                         FALSE
+    Number of determinants                                56
+    Symmetry                                               0
+    Multiplicity                                           1
+    Number of roots                                        1
+    Target root                                            0
+    --------------------------------------------------------
+  Initial guess space is incomplete.
+  Adding 1 determinant(s).
+
+  ==> Initial Guess <==
+
+  Initial guess determinants:         51
+
+  Classification of the initial guess solutions
+
+  Number   2S+1   Selected
+  ------------------------
+    27       1       *
+    18       3        
+     6       5        
+  ------------------------
+
+    Spin    Root           Energy        <S^2>    Status
+  -------------------------------------------------------
+   singlet    0     -108.979950100546  -0.000000  added
+  -------------------------------------------------------
+
+  ==> Davidson-Liu Solver <==
+
+    --------------------------------------------------------
+    Print level                                      Default
+    Energy convergence threshold                   1.000e-12
+    Residual convergence threshold                 1.000e-06
+    Schmidt orthogonality threshold                1.000e-12
+    Schmidt discard threshold                      1.000e-07
+    Size of the space                                     56
+    Number of roots                                        1
+    Maximum number of iterations                         100
+    Collapse subspace size                                 2
+    Maximum subspace size                                 10
+    --------------------------------------------------------
+
+  Davidson-Liu solver: adding 1 guess vectors
+  Iteration     Average Energy            max(∆E)            max(Residual)  Vectors
+  ---------------------------------------------------------------------------------
+       0     -108.979950100546      108.979950100546        0.005884384901      1
+       1     -108.979960607656        0.000010507110        0.000626659097      2
+       2     -108.979960725358        0.000000117703        0.000065752693      3
+       3     -108.979960727673        0.000000002314        0.000019622229      4
+       4     -108.979960727822        0.000000000149        0.000001487460      5
+       5     -108.979960727823        0.000000000001        0.000000121346      6
+       6     -108.979960727823        0.000000000000        0.000000020442      7
+  ---------------------------------------------------------------------------------
+
+  ==> Root No. 0 <==
+
+    2 0 0 0 2 2      0.98201993
+    2 0 2 0 0 2     -0.09479884
+    2 2 0 0 2 0     -0.09479884
+    2 b a 0 b a      0.06588628
+    2 a b 0 a b      0.06588628
+    2 a a 0 b b      0.04857985
+    2 b b 0 a a      0.04857985
+    0 0 2 0 2 2     -0.03479471
+    0 2 0 0 2 2     -0.03479471
+    2 2 2 0 0 0      0.02008008
+    2 b a 0 a b      0.01730644
+    2 a b 0 b a      0.01730644
+    2 0 2 0 2 0     -0.01160612
+    2 2 0 0 0 2     -0.01160612
+    0 0 0 2 2 2     -0.01026615
+
+    Total Energy:    -108.979960727823, <S^2>: 0.000000
+    Time for FCI:       0.013083041000
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    Ag     0     -108.979960727823   0.000000
+    --------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        3Ag     1.994480      1B3u    1.966678      1B2u    1.966678  
+        1B3g    0.035743      1B2g    0.035743      3B1u    0.000679  
+
+
+  ==> Dipole Moments [e a0] (Nuclear + Electronic) for Singlet (Ms = 0) Ag <==
+
+       State           DM_X           DM_Y           DM_Z           |DM|
+    --------------------------------------------------------------------
+         0AG     0.00000000     0.00000000     0.00000000     0.00000000
+    --------------------------------------------------------------------
+     Nuclear     0.00000000     0.00000000     0.00000000     0.00000000
+    --------------------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        3Ag     1.994480      1B3u    1.966678      1B2u    1.966678  
+        1B3g    0.035743      1B2g    0.035743      3B1u    0.000679  
+
+
+  ==> Quadrupole Moments [e a0^2] (Nuclear + Electronic) for Singlet (Ms = 0) Ag <==
+
+       State          QM_XX          QM_XY          QM_XZ          QM_YY          QM_YZ          QM_ZZ
+    --------------------------------------------------------------------------------------------------
+         0AG    -7.29611844     0.00000000     0.00000000    -7.29611844     0.00000000    -8.67427326
+    --------------------------------------------------------------------------------------------------
+     Nuclear     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000    12.49872690
+    --------------------------------------------------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        3Ag     1.994480      1B3u    1.966678      1B2u    1.966678  
+        1B3g    0.035743      1B2g    0.035743      3B1u    0.000679  
+
+
+  ==> MCSCF Iterations <==
+
+                      Energy CI                    Energy Orbital
+           ------------------------------  ------------------------------
+    Iter.        Total Energy       Delta        Total Energy       Delta  Orb. Grad.  Micro
+    ----------------------------------------------------------------------------------------
+       1    -108.979960727823 -1.0898e+02   -109.012302999872 -1.0901e+02  1.9501e-02    6/N
+       2    -109.016292508687 -3.6332e-02   -109.020098011944 -7.7950e-03  1.2697e-03    6/N
+       3    -109.032936640941 -1.6644e-02   -109.041060751067 -2.0963e-02  8.1162e-04    6/N
+       4    -109.043848903618 -1.0912e-02   -109.044125075168 -3.0643e-03  3.2907e-04    6/N
+       5    -109.044160890293 -3.1199e-04   -109.044165125303 -4.0050e-05  1.8666e-05    6/N
+       6    -109.044165637274 -4.7470e-06   -109.044165698835 -5.7353e-07  2.3472e-06    6/N
+       7    -109.044165706223 -6.8949e-08   -109.044165707112 -8.2770e-09  2.8768e-07    6/N
+       8    -109.044165707219 -9.9605e-10   -109.044165707232 -1.1947e-10  3.4733e-08    6/N
+       9    -109.044165707233 -1.4438e-11   -109.044165707233 -1.7053e-12  4.1606e-09    6/N
+      10    -109.044165707234 -1.8474e-13   -109.044165707233  0.0000e+00  5.7036e-10    5/Y
+    ----------------------------------------------------------------------------------------
+
+  A miracle has come to pass: MCSCF iterations have converged!
+
+  Performing final CI Calculation using converged orbitals
+
+  ==> String Lists <==
+
+    --------------------------------------------------------
+    number of alpha electrons                              3
+    number of beta electrons                               3
+    number of alpha strings                               20
+    number of beta strings                                20
+    --------------------------------------------------------
+
+  ==> FCI Solver <==
+
+    --------------------------------------------------------
+    Spin adapt                                         FALSE
+    Number of determinants                                56
+    Symmetry                                               0
+    Multiplicity                                           1
+    Number of roots                                        1
+    Target root                                            0
+    --------------------------------------------------------
+
+  ==> Davidson-Liu Solver <==
+
+    --------------------------------------------------------
+    Print level                                      Default
+    Energy convergence threshold                   1.000e-12
+    Residual convergence threshold                 1.000e-06
+    Schmidt orthogonality threshold                1.000e-12
+    Schmidt discard threshold                      1.000e-07
+    Size of the space                                     56
+    Number of roots                                        1
+    Maximum number of iterations                         100
+    Collapse subspace size                                 2
+    Maximum subspace size                                 10
+    --------------------------------------------------------
+  Iteration     Average Energy            max(∆E)            max(Residual)  Vectors
+  ---------------------------------------------------------------------------------
+       0     -109.044165707234        0.000000000000        0.000000323664      1
+  ---------------------------------------------------------------------------------
+
+  ==> Root No. 0 <==
+
+    2 0 0 0 2 2      0.97585032
+    2 2 0 0 2 0     -0.10373036
+    2 0 2 0 0 2     -0.10373036
+    2 b a 0 b a      0.06822000
+    2 a b 0 a b      0.06822000
+    2 b b 0 a a      0.04643027
+    2 a a 0 b b      0.04643027
+    0 0 0 2 2 2     -0.03721896
+    a a 0 b 2 b      0.03648791
+    b b 0 a 2 a      0.03648791
+    a 0 a b b 2     -0.03648791
+    b 0 b a a 2     -0.03648791
+    b a 0 a 2 b     -0.02460771
+    a b 0 b 2 a     -0.02460771
+    b 0 a a b 2      0.02460771
+    a 0 b b a 2      0.02460771
+    2 2 2 0 0 0      0.02326192
+    2 a b 0 b a      0.02178970
+    2 b a 0 a b      0.02178970
+    2 0 2 0 2 0     -0.01372065
+    2 2 0 0 0 2     -0.01372065
+    b a 0 b 2 a      0.01188019
+    a b 0 a 2 b      0.01188019
+    b 0 a b a 2     -0.01188019
+    a 0 b a b 2     -0.01188019
+
+    Total Energy:    -109.044165707234, <S^2>: -0.000000
+    Time for FCI:       0.005765667000
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    Ag     0     -109.044165707234  -0.000000
+    --------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        3Ag     1.987778      1B2u    1.957112      1B3u    1.957112  
+        1B2g    0.042830      1B3g    0.042830      3B1u    0.012338  
+
+
+  ==> Dipole Moments [e a0] (Nuclear + Electronic) for Singlet (Ms = 0) Ag <==
+
+       State           DM_X           DM_Y           DM_Z           |DM|
+    --------------------------------------------------------------------
+         0AG     0.00000000     0.00000000     0.00000000     0.00000000
+    --------------------------------------------------------------------
+     Nuclear     0.00000000     0.00000000     0.00000000     0.00000000
+    --------------------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        3Ag     1.987778      1B2u    1.957112      1B3u    1.957112  
+        1B2g    0.042830      1B3g    0.042830      3B1u    0.012338  
+
+
+  ==> Quadrupole Moments [e a0^2] (Nuclear + Electronic) for Singlet (Ms = 0) Ag <==
+
+       State          QM_XX          QM_XY          QM_XZ          QM_YY          QM_YZ          QM_ZZ
+    --------------------------------------------------------------------------------------------------
+         0AG    -7.30647468     0.00000000     0.00000000    -7.30647468     0.00000000    -8.78175676
+    --------------------------------------------------------------------------------------------------
+     Nuclear     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000    12.49872690
+    --------------------------------------------------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        3Ag     1.987778      1B2u    1.957112      1B3u    1.957112  
+        1B2g    0.042830      1B3g    0.042830      3B1u    0.012338  
+
+  Canonicalizing final MCSCF orbitals
+
+  ==> Semicanonicalize Orbitals <==
+
+    MIX INACTIVE ORBITALS         FALSE
+    MIX GAS ACTIVE ORBITALS       FALSE
+    FROZEN_DOCC                   CANONICAL
+    FROZEN_UOCC                   CANONICAL
+    GAS1                          CANONICAL
+    RESTRICTED_DOCC               CANONICAL
+    RESTRICTED_UOCC               CANONICAL
+
+    Off-Diag. Elements       Max           2-Norm
+    ------------------------------------------------
+    GAS1                 0.0000000000   0.0000000000
+    RESTRICTED_DOCC      0.6790765904   0.9603638531
+    RESTRICTED_UOCC      0.4602384060   0.6813719679
+    ------------------------------------------------
+
+    Canonicalization test failed
+
+  Timing for orbital canonicalization:                        0.000 s.
+
+  !!! WARNING: Final Active Orbitals Maybe Different from the Original !!!
+
+    Based on projections of maximum overlap method:
+          2Ag -> 1Ag       RESTRICTED_DOCC
+         2B1u -> 3B1u      RESTRICTED_UOCC
+
+  ==> MCSCF Gradient <==
+
+
+  ==> Prepare AO Densities <==
+
+    Computing AO Lagrangian ...... Done.
+    Computing AO OPDM ............ Done.
+    Dumping DF AO TPDM to disk ... Done.
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         N            0.000000000000     0.000000000000    -0.944863062729
+         N            0.000000000000     0.000000000000     0.944863062729
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000    -0.000000000000     0.493015235917
+       2       -0.000000000000     0.000000000000    -0.493015235917
+
+
+
+ ==> Forte Timings <==
+
+  Time to prepare integrals            :        0.030 seconds
+  Time to run forte energy             :        0.495 seconds
+  Time to compute derivative integrals :        0.037 seconds
+  Total                                :        0.562 seconds
+    DF-CASSCF(6,6)/cc-pVDZ/AE gradient on N2..............................................PASSED
+
+Scratch directory: /Users/york/scratch/psi4/
+gradient() will perform analytic gradient computation.
+
+  Forte
+  ----------------------------------------------------------------------------
+  A suite of quantum chemistry methods for strongly correlated electrons
+
+    git branch: dfmcscf_grad - git commit: 320e18ba
+
+  Developed by:
+    Francesco A. Evangelista, Chenyang Li, Kevin P. Hannon,
+    Jeffrey B. Schriber, Tianyuan Zhang, Chenxi Cai,
+    Nan He, Nicholas Stair, Shuhe Wang, Renke Huang
+  ----------------------------------------------------------------------------
+
+
+  Preparing forte objects from a Psi4 Wavefunction object
+  No reference wave function provided for Forte. Computing SCF orbitals using Psi4 ...
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  5, 4, 3
+    Auxiliary basis highest AM E, G, H:  6, 5, 4
+    Onebody   basis highest AM E, G, H:  6, 5, 4
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on Chenyangs-MacBook-Pro.local
+*** at Thu Sep  5 04:04:50 2024
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-2 entry N          line   168 file /Users/york/src/psi4-build/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         N            0.000000000000     0.000000000000    -0.500000000000    14.003074004430
+         N            0.000000000000     0.000000000000     0.500000000000    14.003074004430
+
+  Running in d2h symmetry.
+
+  Rotational constants: A = ************  B =      2.40770  C =      2.40770 [cm^-1]
+  Rotational constants: A = ************  B =  72181.15232  C =  72181.15232 [MHz]
+  Nuclear repulsion =   25.929683322829987
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 14
+  Nalpha       = 7
+  Nbeta        = 7
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-10
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 28
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-2 entry N          line   171 file /Users/york/src/psi4-build/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.366 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: CC-PVDZ-JKFIT
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 48
+    Number of basis functions: 140
+    Number of Cartesian functions: 162
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  Minimum eigenvalue in the overlap matrix is 8.5752098786E-03.
+  Reciprocal condition number of the overlap matrix is 2.9332613017E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag         7       7 
+     B1g        1       1 
+     B2g        3       3 
+     B3g        3       3 
+     Au         1       1 
+     B1u        7       7 
+     B2u        3       3 
+     B3u        3       3 
+   -------------------------
+    Total      28      28
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -109.50010367949019   -1.09500e+02   0.00000e+00 
+   @DF-RHF iter   1:  -108.64688940446088    8.53214e-01   6.63039e-02 DIIS/ADIIS
+   @DF-RHF iter   2:  -108.91340512996361   -2.66516e-01   1.62149e-02 DIIS/ADIIS
+   @DF-RHF iter   3:  -108.92943887410331   -1.60337e-02   1.03694e-03 DIIS/ADIIS
+   @DF-RHF iter   4:  -108.92956078123147   -1.21907e-04   2.16559e-04 DIIS/ADIIS
+   @DF-RHF iter   5:  -108.92956651876540   -5.73753e-06   1.87200e-05 DIIS
+   @DF-RHF iter   6:  -108.92956655142635   -3.26609e-08   7.47392e-07 DIIS
+   @DF-RHF iter   7:  -108.92956655146612   -3.97762e-11   9.92034e-08 DIIS
+   @DF-RHF iter   8:  -108.92956655146688   -7.53175e-13   6.61492e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag   -15.655988     1B1u  -15.649496     2Ag    -1.544209  
+       2B1u   -0.741102     1B2u   -0.653686     1B3u   -0.653686  
+       3Ag    -0.633585  
+
+    Virtual:                                                              
+
+       1B2g    0.230627     1B3g    0.230627     3B1u    0.616590  
+       4Ag     0.785928     2B3u    0.841040     2B2u    0.841040  
+       5Ag     1.006309     2B2g    1.077606     2B3g    1.077606  
+       4B1u    1.298255     6Ag     1.729597     1B1g    1.729597  
+       5B1u    1.767463     3B2u    1.994670     3B3u    1.994670  
+       6B1u    2.371054     1Au     2.371054     7Ag     2.953970  
+       3B2g    3.109175     3B3g    3.109175     7B1u    3.597508  
+
+    Final Occupation by Irrep:
+             Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u 
+    DOCC [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    NA   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+    NB   [     3,    0,    0,    0,    0,    2,    1,    1 ]
+
+  @DF-RHF Final Energy:  -108.92956655146688
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             25.9296833228299874
+    One-Electron Energy =                -198.6549980288319261
+    Two-Electron Energy =                  63.7957481545350547
+    Total Energy =                       -108.9295665514668769
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000           -0.0000000           -0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on Chenyangs-MacBook-Pro.local at Thu Sep  5 04:04:50 2024
+Module time:
+	user time   =       0.09 seconds =       0.00 minutes
+	system time =       0.01 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.82 seconds =       0.01 minutes
+	system time =       0.06 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+  Read options for space FROZEN_DOCC
+  Read options for space RESTRICTED_DOCC
+  Read options for space ACTIVE
+  Read options for space FROZEN_DOCC
+  Read options for space RESTRICTED_DOCC
+
+  ==> MO Space Information <==
+
+  -------------------------------------------------------------------------
+                       Ag   B1g   B2g   B3g    Au   B1u   B2u   B3u   Sum
+  -------------------------------------------------------------------------
+    FROZEN_DOCC         1     0     0     0     0     1     0     0     2
+    RESTRICTED_DOCC     1     0     0     0     0     1     0     0     2
+    GAS1                1     0     1     1     0     1     1     1     6
+    GAS2                0     0     0     0     0     0     0     0     0
+    GAS3                0     0     0     0     0     0     0     0     0
+    GAS4                0     0     0     0     0     0     0     0     0
+    GAS5                0     0     0     0     0     0     0     0     0
+    GAS6                0     0     0     0     0     0     0     0     0
+    RESTRICTED_UOCC     4     1     2     2     1     4     2     2    18
+    FROZEN_UOCC         0     0     0     0     0     0     0     0     0
+    Total               7     1     3     3     1     7     3     3    28
+  -------------------------------------------------------------------------   => Loading Basis Set <=
+
+    Name: CC-PVDZ-JKFIT
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1-2 entry N          line   171 file /Users/york/src/psi4-build/stage/share/psi4/basis/cc-pvdz-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: MINAO_BASIS
+    atoms 1-2 entry N          line    71 file /Users/york/src/psi4-build/stage/share/psi4/basis/sto-3g.gbs 
+
+
+  State Singlet (Ms = 0) Ag GAS min: 0 0 0 0 0 0 ; GAS max: 12 0 0 0 0 0 ; weights:
+      1.000000000000
+  Forte will use psi4 integrals
+
+  ==> Primary Basis Set Summary <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 28
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+
+  JK created using MemDF integrals
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.391 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               400
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: CC-PVDZ-JKFIT
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 48
+    Number of basis functions: 140
+    Number of Cartesian functions: 162
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+
+
+  ==> Integral Transformation <==
+
+  Number of molecular orbitals:                         28
+  Number of correlated molecular orbitals:              26
+  Number of frozen occupied orbitals:                    2
+  Number of frozen unoccupied orbitals:                  0
+  Two-electron integral type:              Density fitting
+
+
+  Computing density fitted integrals
+
+  Number of auxiliary basis functions:  140
+  Need 878.08 KB to store DF integrals
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.438 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> DFHelper <==
+    NBF:                              28
+    NAux:                            140
+    Schwarz Cutoff:                1E-12
+    Mask sparsity (%):                 0
+    DFH Avail. Memory [GiB]:       0.438
+    OpenMP threads:                    1
+    Algorithm:                     STORE
+    AO Core:                        True
+    MO Core:                       False
+    Hold Metric:                   False
+    Metric Power:                 -0.500
+    Fitting Condition:             1E-10
+    Q Shell Max:                       7
+
+
+
+  Transforming DF Integrals
+  Timing for density-fitting transformation:                  0.003 s.
+
+  Frozen-core energy        -102.166573560773145 a.u.
+  Timing for frozen one-body operator:                        0.000 s.
+  Resorting integrals after freezing core.
+  Timing for resorting DF integrals:                          0.001 s.
+  Timing for freezing core and virtual orbitals:              0.001 s.
+  Timing for computing density-fitted integrals:              0.016 s.
+
+  ==> Primary Basis Set Summary <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 28
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+
+  JK created using MemDF integrals
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.391 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               1
+    Memory [MiB]:               400
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       0.0000
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: CC-PVDZ-JKFIT
+    Blend: CC-PVDZ-JKFIT
+    Number of shells: 48
+    Number of basis functions: 140
+    Number of Cartesian functions: 162
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+
+
+  ==> Integral Transformation <==
+
+  Number of molecular orbitals:                         28
+  Number of correlated molecular orbitals:              26
+  Number of frozen occupied orbitals:                    2
+  Number of frozen unoccupied orbitals:                  0
+  Two-electron integral type:              Density fitting
+
+
+  Computing density fitted integrals
+
+  Number of auxiliary basis functions:  140
+  Need 878.08 KB to store DF integrals
+  DFHelper Memory: AOs need 0.001 GiB; user supplied 0.438 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> DFHelper <==
+    NBF:                              28
+    NAux:                            140
+    Schwarz Cutoff:                1E-12
+    Mask sparsity (%):                 0
+    DFH Avail. Memory [GiB]:       0.438
+    OpenMP threads:                    1
+    Algorithm:                     STORE
+    AO Core:                        True
+    MO Core:                       False
+    Hold Metric:                   False
+    Metric Power:                 -0.500
+    Fitting Condition:             1E-10
+    Q Shell Max:                       7
+
+
+
+  Transforming DF Integrals
+  Timing for density-fitting transformation:                  0.003 s.
+
+  Frozen-core energy        -102.166573560773145 a.u.
+  Timing for frozen one-body operator:                        0.000 s.
+  Resorting integrals after freezing core.
+  Timing for resorting DF integrals:                          0.001 s.
+  Timing for freezing core and virtual orbitals:              0.001 s.
+  Timing for computing density-fitted integrals:              0.019 s.
+
+          -----------------------------------------------------------
+                  Multi-Configurational Self Consistent Field
+                Two-Step Approximate Second-Order AO Algorithm
+            written by Chenyang Li, Kevin P. Hannon, and Shuhe Wang
+          -----------------------------------------------------------
+
+
+  ==> MCSCF Calculation Information <==
+
+    --------------------------------------------------------
+    Print level                                      Default
+    Integral type                                         DF
+    CI solver type                                       FCI
+    Final orbital type                             CANONICAL
+    Derivative type                                    FIRST
+    Optimize orbitals                                   TRUE
+    Include internal rotations                         FALSE
+    Debug printing                                     FALSE
+    Energy convergence                             1.000e-12
+    Gradient convergence                           1.000e-12
+    Max value for rotation                         2.000e-01
+    Max number of macro iter.                            100
+    Max number of micro iter. for orbitals                 6
+    Max number of micro iter. for CI                      12
+    DIIS start                                            15
+    Min DIIS vectors                                       3
+    Max DIIS vectors                                       8
+    Frequency of DIIS extrapolation                        1
+    --------------------------------------------------------
+
+  ==> Independent Orbital Rotations <==
+
+    ORBITAL SPACES                        Ag    B1g    B2g    B3g     Au    B1u    B2u    B3u
+    -----------------------------------------------------------------------------------------
+             ACTIVE / RESTRICTED_DOCC      1      0      0      0      0      1      0      0
+    RESTRICTED_UOCC /          ACTIVE      4      0      2      2      0      4      2      2
+    RESTRICTED_UOCC / RESTRICTED_DOCC      4      0      0      0      0      4      0      0
+    -----------------------------------------------------------------------------------------
+
+  DF-MCSCF adopts integrals from DFHelper of Psi4.
+
+
+  ==> String Lists <==
+
+    --------------------------------------------------------
+    number of alpha electrons                              3
+    number of beta electrons                               3
+    number of alpha strings                               20
+    number of beta strings                                20
+    --------------------------------------------------------
+
+  ==> FCI Solver <==
+
+    --------------------------------------------------------
+    Spin adapt                                         FALSE
+    Number of determinants                                56
+    Symmetry                                               0
+    Multiplicity                                           1
+    Number of roots                                        1
+    Target root                                            0
+    --------------------------------------------------------
+  Initial guess space is incomplete.
+  Adding 1 determinant(s).
+
+  ==> Initial Guess <==
+
+  Initial guess determinants:         51
+
+  Classification of the initial guess solutions
+
+  Number   2S+1   Selected
+  ------------------------
+    27       1       *
+    18       3        
+     6       5        
+  ------------------------
+
+    Spin    Root           Energy        <S^2>    Status
+  -------------------------------------------------------
+   singlet    0     -211.146523661319  -0.000000  added
+  -------------------------------------------------------
+
+  ==> Davidson-Liu Solver <==
+
+    --------------------------------------------------------
+    Print level                                      Default
+    Energy convergence threshold                   1.000e-12
+    Residual convergence threshold                 1.000e-06
+    Schmidt orthogonality threshold                1.000e-12
+    Schmidt discard threshold                      1.000e-07
+    Size of the space                                     56
+    Number of roots                                        1
+    Maximum number of iterations                         100
+    Collapse subspace size                                 2
+    Maximum subspace size                                 10
+    --------------------------------------------------------
+
+  Davidson-Liu solver: adding 1 guess vectors
+  Iteration     Average Energy            max(∆E)            max(Residual)  Vectors
+  ---------------------------------------------------------------------------------
+       0     -108.979950100546      108.979950100546        0.005884384901      1
+       1     -108.979960607656        0.000010507110        0.000626659097      2
+       2     -108.979960725358        0.000000117703        0.000065752693      3
+       3     -108.979960727673        0.000000002314        0.000019622229      4
+       4     -108.979960727822        0.000000000149        0.000001487460      5
+       5     -108.979960727823        0.000000000001        0.000000121346      6
+       6     -108.979960727823        0.000000000000        0.000000020442      7
+  ---------------------------------------------------------------------------------
+
+  ==> Root No. 0 <==
+
+    2 0 0 0 2 2      0.98201993
+    2 0 2 0 0 2     -0.09479884
+    2 2 0 0 2 0     -0.09479884
+    2 a b 0 a b      0.06588628
+    2 b a 0 b a      0.06588628
+    2 b b 0 a a      0.04857985
+    2 a a 0 b b      0.04857985
+    0 0 2 0 2 2     -0.03479471
+    0 2 0 0 2 2     -0.03479471
+    2 2 2 0 0 0      0.02008008
+    2 b a 0 a b      0.01730644
+    2 a b 0 b a      0.01730644
+    2 0 2 0 2 0     -0.01160612
+    2 2 0 0 0 2     -0.01160612
+    0 0 0 2 2 2     -0.01026615
+
+    Total Energy:    -108.979960727823, <S^2>: 0.000000
+    Time for FCI:       0.013303541000
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    Ag     0     -108.979960727823   0.000000
+    --------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        3Ag     1.994480      1B3u    1.966678      1B2u    1.966678  
+        1B3g    0.035743      1B2g    0.035743      3B1u    0.000679  
+
+
+  ==> Dipole Moments [e a0] (Nuclear + Electronic) for Singlet (Ms = 0) Ag <==
+
+       State           DM_X           DM_Y           DM_Z           |DM|
+    --------------------------------------------------------------------
+         0AG     0.00000000     0.00000000     0.00000000     0.00000000
+    --------------------------------------------------------------------
+     Nuclear     0.00000000     0.00000000     0.00000000     0.00000000
+    --------------------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        3Ag     1.994480      1B3u    1.966678      1B2u    1.966678  
+        1B3g    0.035743      1B2g    0.035743      3B1u    0.000679  
+
+
+  ==> Quadrupole Moments [e a0^2] (Nuclear + Electronic) for Singlet (Ms = 0) Ag <==
+
+       State          QM_XX          QM_XY          QM_XZ          QM_YY          QM_YZ          QM_ZZ
+    --------------------------------------------------------------------------------------------------
+         0AG    -7.29611844     0.00000000     0.00000000    -7.29611844     0.00000000    -8.67427326
+    --------------------------------------------------------------------------------------------------
+     Nuclear     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000    12.49872690
+    --------------------------------------------------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        3Ag     1.994480      1B3u    1.966678      1B2u    1.966678  
+        1B3g    0.035743      1B2g    0.035743      3B1u    0.000679  
+
+
+  ==> MCSCF Iterations <==
+
+                      Energy CI                    Energy Orbital
+           ------------------------------  ------------------------------
+    Iter.        Total Energy       Delta        Total Energy       Delta  Orb. Grad.  Micro
+    ----------------------------------------------------------------------------------------
+       1    -108.979960727823 -1.0898e+02   -109.012193403917 -1.0901e+02  2.2917e-02    6/N
+       2    -109.016128266275 -3.6168e-02   -109.020038204876 -7.8448e-03  1.5950e-03    6/N
+       3    -109.033668302196 -1.7540e-02   -109.041449138476 -2.1411e-02  1.0667e-03    6/N
+       4    -109.043872448766 -1.0204e-02   -109.044105077298 -2.6559e-03  2.8708e-04    6/N
+       5    -109.044134325405 -2.6188e-04   -109.044137718370 -3.2641e-05  1.7213e-05    6/N
+       6    -109.044138120455 -3.7950e-06   -109.044138167891 -4.4952e-07  2.1308e-06    6/N
+       7    -109.044138173479 -5.3024e-08   -109.044138174139 -6.2480e-09  2.5664e-07    6/N
+       8    -109.044138174217 -7.3791e-10   -109.044138174226 -8.6914e-11  3.0457e-08    6/N
+       9    -109.044138174227 -1.0289e-11   -109.044138174227 -1.2506e-12  3.5808e-09    6/N
+      10    -109.044138174227 -9.9476e-14   -109.044138174227  1.4211e-14  4.8607e-10    5/Y
+    ----------------------------------------------------------------------------------------
+
+  A miracle has come to pass: MCSCF iterations have converged!
+
+  Performing final CI Calculation using converged orbitals
+
+  ==> String Lists <==
+
+    --------------------------------------------------------
+    number of alpha electrons                              3
+    number of beta electrons                               3
+    number of alpha strings                               20
+    number of beta strings                                20
+    --------------------------------------------------------
+
+  ==> FCI Solver <==
+
+    --------------------------------------------------------
+    Spin adapt                                         FALSE
+    Number of determinants                                56
+    Symmetry                                               0
+    Multiplicity                                           1
+    Number of roots                                        1
+    Target root                                            0
+    --------------------------------------------------------
+
+  ==> Davidson-Liu Solver <==
+
+    --------------------------------------------------------
+    Print level                                      Default
+    Energy convergence threshold                   1.000e-12
+    Residual convergence threshold                 1.000e-06
+    Schmidt orthogonality threshold                1.000e-12
+    Schmidt discard threshold                      1.000e-07
+    Size of the space                                     56
+    Number of roots                                        1
+    Maximum number of iterations                         100
+    Collapse subspace size                                 2
+    Maximum subspace size                                 10
+    --------------------------------------------------------
+  Iteration     Average Energy            max(∆E)            max(Residual)  Vectors
+  ---------------------------------------------------------------------------------
+       0     -109.044138174227        0.000000000000        0.000000270355      1
+  ---------------------------------------------------------------------------------
+
+  ==> Root No. 0 <==
+
+    2 0 0 0 2 2     -0.97583969
+    2 2 0 0 2 0      0.10376099
+    2 0 2 0 0 2      0.10376099
+    2 b a 0 b a     -0.06824017
+    2 a b 0 a b     -0.06824017
+    2 a a 0 b b     -0.04643456
+    2 b b 0 a a     -0.04643456
+    0 0 0 2 2 2      0.03726624
+    a a 0 b 2 b     -0.03649659
+    b b 0 a 2 a     -0.03649659
+    b 0 b a a 2      0.03649659
+    a 0 a b b 2      0.03649659
+    b a 0 a 2 b      0.02452556
+    a b 0 b 2 a      0.02452556
+    b 0 a a b 2     -0.02452556
+    a 0 b b a 2     -0.02452556
+    2 2 2 0 0 0     -0.02327747
+    2 b a 0 a b     -0.02180558
+    2 a b 0 b a     -0.02180558
+    2 0 2 0 2 0      0.01371523
+    2 2 0 0 0 2      0.01371523
+    a b 0 a 2 b     -0.01197102
+    b a 0 b 2 a     -0.01197102
+    b 0 a b a 2      0.01197102
+    a 0 b a b 2      0.01197102
+
+    Total Energy:    -109.044138174227, <S^2>: 0.000000
+    Time for FCI:       0.005676750000
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    Ag     0     -109.044138174227   0.000000
+    --------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        3Ag     1.987773      1B2u    1.957094      1B3u    1.957094  
+        1B2g    0.042850      1B3g    0.042850      3B1u    0.012340  
+
+
+  ==> Dipole Moments [e a0] (Nuclear + Electronic) for Singlet (Ms = 0) Ag <==
+
+       State           DM_X           DM_Y           DM_Z           |DM|
+    --------------------------------------------------------------------
+         0AG     0.00000000     0.00000000     0.00000000     0.00000000
+    --------------------------------------------------------------------
+     Nuclear     0.00000000     0.00000000     0.00000000     0.00000000
+    --------------------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        3Ag     1.987773      1B2u    1.957094      1B3u    1.957094  
+        1B2g    0.042850      1B3g    0.042850      3B1u    0.012340  
+
+
+  ==> Quadrupole Moments [e a0^2] (Nuclear + Electronic) for Singlet (Ms = 0) Ag <==
+
+       State          QM_XX          QM_XY          QM_XZ          QM_YY          QM_YZ          QM_ZZ
+    --------------------------------------------------------------------------------------------------
+         0AG    -7.30649108     0.00000000     0.00000000    -7.30649108     0.00000000    -8.78182069
+    --------------------------------------------------------------------------------------------------
+     Nuclear     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000    12.49872690
+    --------------------------------------------------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        3Ag     1.987773      1B2u    1.957094      1B3u    1.957094  
+        1B2g    0.042850      1B3g    0.042850      3B1u    0.012340  
+
+  Canonicalizing final MCSCF orbitals
+
+  ==> Semicanonicalize Orbitals <==
+
+    MIX INACTIVE ORBITALS         FALSE
+    MIX GAS ACTIVE ORBITALS       FALSE
+    FROZEN_DOCC                   CANONICAL
+    FROZEN_UOCC                   CANONICAL
+    GAS1                          CANONICAL
+    RESTRICTED_DOCC               CANONICAL
+    RESTRICTED_UOCC               CANONICAL
+
+    Off-Diag. Elements       Max           2-Norm
+    ------------------------------------------------
+    FROZEN_DOCC          0.0000000000   0.0000000000
+    GAS1                 0.0000000000   0.0000000000
+    RESTRICTED_DOCC      0.0000000000   0.0000000000
+    RESTRICTED_UOCC      0.4602514420   0.6826365648
+    ------------------------------------------------
+
+    Canonicalization test failed
+
+  Timing for orbital canonicalization:                        0.000 s.
+
+  !!! WARNING: Final Active Orbitals Maybe Different from the Original !!!
+
+    Based on projections of maximum overlap method:
+          2Ag -> 1Ag       RESTRICTED_DOCC
+         2B1u -> 3B1u      RESTRICTED_UOCC
+
+  ==> MCSCF Gradient <==
+
+
+  ==> Solving CP-SCF Equation <==
+
+
+  ==> Prepare AO Densities <==
+
+    Computing AO Lagrangian ...... Done.
+    Computing AO OPDM ............ Done.
+    Dumping DF AO TPDM to disk ... Done.
+
+    Molecular point group: d2h
+    Full point group: D_inf_h
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         N            0.000000000000     0.000000000000    -0.944863062729
+         N            0.000000000000     0.000000000000     0.944863062729
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000    -0.000000000000     0.493103903249
+       2       -0.000000000000     0.000000000000    -0.493103903249
+
+
+
+ ==> Forte Timings <==
+
+  Time to prepare integrals            :        0.032 seconds
+  Time to run forte energy             :        0.532 seconds
+  Time to compute derivative integrals :        0.036 seconds
+  Total                                :        0.600 seconds
+    DF-CASSCF(6,6)/cc-pVDZ/FC gradient on N2..............................................PASSED
+
+    Psi4 stopped on: Thursday, 05 September 2024 04:04AM
+    Psi4 wall time for execution: 0:00:01.78
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/methods/df-casscf-gradient-2/input.dat
+++ b/tests/methods/df-casscf-gradient-2/input.dat
@@ -1,0 +1,62 @@
+# Test DF-MCSCF analytic gradients with frozen orbitals
+
+import forte
+
+# ref_grad from 5-point finite difference
+ref_grad = psi4.Matrix.from_list([
+    [-0.0009775460, -0.0082154776, 0.0000000000],
+    [ 0.0009775460,  0.0082154776, 0.0000000000],
+    [ 0.0068717247,  0.0043753883, 0.0000000000],
+    [-0.0068717247, -0.0043753883, 0.0000000000],
+    [-0.0085117226, -0.0044009360, 0.0000000000],
+    [ 0.0085117226,  0.0044009360, 0.0000000000],
+    [-0.0186375215, -0.0052285808, 0.0000000000],
+    [ 0.0186375215,  0.0052285808, 0.0000000000],
+    [-0.0190885742,  0.0141712291, 0.0000000000],
+    [ 0.0190885742, -0.0141712291, 0.0000000000]
+])
+
+molecule butadiene{
+H  1.080977 -2.558832  0.000000
+H -1.080977  2.558832  0.000000
+H  2.103773 -1.017723  0.000000
+H -2.103773  1.017723  0.000000
+H -0.973565 -1.219040  0.000000
+H  0.973565  1.219040  0.000000
+C  0.000000  0.728881  0.000000
+C  0.000000 -0.728881  0.000000
+C  1.117962 -1.474815  0.000000
+C -1.117962  1.474815  0.000000
+}
+
+set globals {
+  reference            rhf
+  scf_type             df
+  e_convergence        12
+  d_convergence        10
+  maxiter              100
+  basis                dz
+  docc                 [7,1,1,6]
+  df_basis_scf         def2-universal-jkfit
+  df_basis_mp2         def2-universal-jkfit
+}
+
+set forte{
+  int_type             df
+  active_space_solver  fci
+  frozen_docc          [2,0,0,2]
+  restricted_docc      [5,0,0,4]
+  active               [0,2,2,0]
+  frozen_uocc          [2,0,0,2]
+  e_convergence        1e-12
+  mcscf_maxiter        100
+  mcscf_g_convergence  1e-10
+  mcscf_e_convergence  1e-12
+  cpscf_convergence    1e-10
+  mcscf_ignore_frozen_orbs false
+}
+
+#set gradient_write true
+#set findif points 5
+grad = gradient('forte')
+compare_matrices(ref_grad, grad, 7, "CASSCF(4,4)/DZ gradient on butadiene with frozen orbitals")

--- a/tests/methods/df-casscf-gradient-2/output.ref
+++ b/tests/methods/df-casscf-gradient-2/output.ref
@@ -1,0 +1,960 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 1.10a1.dev48 
+
+                         Git: Rev {master} 1813c0c dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, M. H. Lechner, A. Jiang, S. Behnle, A. G. Heide,
+    M. F. Herbst, and D. L. Poole
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Thursday, 05 September 2024 03:57AM
+
+    Process ID: 11715
+    Host:       Chenyangs-MacBook-Pro.local
+    PSIDATADIR: /Users/york/src/psi4-build/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+# Test DF-MCSCF analytic gradients with frozen orbitals
+
+import forte
+
+# ref_grad from 5-point finite difference
+ref_grad = psi4.Matrix.from_list([
+    [-0.0009775460, -0.0082154776, 0.0000000000],
+    [ 0.0009775460,  0.0082154776, 0.0000000000],
+    [ 0.0068717247,  0.0043753883, 0.0000000000],
+    [-0.0068717247, -0.0043753883, 0.0000000000],
+    [-0.0085117226, -0.0044009360, 0.0000000000],
+    [ 0.0085117226,  0.0044009360, 0.0000000000],
+    [-0.0186375215, -0.0052285808, 0.0000000000],
+    [ 0.0186375215,  0.0052285808, 0.0000000000],
+    [-0.0190885742,  0.0141712291, 0.0000000000],
+    [ 0.0190885742, -0.0141712291, 0.0000000000]
+])
+
+molecule butadiene{
+H  1.080977 -2.558832  0.000000
+H -1.080977  2.558832  0.000000
+H  2.103773 -1.017723  0.000000
+H -2.103773  1.017723  0.000000
+H -0.973565 -1.219040  0.000000
+H  0.973565  1.219040  0.000000
+C  0.000000  0.728881  0.000000
+C  0.000000 -0.728881  0.000000
+C  1.117962 -1.474815  0.000000
+C -1.117962  1.474815  0.000000
+}
+
+set globals {
+  reference            rhf
+  scf_type             df
+  e_convergence        12
+  d_convergence        10
+  maxiter              100
+  basis                dz
+  docc                 [7,1,1,6]
+  df_basis_scf         def2-universal-jkfit
+  df_basis_mp2         def2-universal-jkfit
+}
+
+set forte{
+  int_type             df
+  active_space_solver  fci
+  frozen_docc          [2,0,0,2]
+  restricted_docc      [5,0,0,4]
+  active               [0,2,2,0]
+  frozen_uocc          [2,0,0,2]
+  e_convergence        1e-12
+  mcscf_maxiter        100
+  mcscf_g_convergence  1e-10
+  mcscf_e_convergence  1e-12
+  cpscf_convergence    1e-10
+  mcscf_ignore_frozen_orbs false
+}
+
+#set gradient_write true
+#set findif points 5
+grad = gradient('forte')
+compare_matrices(ref_grad, grad, 7, "CASSCF(4,4)/DZ gradient on butadiene with frozen orbitals")
+--------------------------------------------------------------------------
+
+Scratch directory: /Users/york/scratch/psi4/
+gradient() will perform analytic gradient computation.
+
+  Forte
+  ----------------------------------------------------------------------------
+  A suite of quantum chemistry methods for strongly correlated electrons
+
+    git branch: dfmcscf_grad - git commit: 320e18ba
+
+  Developed by:
+    Francesco A. Evangelista, Chenyang Li, Kevin P. Hannon,
+    Jeffrey B. Schriber, Tianyuan Zhang, Chenxi Cai,
+    Nan He, Nicholas Stair, Shuhe Wang, Renke Huang
+  ----------------------------------------------------------------------------
+
+
+  Preparing forte objects from a Psi4 Wavefunction object
+  No reference wave function provided for Forte. Computing SCF orbitals using Psi4 ...
+   => Libint2 <=
+
+    Primary   basis highest AM E, G, H:  5, 4, 3
+    Auxiliary basis highest AM E, G, H:  6, 5, 4
+    Onebody   basis highest AM E, G, H:  6, 5, 4
+    Solid Harmonics ordering:            Gaussian
+
+*** tstart() called on Chenyangs-MacBook-Pro.local
+*** at Thu Sep  5 03:57:38 2024
+
+   => Loading Basis Set <=
+
+    Name: DZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1-6  entry H          line    12 file /Users/york/src/psi4-build/stage/share/psi4/basis/dz.gbs 
+    atoms 7-10 entry C          line    63 file /Users/york/src/psi4-build/stage/share/psi4/basis/dz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2h
+    Full point group: C2h
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         H            1.080977000000    -2.558832000000     0.000000000000     1.007825032230
+         H           -1.080977000000     2.558832000000     0.000000000000     1.007825032230
+         H            2.103773000000    -1.017723000000     0.000000000000     1.007825032230
+         H           -2.103773000000     1.017723000000     0.000000000000     1.007825032230
+         H           -0.973565000000    -1.219040000000     0.000000000000     1.007825032230
+         H            0.973565000000     1.219040000000     0.000000000000     1.007825032230
+         C           -0.000000000000     0.728881000000     0.000000000000    12.000000000000
+         C            0.000000000000    -0.728881000000     0.000000000000    12.000000000000
+         C            1.117962000000    -1.474815000000     0.000000000000    12.000000000000
+         C           -1.117962000000     1.474815000000     0.000000000000    12.000000000000
+
+  Running in c2h symmetry.
+
+  Rotational constants: A =      1.39831  B =      0.14741  C =      0.13335 [cm^-1]
+  Rotational constants: A =  41920.28303  B =   4419.18036  C =   3997.74357 [MHz]
+  Nuclear repulsion =  103.516094180281002
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 30
+  Nalpha       = 15
+  Nbeta        = 15
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-12
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DZ
+    Blend: DZ
+    Number of shells: 36
+    Number of basis functions: 52
+    Number of Cartesian functions: 52
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1-6  entry H          line    18 file /Users/york/src/psi4-build/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 7-10 entry C          line   198 file /Users/york/src/psi4-build/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  DFHelper Memory: AOs need 0.012 GiB; user supplied 0.366 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               4
+    Memory [MiB]:               375
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.4053
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 136
+    Number of basis functions: 476
+    Number of Cartesian functions: 476
+    Spherical Harmonics?: false
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.1213752613E-03.
+  Reciprocal condition number of the overlap matrix is 6.9016225633E-04.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     Ag        22      22 
+     Bg         4       4 
+     Au         4       4 
+     Bu        22      22 
+   -------------------------
+    Total      52      52
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -153.06766919596225   -1.53068e+02   0.00000e+00 
+   @DF-RHF iter   1:  -151.95953318498280    1.10814e+00   6.38986e-02 ADIIS/DIIS
+   @DF-RHF iter   2:  -154.01783967561369   -2.05831e+00   3.89685e-02 ADIIS/DIIS
+   @DF-RHF iter   3:  -154.80313141097778   -7.85292e-01   1.14727e-02 ADIIS/DIIS
+   @DF-RHF iter   4:  -154.87206307765308   -6.89317e-02   2.98414e-03 ADIIS/DIIS
+   @DF-RHF iter   5:  -154.87731211373654   -5.24904e-03   3.67276e-04 ADIIS/DIIS
+   @DF-RHF iter   6:  -154.87744510669950   -1.32993e-04   5.51924e-05 DIIS
+   @DF-RHF iter   7:  -154.87744976421726   -4.65752e-06   1.48250e-05 DIIS
+   @DF-RHF iter   8:  -154.87745014719394   -3.82977e-07   4.60295e-06 DIIS
+   @DF-RHF iter   9:  -154.87745016916409   -2.19702e-08   4.85273e-07 DIIS
+   @DF-RHF iter  10:  -154.87745016949211   -3.28015e-10   6.53012e-08 DIIS
+   @DF-RHF iter  11:  -154.87745016949646   -4.34852e-12   7.93505e-09 DIIS
+   @DF-RHF iter  12:  -154.87745016949657   -1.13687e-13   1.03047e-09 DIIS
+   @DF-RHF iter  13:  -154.87745016949663   -5.68434e-14   1.32083e-10 DIIS
+   @DF-RHF iter  14:  -154.87745016949668   -5.68434e-14   1.87956e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ag   -11.254780     1Bu   -11.253969     2Ag   -11.241759  
+       2Bu   -11.241756     3Ag    -1.098430     3Bu    -1.006021  
+       4Ag    -0.829308     4Bu    -0.757394     5Bu    -0.647776  
+       5Ag    -0.639640     6Ag    -0.558463     6Bu    -0.544920  
+       7Ag    -0.492764     1Au    -0.446390     1Bg    -0.321588  
+
+    Virtual:                                                              
+
+       2Au     0.104648     2Bg     0.208260     7Bu     0.255874  
+       8Ag     0.279657     8Bu     0.289711     9Ag     0.334531  
+       9Bu     0.343198    10Bu     0.380058    10Ag     0.392780  
+      11Ag     0.422684     3Au     0.472033    11Bu     0.487400  
+      12Ag     0.495724    12Bu     0.521786     3Bg     0.541451  
+      13Bu     0.581359     4Bg     0.618930    13Ag     0.629443  
+       4Au     0.637731    14Ag     0.717447    15Ag     0.778363  
+      14Bu     0.781873    15Bu     0.884975    16Ag     1.012177  
+      16Bu     1.096468    17Bu     1.166453    17Ag     1.196361  
+      18Ag     1.350465    18Bu     1.453811    19Bu     1.488380  
+      19Ag     1.517540    20Ag     1.641779    20Bu     1.689619  
+      21Ag    23.713989    21Bu    23.883262    22Ag    24.067049  
+      22Bu    24.115081  
+
+    Final Occupation by Irrep:
+             Ag    Bg    Au    Bu 
+    DOCC [     7,    1,    1,    6 ]
+    NA   [     7,    1,    1,    6 ]
+    NB   [     7,    1,    1,    6 ]
+
+  @DF-RHF Final Energy:  -154.87745016949668
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =            103.5160941802810015
+    One-Electron Energy =                -412.1171730279452845
+    Two-Electron Energy =                 153.7236286781675858
+    Total Energy =                       -154.8774501694966830
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+
+ Multipole Moments:
+
+ ------------------------------------------------------------------------------------
+     Multipole            Electronic (a.u.)      Nuclear  (a.u.)        Total (a.u.)
+ ------------------------------------------------------------------------------------
+
+ L = 1.  Multiply by 2.5417464519 to convert [e a0] to [Debye]
+ Dipole X            :          0.0000000            0.0000000            0.0000000
+ Dipole Y            :          0.0000000            0.0000000            0.0000000
+ Dipole Z            :          0.0000000            0.0000000            0.0000000
+ Magnitude           :                                                    0.0000000
+
+ ------------------------------------------------------------------------------------
+
+*** tstop() called on Chenyangs-MacBook-Pro.local at Thu Sep  5 03:57:38 2024
+Module time:
+	user time   =       0.35 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.35 seconds =       0.01 minutes
+	system time =       0.03 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+
+  Read options for space FROZEN_DOCC
+  Read options for space RESTRICTED_DOCC
+  Read options for space FROZEN_UOCC
+  Read options for space ACTIVE
+  Read options for space FROZEN_DOCC
+  Read options for space FROZEN_UOCC
+  Read options for space RESTRICTED_DOCC
+
+  ==> MO Space Information <==
+
+  -------------------------------------------------
+                       Ag    Bg    Au    Bu   Sum
+  -------------------------------------------------
+    FROZEN_DOCC         2     0     0     2     4
+    RESTRICTED_DOCC     5     0     0     4     9
+    GAS1                0     2     2     0     4
+    GAS2                0     0     0     0     0
+    GAS3                0     0     0     0     0
+    GAS4                0     0     0     0     0
+    GAS5                0     0     0     0     0
+    GAS6                0     0     0     0     0
+    RESTRICTED_UOCC    13     2     2    14    31
+    FROZEN_UOCC         2     0     0     2     4
+    Total              22     4     4    22    52
+  -------------------------------------------------   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: RIFIT
+    Keyword: DF_BASIS_MP2
+    atoms 1-6  entry H          line    18 file /Users/york/src/psi4-build/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 7-10 entry C          line   198 file /Users/york/src/psi4-build/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: STO-3G
+    Role: ORBITAL
+    Keyword: MINAO_BASIS
+    atoms 1-6  entry H          line    19 file /Users/york/src/psi4-build/stage/share/psi4/basis/sto-3g.gbs 
+    atoms 7-10 entry C          line    61 file /Users/york/src/psi4-build/stage/share/psi4/basis/sto-3g.gbs 
+
+
+  State Singlet (Ms = 0) Ag GAS min: 0 0 0 0 0 0 ; GAS max: 8 0 0 0 0 0 ; weights:
+      1.000000000000
+  Forte will use psi4 integrals
+
+  ==> Primary Basis Set Summary <==
+
+  Basis Set: DZ
+    Blend: DZ
+    Number of shells: 36
+    Number of basis functions: 52
+    Number of Cartesian functions: 52
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+
+  JK created using MemDF integrals
+  DFHelper Memory: AOs need 0.012 GiB; user supplied 0.391 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               4
+    Memory [MiB]:               400
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.4053
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 136
+    Number of basis functions: 476
+    Number of Cartesian functions: 476
+    Spherical Harmonics?: false
+    Max angular momentum: 4
+
+
+
+  ==> Integral Transformation <==
+
+  Number of molecular orbitals:                         52
+  Number of correlated molecular orbitals:              44
+  Number of frozen occupied orbitals:                    4
+  Number of frozen unoccupied orbitals:                  4
+  Two-electron integral type:              Density fitting
+
+
+  Computing density fitted integrals
+
+  Number of auxiliary basis functions:  476
+  Need 10.30 MB to store DF integrals
+  DFHelper Memory: AOs need 0.012 GiB; user supplied 0.427 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> DFHelper <==
+    NBF:                              52
+    NAux:                            476
+    Schwarz Cutoff:                1E-12
+    Mask sparsity (%):                 1
+    DFH Avail. Memory [GiB]:       0.427
+    OpenMP threads:                    4
+    Algorithm:                     STORE
+    AO Core:                        True
+    MO Core:                       False
+    Hold Metric:                   False
+    Metric Power:                 -0.500
+    Fitting Condition:             1E-10
+    Q Shell Max:                      15
+
+
+
+  Transforming DF Integrals
+  Timing for density-fitting transformation:                  0.009 s.
+
+  Frozen-core energy        -176.828136215948490 a.u.
+  Timing for frozen one-body operator:                        0.001 s.
+  Resorting integrals after freezing core.
+  Timing for resorting DF integrals:                          0.010 s.
+  Timing for freezing core and virtual orbitals:              0.011 s.
+  Timing for computing density-fitted integrals:              0.097 s.
+
+  ==> Primary Basis Set Summary <==
+
+  Basis Set: DZ
+    Blend: DZ
+    Number of shells: 36
+    Number of basis functions: 52
+    Number of Cartesian functions: 52
+    Spherical Harmonics?: false
+    Max angular momentum: 1
+
+
+  JK created using MemDF integrals
+  DFHelper Memory: AOs need 0.012 GiB; user supplied 0.391 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> MemDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                   Yes
+    K tasked:                   Yes
+    wK tasked:                   No
+    OpenMP threads:               4
+    Memory [MiB]:               400
+    Algorithm:                 Core
+    Schwarz Cutoff:           1E-12
+    Mask sparsity (%):       1.4053
+    Fitting Condition:        1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 136
+    Number of basis functions: 476
+    Number of Cartesian functions: 476
+    Spherical Harmonics?: false
+    Max angular momentum: 4
+
+
+
+  ==> Integral Transformation <==
+
+  Number of molecular orbitals:                         52
+  Number of correlated molecular orbitals:              44
+  Number of frozen occupied orbitals:                    4
+  Number of frozen unoccupied orbitals:                  4
+  Two-electron integral type:              Density fitting
+
+
+  Computing density fitted integrals
+
+  Number of auxiliary basis functions:  476
+  Need 10.30 MB to store DF integrals
+  DFHelper Memory: AOs need 0.012 GiB; user supplied 0.427 GiB. 
+  SCF_SUBTYPE=INCORE selected. In-core MEM_DF algorithm will be used.
+  Using in-core AOs.
+
+  ==> DFHelper <==
+    NBF:                              52
+    NAux:                            476
+    Schwarz Cutoff:                1E-12
+    Mask sparsity (%):                 1
+    DFH Avail. Memory [GiB]:       0.427
+    OpenMP threads:                    4
+    Algorithm:                     STORE
+    AO Core:                        True
+    MO Core:                       False
+    Hold Metric:                   False
+    Metric Power:                 -0.500
+    Fitting Condition:             1E-10
+    Q Shell Max:                      15
+
+
+
+  Transforming DF Integrals
+  Timing for density-fitting transformation:                  0.008 s.
+
+  Frozen-core energy        -176.828136215948490 a.u.
+  Timing for frozen one-body operator:                        0.001 s.
+  Resorting integrals after freezing core.
+  Timing for resorting DF integrals:                          0.007 s.
+  Timing for freezing core and virtual orbitals:              0.009 s.
+  Timing for computing density-fitted integrals:              0.092 s.
+
+          -----------------------------------------------------------
+                  Multi-Configurational Self Consistent Field
+                Two-Step Approximate Second-Order AO Algorithm
+            written by Chenyang Li, Kevin P. Hannon, and Shuhe Wang
+          -----------------------------------------------------------
+
+
+  ==> MCSCF Calculation Information <==
+
+    --------------------------------------------------------
+    Print level                                      Default
+    Integral type                                         DF
+    CI solver type                                       FCI
+    Final orbital type                             CANONICAL
+    Derivative type                                    FIRST
+    Optimize orbitals                                   TRUE
+    Include internal rotations                         FALSE
+    Debug printing                                     FALSE
+    Energy convergence                             1.000e-12
+    Gradient convergence                           1.000e-10
+    Max value for rotation                         2.000e-01
+    Max number of macro iter.                            100
+    Max number of micro iter. for orbitals                 6
+    Max number of micro iter. for CI                      12
+    DIIS start                                            15
+    Min DIIS vectors                                       3
+    Max DIIS vectors                                       8
+    Frequency of DIIS extrapolation                        1
+    --------------------------------------------------------
+
+  ==> Independent Orbital Rotations <==
+
+    ORBITAL SPACES                        Ag     Bg     Au     Bu
+    -------------------------------------------------------------
+             ACTIVE / RESTRICTED_DOCC      0      0      0      0
+    RESTRICTED_UOCC /          ACTIVE      0      4      4      0
+    RESTRICTED_UOCC / RESTRICTED_DOCC     65      0      0     56
+    -------------------------------------------------------------
+
+  DF-MCSCF adopts integrals from DFHelper of Psi4.
+
+
+  ==> String Lists <==
+
+    --------------------------------------------------------
+    number of alpha electrons                              2
+    number of beta electrons                               2
+    number of alpha strings                                6
+    number of beta strings                                 6
+    --------------------------------------------------------
+
+  ==> FCI Solver <==
+
+    --------------------------------------------------------
+    Spin adapt                                         FALSE
+    Number of determinants                                20
+    Symmetry                                               0
+    Multiplicity                                           1
+    Number of roots                                        1
+    Target root                                            0
+    --------------------------------------------------------
+
+  ==> Initial Guess <==
+
+  Initial guess determinants:         20
+
+  Classification of the initial guess solutions
+
+  Number   2S+1   Selected
+  ------------------------
+    12       1       *
+     7       3        
+     1       5        
+  ------------------------
+
+    Spin    Root           Energy        <S^2>    Status
+  -------------------------------------------------------
+   singlet    0     -331.737790283405  -0.000000  added
+  -------------------------------------------------------
+
+  ==> Davidson-Liu Solver <==
+
+    --------------------------------------------------------
+    Print level                                      Default
+    Energy convergence threshold                   1.000e-12
+    Residual convergence threshold                 1.000e-06
+    Schmidt orthogonality threshold                1.000e-12
+    Schmidt discard threshold                      1.000e-07
+    Size of the space                                     20
+    Number of roots                                        1
+    Maximum number of iterations                         100
+    Collapse subspace size                                 2
+    Maximum subspace size                                 10
+    --------------------------------------------------------
+
+  Davidson-Liu solver: adding 1 guess vectors
+  Iteration     Average Energy            max(∆E)            max(Residual)  Vectors
+  ---------------------------------------------------------------------------------
+       0     -154.909654067456      154.909654067456        0.000000000000      1
+       1     -154.909654067456        0.000000000000        0.000000000000      2
+  ---------------------------------------------------------------------------------
+
+  ==> Root No. 0 <==
+
+    20 20      0.96966863
+    00 22     -0.16600407
+    ba ab     -0.08088344
+    ab ba     -0.08088344
+    20 02     -0.06815696
+    bb aa      0.05970047
+    aa bb      0.05970047
+    22 00     -0.05733837
+    02 20     -0.04987063
+    02 02      0.02332427
+    ba ba     -0.02118298
+    ab ab     -0.02118298
+
+    Total Energy:    -154.909654067456, <S^2>: -0.000000
+    Time for FCI:       0.001588375000
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    Ag     0     -154.909654067456  -0.000000
+    --------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        1Au     1.961790      1Bg     1.917629      2Au     0.086750  
+        2Bg     0.033832  
+
+
+  ==> Dipole Moments [e a0] (Nuclear + Electronic) for Singlet (Ms = 0) Ag <==
+
+       State           DM_X           DM_Y           DM_Z           |DM|
+    --------------------------------------------------------------------
+         0AG     0.00000000     0.00000000     0.00000000     0.00000000
+    --------------------------------------------------------------------
+     Nuclear     0.00000000     0.00000000     0.00000000     0.00000000
+    --------------------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        1Au     1.961790      1Bg     1.917629      2Au     0.086750  
+        2Bg     0.033832  
+
+
+  ==> Quadrupole Moments [e a0^2] (Nuclear + Electronic) for Singlet (Ms = 0) Ag <==
+
+       State          QM_XX          QM_XY          QM_XZ          QM_YY          QM_YZ          QM_ZZ
+    --------------------------------------------------------------------------------------------------
+         0AG   -17.21245152     0.23986171     0.00000000   -17.55030013     0.00000000   -22.55097713
+    --------------------------------------------------------------------------------------------------
+     Nuclear   100.28432179   -97.22584527     0.00000000   180.74959352     0.00000000     0.00000000
+    --------------------------------------------------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        1Au     1.961790      1Bg     1.917629      2Au     0.086750  
+        2Bg     0.033832  
+
+
+  ==> MCSCF Iterations <==
+
+                      Energy CI                    Energy Orbital
+           ------------------------------  ------------------------------
+    Iter.        Total Energy       Delta        Total Energy       Delta  Orb. Grad.  Micro
+    ----------------------------------------------------------------------------------------
+       1    -154.909654067456 -1.5491e+02   -154.933571289333 -1.5493e+02  6.4566e-03    6/N
+       2    -154.936839954582 -2.7186e-02   -154.937110122729 -3.5388e-03  5.5645e-05    6/N
+       3    -154.937138656029 -2.9870e-04   -154.937141430784 -3.1308e-05  1.1319e-06    6/N
+       4    -154.937141786286 -3.1303e-06   -154.937141850149 -4.1937e-07  1.8699e-07    6/N
+       5    -154.937141865158 -7.8872e-08   -154.937141869146 -1.8997e-08  1.8390e-08    6/N
+       6    -154.937141870253 -5.0954e-09   -154.937141870565 -1.4188e-09  6.2240e-09    6/N
+       7    -154.937141870653 -3.9967e-10   -154.937141870678 -1.1300e-10  1.9679e-09    6/N
+       8    -154.937141870685 -3.2003e-11   -154.937141870687 -9.0665e-12  5.7314e-10    6/N
+       9    -154.937141870687 -2.5011e-12   -154.937141870688 -7.9581e-13  1.6355e-10    6/N
+      10    -154.937141870688 -2.2737e-13   -154.937141870688  0.0000e+00  4.6414e-11    6/N
+    ----------------------------------------------------------------------------------------
+
+  A miracle has come to pass: MCSCF iterations have converged!
+
+  Performing final CI Calculation using converged orbitals
+
+  ==> String Lists <==
+
+    --------------------------------------------------------
+    number of alpha electrons                              2
+    number of beta electrons                               2
+    number of alpha strings                                6
+    number of beta strings                                 6
+    --------------------------------------------------------
+
+  ==> FCI Solver <==
+
+    --------------------------------------------------------
+    Spin adapt                                         FALSE
+    Number of determinants                                20
+    Symmetry                                               0
+    Multiplicity                                           1
+    Number of roots                                        1
+    Target root                                            0
+    --------------------------------------------------------
+
+  ==> Initial Guess <==
+
+  Initial guess determinants:         20
+
+  Classification of the initial guess solutions
+
+  Number   2S+1   Selected
+  ------------------------
+    12       1       *
+     7       3        
+     1       5        
+  ------------------------
+
+    Spin    Root           Energy        <S^2>    Status
+  -------------------------------------------------------
+   singlet    0     -331.765278086636  +0.000000  added
+  -------------------------------------------------------
+
+  ==> Davidson-Liu Solver <==
+
+    --------------------------------------------------------
+    Print level                                      Default
+    Energy convergence threshold                   1.000e-12
+    Residual convergence threshold                 1.000e-06
+    Schmidt orthogonality threshold                1.000e-12
+    Schmidt discard threshold                      1.000e-07
+    Size of the space                                     20
+    Number of roots                                        1
+    Maximum number of iterations                         100
+    Collapse subspace size                                 2
+    Maximum subspace size                                 10
+    --------------------------------------------------------
+
+  Davidson-Liu solver: adding 1 guess vectors
+  Iteration     Average Energy            max(∆E)            max(Residual)  Vectors
+  ---------------------------------------------------------------------------------
+       0     -154.937141870688        0.000000000000        0.000000000000      1
+  ---------------------------------------------------------------------------------
+
+  ==> Root No. 0 <==
+
+    20 20      0.95062208
+    00 22     -0.18960603
+    ba ab     -0.10895676
+    ab ba     -0.10895676
+    bb aa      0.08485847
+    aa bb      0.08485847
+    20 02     -0.08479891
+    22 00     -0.08177880
+    02 20     -0.07105840
+    02 02      0.04162465
+    ba ba     -0.02409828
+    ab ab     -0.02409828
+
+    Total Energy:    -154.937141870688, <S^2>: -0.000000
+    Time for FCI:       0.001398333000
+
+  ==> Energy Summary <==
+
+    Multi.(2ms)  Irrep.  No.               Energy      <S^2>
+    --------------------------------------------------------
+       1  (  0)    Ag     0     -154.937141870688  -0.000000
+    --------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        1Au     1.929107      1Bg     1.874877      2Au     0.129418  
+        2Bg     0.066598  
+
+
+  ==> Dipole Moments [e a0] (Nuclear + Electronic) for Singlet (Ms = 0) Ag <==
+
+       State           DM_X           DM_Y           DM_Z           |DM|
+    --------------------------------------------------------------------
+         0AG     0.00000000     0.00000000     0.00000000     0.00000000
+    --------------------------------------------------------------------
+     Nuclear     0.00000000     0.00000000     0.00000000     0.00000000
+    --------------------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        1Au     1.929107      1Bg     1.874877      2Au     0.129418  
+        2Bg     0.066598  
+
+
+  ==> Quadrupole Moments [e a0^2] (Nuclear + Electronic) for Singlet (Ms = 0) Ag <==
+
+       State          QM_XX          QM_XY          QM_XZ          QM_YY          QM_YZ          QM_ZZ
+    --------------------------------------------------------------------------------------------------
+         0AG   -17.36252816     0.29523719     0.00000000   -17.68163418     0.00000000   -22.63673906
+    --------------------------------------------------------------------------------------------------
+     Nuclear   100.28432179   -97.22584527     0.00000000   180.74959352     0.00000000     0.00000000
+    --------------------------------------------------------------------------------------------------
+
+  ==> Natural Orbitals <==
+
+        1Au     1.929107      1Bg     1.874877      2Au     0.129418  
+        2Bg     0.066598  
+
+  Canonicalizing final MCSCF orbitals
+
+  ==> Semicanonicalize Orbitals <==
+
+    MIX INACTIVE ORBITALS         FALSE
+    MIX GAS ACTIVE ORBITALS       FALSE
+    FROZEN_DOCC                   CANONICAL
+    FROZEN_UOCC                   CANONICAL
+    GAS1                          CANONICAL
+    RESTRICTED_DOCC               CANONICAL
+    RESTRICTED_UOCC               CANONICAL
+
+    Off-Diag. Elements       Max           2-Norm
+    ------------------------------------------------
+    FROZEN_DOCC          0.0001134991   0.0002168027
+    FROZEN_UOCC          0.0009269409   0.0018069691
+    GAS1                 0.0011590346   0.0017945401
+    RESTRICTED_DOCC      0.0012694274   0.0045781169
+    RESTRICTED_UOCC      0.0400328502   0.0596628275
+    ------------------------------------------------
+
+    Canonicalization test failed
+
+  Timing for orbital canonicalization:                        0.001 s.
+
+  ==> MCSCF Gradient <==
+
+
+  ==> Solving CP-SCF Equation <==
+
+
+  ==> Prepare AO Densities <==
+
+    Computing AO Lagrangian ...... Done.
+    Computing AO OPDM ............ Done.
+    Dumping DF AO TPDM to disk ... Done.
+
+    Molecular point group: c2h
+    Full point group: C2h
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         H            2.042750477919    -4.835491681058     0.000000000000
+         H           -2.042750477919     4.835491681058     0.000000000000
+         H            3.975554800133    -1.923217741579     0.000000000000
+         H           -3.975554800133     1.923217741579     0.000000000000
+         H           -1.839771215331    -2.303651735978     0.000000000000
+         H            1.839771215331     2.303651735978     0.000000000000
+         C           -0.000000000000     1.377385468050     0.000000000000
+         C            0.000000000000    -1.377385468050     0.000000000000
+         C            2.112641998669    -2.786996435717     0.000000000000
+         C           -2.112641998669     2.786996435717     0.000000000000
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000977535151    -0.008215476329     0.000000000000
+       2        0.000977535151     0.008215476329     0.000000000000
+       3        0.006871706414     0.004375371623     0.000000000000
+       4       -0.006871706414    -0.004375371623     0.000000000000
+       5       -0.008511758530    -0.004400946294     0.000000000000
+       6        0.008511758530     0.004400946294     0.000000000000
+       7       -0.018637545674    -0.005228667135     0.000000000000
+       8        0.018637545674     0.005228667135     0.000000000000
+       9       -0.019088591084     0.014171287356     0.000000000000
+      10        0.019088591084    -0.014171287356     0.000000000000
+
+
+
+ ==> Forte Timings <==
+
+  Time to prepare integrals            :        0.195 seconds
+  Time to run forte energy             :        1.171 seconds
+  Time to compute derivative integrals :        0.064 seconds
+  Total                                :        1.429 seconds
+    CASSCF(4,4)/DZ gradient on butadiene with frozen orbitals.............................PASSED
+
+    Psi4 stopped on: Thursday, 05 September 2024 03:57AM
+    Psi4 wall time for execution: 0:00:02.27
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/methods/df-dsrg-mrpt2-7-localized-actv/input.dat
+++ b/tests/methods/df-dsrg-mrpt2-7-localized-actv/input.dat
@@ -49,7 +49,7 @@ set forte{
   mcscf_g_convergence 1.0e-6
   mcscf_e_convergence 1.0e-12
   ci_spin_adapt        true
-  mcscf_freeze_core   true
+  mcscf_ignore_frozen_orbs false
 }
 
 Ecas, wfn = energy('forte', ref_wfn=wfn, return_wfn=True)

--- a/tests/methods/tests.yaml
+++ b/tests/methods/tests.yaml
@@ -77,6 +77,7 @@ casscf:
       - casscf-gradient-1
       - casscf-gradient-3
       - casscf-opt-3
+      - df-casscf-gradient-1
    medium:
       - casscf-1
       - casscf-2
@@ -86,6 +87,7 @@ casscf:
       - casscf-6
       - casscf-9
       - casscf-gradient-2
+      - df-casscf-gradient-2
       - casscf-opt-1
       # - casscf-opt-2
       - sa-casscf-1


### PR DESCRIPTION
## Description
The previous version of analytic DF-MCSCF gradient code dumps 4-index 2-RDM elements via Psi4 `IWL`. This PR implements the genuine analytic DF-MCSCF gradients by saving the 3-index and 2-index 2-RDMs contributions to Psi4 `PSIO`.

There is also an algorithmic change of building the 3-active/1-general 2-electron integrals in DF-MCSCF. Previous implementation computes MO integrals (pu|xy) using JK builder for every xy slice, which turns out to be good for small active spaces. For the larger active space (NA > 20), this `TEIALG::JK` approach does not scale. This PR switches to the `TEIALG::DF` approach that relies on `DFHelper` of Psi4 to obtain (Q|pu) 3-index MO integrals.

Besides, `MCSCF_FREEZE_CORE` (default: `False`) is replaced by `MCSCF_IGNORE_FROZEN_ORBS` (default: `True`) because MCSCF can also freeze virtual orbitals.

## User Notes
- [x] Add genuine DF-MCSCF gradients.
- [x] Replace `MCSCF_FREEZE_CORE` (default: `False`) to `MCSCF_IGNORE_FROZEN_ORBS` (default: `True`).
- [x] Add two test cases for N2 (`df-casscf-gradient-1`) and butadiene (`df-casscf-gradient-2`).

## Checklist
- [x] Added/updated tests of new features and included a reference `output.ref` file
- [x] Removed comments in code and input files
- [x] Documented source code
- [x] Checked for redundant headers
- [x] Checked for consistency in the formatting of the output file
- [x] Documented new features in the manual
- [x] Ready to go!
