### PR TITLE
Update disk_io.cc

### DIFF
--- a/forte/helpers/disk_io.cc
+++ b/forte/helpers/disk_io.cc
@@ -30,6 +30,7 @@
 #include <iostream>
 #include <fstream>
 #include <sys/stat.h>
+#include <iomanip>
 
 #include "psi4/psi4-dec.h"
 


### PR DESCRIPTION
Add C++ header for `std::setw`. Somehow `iomanip` is not needed on my mac but linux g++ complains about it.

## Description
A brief description of the goals accomplished by this PR

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features and included a reference `output.ref` file
- [ ] Removed comments in code and input files
- [ ] Documented source code
- [ ] Checked for redundant headers
- [ ] Checked for consistency in the formatting of the output file
- [ ] Documented new features in the manual
- [x] Ready to go!
