### PR TITLE
SparseHamiltonian to SparseOperator

### DIFF
--- a/forte/api/sparse_hamiltonian_api.cc
+++ b/forte/api/sparse_hamiltonian_api.cc
@@ -43,6 +43,7 @@ void export_SparseHamiltonian(py::module& m) {
         .def("compute", &SparseHamiltonian::compute)
         .def("apply", &SparseHamiltonian::compute)
         .def("compute_on_the_fly", &SparseHamiltonian::compute_on_the_fly)
-        .def("timings", &SparseHamiltonian::timings);
+        .def("timings", &SparseHamiltonian::timings)
+        .def("to_sparse_operator", &SparseHamiltonian::to_sparse_operator);
 }
 } // namespace forte

--- a/forte/sparse_ci/sparse_hamiltonian.cc
+++ b/forte/sparse_ci/sparse_hamiltonian.cc
@@ -347,30 +347,30 @@ SparseOperator SparseHamiltonian::to_sparse_operator() const {
     SparseOperator H;
     size_t nmo = as_ints_->nmo();
     
-    H.add_term_from_str("[]", as_ints_->nuclear_repulsion_energy() + as_ints_->scalar_energy());
-    for (size_t i = 0; i < nmo; i++) {
-        for (size_t j = 0; j < nmo; j++) {
-            H.add_term_from_str(fmt::format("{}a+ {}a-", i, j), as_ints_->oei_a(i, j));
-            H.add_term_from_str(fmt::format("{}b+ {}b-", i, j), as_ints_->oei_b(i, j));
+    H.add_term_from_str("[]", as_ints_->nuclear_repulsion_energy() + as_ints_->scalar_energy() + as_ints_->frozen_core_energy());
+    for (size_t p = 0; p < nmo; p++) {
+        for (size_t p = 0; p < nmo; p++) {
+            H.add_term_from_str(fmt::format("{}a+ {}a-", p, q), as_ints_->oei_a(p, q));
+            H.add_term_from_str(fmt::format("{}b+ {}b-", p, q), as_ints_->oei_b(p, q));
         }
     }
 
-    for (size_t i = 0; i < nmo; i++){
-        for (size_t j = i + 1; j < nmo; j++){
-            for (size_t a = 0; a < nmo; a++){
-                for (size_t b = a + 1; b < nmo; b++){
-                    H.add_term_from_str(fmt::format("{}a+ {}a+ {}a- {}a-", i, j, a, b), as_ints_->tei_aa(i, j, a, b));
-                    H.add_term_from_str(fmt::format("{}b+ {}b+ {}b- {}b-", i, j, a, b), as_ints_->tei_bb(i, j, a, b));
+    for (size_t p = 0; p < nmo; p++){
+        for (size_t q = p + 1; q < nmo; q++){
+            for (size_t r = 0; r < nmo; r++){
+                for (size_t s = r + 1; s < nmo; s++){
+                    H.add_term_from_str(fmt::format("{}a+ {}a+ {}a- {}a-", p, q, s, r), as_ints_->tei_aa(p, q, r, s));
+                    H.add_term_from_str(fmt::format("{}b+ {}b+ {}b- {}b-", p, q, s, r), as_ints_->tei_bb(p, q, r, s));
                 }
             }
         }
     }
 
-    for (size_t i = 0; i < nmo; i++){
-        for (size_t j = 0; j < nmo; j++){
-            for (size_t a = 0; a < nmo; a++){
-                for (size_t b = 0; b < nmo; b++){
-                    H.add_term_from_str(fmt::format("{}a+ {}b+ {}b- {}a-", i, j, a, b), as_ints_->tei_ab(i, j, a, b));
+    for (size_t p = 0; p < nmo; p++){
+        for (size_t q = 0; q < nmo; q++){
+            for (size_t r = 0; r < nmo; r++){
+                for (size_t s = 0; s < nmo; s++){
+                    H.add_term_from_str(fmt::format("{}a+ {}b+ {}b- {}a-", p, q, s, r), as_ints_->tei_ab(p, q, r, s));
                 }
             }
         }

--- a/forte/sparse_ci/sparse_hamiltonian.cc
+++ b/forte/sparse_ci/sparse_hamiltonian.cc
@@ -349,7 +349,7 @@ SparseOperator SparseHamiltonian::to_sparse_operator() const {
     
     H.add_term_from_str("[]", as_ints_->nuclear_repulsion_energy() + as_ints_->scalar_energy() + as_ints_->frozen_core_energy());
     for (size_t p = 0; p < nmo; p++) {
-        for (size_t p = 0; p < nmo; p++) {
+        for (size_t q = 0; q < nmo; q++) {
             H.add_term_from_str(fmt::format("{}a+ {}a-", p, q), as_ints_->oei_a(p, q));
             H.add_term_from_str(fmt::format("{}b+ {}b-", p, q), as_ints_->oei_b(p, q));
         }

--- a/forte/sparse_ci/sparse_hamiltonian.h
+++ b/forte/sparse_ci/sparse_hamiltonian.h
@@ -67,6 +67,9 @@ class SparseHamiltonian {
     /// @return timings for this class
     std::map<std::string, double> timings() const;
 
+    /// @return the SparseOperator object constructed from the Hamiltonian
+    SparseOperator to_sparse_operator() const;
+
   private:
     /// Compute couplings for new determinants
     void compute_new_couplings(const std::vector<Determinant>& new_dets, double screen_thresh);

--- a/tests/pytest/sparse_ci/test_sparse_operator2.py
+++ b/tests/pytest/sparse_ci/test_sparse_operator2.py
@@ -22,13 +22,16 @@ def test_sparse_operator2():
 
     as_ints = data.as_ints  # forte_objs["as_ints"]
 
-    ham_op = forte.SparseHamiltonian(as_ints)
+    ham = forte.SparseHamiltonian(as_ints)
 
     ref = forte.SparseState({det("20"): 1.0})
-    Href1 = ham_op.compute(ref, 0.0)
-    Href2 = ham_op.compute_on_the_fly(ref, 0.0)
+    Href1 = ham.compute(ref, 0.0)
+    Href2 = ham.compute_on_the_fly(ref, 0.0)
     assert Href1[det("20")] == pytest.approx(-1.094572, abs=1e-6)
     assert Href2[det("20")] == pytest.approx(-1.094572, abs=1e-6)
+
+    ham_op = ham.to_sparse_operator()
+    assert forte.overlap(ref, forte.apply_op(ham_op, ref)) == pytest.approx(-1.094572, abs=1e-6)
 
     psi4.core.clean()
 


### PR DESCRIPTION
## Description
This is a very short PR adding a small convenience function that converts a `SparseHamiltonian` object (initialized by an `ActiveSpaceIntegral`) into a `SparseOperator` object. Thanks @imagoulas for catching this use case!

## Checklist
- [x] Added/updated tests of new features and included a reference `output.ref` file
- [x] Ready to go!
