### PR TITLE
Update math_structures.h

### DIFF
--- a/forte/helpers/math_structures.h
+++ b/forte/helpers/math_structures.h
@@ -403,7 +403,7 @@ template <typename Derived, typename T, typename F> class VectorSpaceList {
     VectorSpaceList adjoint() const {
         VectorSpaceList result;
         for (const auto& [e, c] : elements_) {
-            result.insert(e.adjoint(), conjugate(c));
+            result.add(e.adjoint(), conjugate(c));
         }
         return result;
     }


### PR DESCRIPTION
## Description
Intel 2025.0 complains about the `insert` method in `VectorSpaceList`, which is only defined in `VectorSpace`. I think the correct way is to use `add` instead of `insert` for `VectorSpaceList`. Please close this PR if I am wrong. Thanks!

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features and included a reference `output.ref` file
- [ ] Removed comments in code and input files
- [ ] Documented source code
- [ ] Checked for redundant headers
- [ ] Checked for consistency in the formatting of the output file
- [ ] Documented new features in the manual
- [x] Ready to go!
