### PR TITLE
Fix `prepare_forte_objects` and a tutorial

### DIFF
--- a/forte/utils/helpers.py
+++ b/forte/utils/helpers.py
@@ -98,43 +98,9 @@ def psi4_casscf(geom, basis, reference, restricted_docc, active, options={}) -> 
     # pipe output to the file output.dat
     psi4.core.set_output_file("output.dat", True)
 
-    # psi4.core.clean()
-
     # run scf and return the energy and a wavefunction object (will work only if pass return_wfn=True)
     E_scf, wfn = psi4.energy("casscf", molecule=mol, return_wfn=True)
     return (E_scf, wfn)
-
-
-def psi4_casscf(geom, basis, mo_spaces):
-    """
-    Run a Psi4 SCF.
-    :param geom: a string for molecular geometry
-    :param basis: a string for basis set
-    :param reference: a string for the type of reference
-    :return: a tuple of (scf energy, psi4 Wavefunction)
-    """
-    psi4.core.clean()
-    mol = psi4.geometry(geom)
-
-    psi4.set_options(
-        {
-            "basis": basis,
-            "scf_type": "pk",
-            "e_convergence": 1e-13,
-            "d_convergence": 1e-6,
-            "restricted_docc": mo_spaces["RESTRICTED_DOCC"],
-            "active": mo_spaces["ACTIVE"],
-            "mcscf_maxiter": 100,
-            "mcscf_e_convergence": 1.0e-11,
-            "mcscf_r_convergence": 1.0e-6,
-            "mcscf_diis_start": 20,
-        }
-    )
-    psi4.core.set_output_file("output.dat", False)
-
-    Escf, wfn = psi4.energy("casscf", return_wfn=True)
-    psi4.core.clean()
-    return Escf, wfn
 
 
 def psi4_cubeprop(wfn, path=".", orbs=[], nocc=0, nvir=0, density=False, frontier_orbitals=False, load=False):
@@ -184,7 +150,7 @@ def psi4_cubeprop(wfn, path=".", orbs=[], nocc=0, nvir=0, density=False, frontie
 
 
 def prepare_forte_objects(
-    wfn, mo_spaces=None, active_space="ACTIVE", core_spaces=["RESTRICTED_DOCC"], localize=False, localize_spaces=[]
+    wfn, mo_spaces, active_space="ACTIVE", core_spaces=["RESTRICTED_DOCC"], localize=False, localize_spaces=[]
 ):
     """Take a psi4 wavefunction object and prepare the ForteIntegrals, SCFInfo, and MOSpaceInfo objects
 
@@ -235,10 +201,7 @@ def prepare_forte_objects(
     point_group = wfn.molecule().point_group().symbol()
 
     # create a MOSpaceInfo object
-    if mo_spaces is None:
-        mo_space_info = forte.make_mo_space_info(nmopi, point_group, options)
-    else:
-        mo_space_info = forte.make_mo_space_info_from_map(nmopi, point_group, mo_spaces)
+    mo_space_info = forte.make_mo_space_info_from_map(nmopi, point_group, mo_spaces)
 
     # These variables are needed in make_state_weights_map
     nel = wfn.nalpha() + wfn.nbeta()

--- a/forte/utils/helpers.py
+++ b/forte/utils/helpers.py
@@ -240,10 +240,16 @@ def prepare_forte_objects(
     else:
         mo_space_info = forte.make_mo_space_info_from_map(nmopi, point_group, mo_spaces)
 
+    # These variables are needed in make_state_weights_map
+    nel = wfn.nalpha() + wfn.nbeta()
+    multiplicity = 1
+
+    options.set_int("NEL", nel)
+    options.set_int("MULTIPLICITY", multiplicity)
     state_weights_map = forte.make_state_weights_map(options, mo_space_info)
 
     # make a ForteIntegral object
-    ints = forte.make_ints_from_psi4(wfn, options, mo_space_info)
+    ints = forte.make_ints_from_psi4(wfn, options, scf_info, mo_space_info)
 
     if localize:
         localizer = forte.Localize(forte.forte_options, ints, mo_space_info)

--- a/tests/pytest/helpers/test_helpers.py
+++ b/tests/pytest/helpers/test_helpers.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+def test_helpers():
+    import math
+    import pytest
+    import psi4
+    import forte
+    import forte.utils
+
+    psi4.core.clean()
+
+    geom = """
+    O  0.0000  0.0000  0.1173
+    H  0.0000  0.7572 -0.4692
+    H  0.0000 -0.7572 -0.4692    
+    symmetry c2v
+    """
+    (E_scf, wfn_scf) = forte.utils.psi4_scf(geom,basis='6-31g',reference='rhf')
+    assert math.isclose(E_scf, -75.98397447271522)
+
+    (E_casscf, wfn_casscf) = forte.utils.psi4_casscf(geom,basis='6-31g',reference='rhf', restricted_docc=[2,0,0,1], active=[2,0,1,1])
+    assert math.isclose(E_casscf, -75.9998515885993)
+
+    res = forte.utils.prepare_forte_objects(wfn_casscf, {"RESTRICTED_DOCC": [2,0,0,1], "ACTIVE": [2,0,1,1]})
+    mo_space_info = res["mo_space_info"]
+    # mo_space_info.corr_absolute_mo("RESTRICTED_DOCC") == [0, 1, 9]
+    assert mo_space_info.corr_absolute_mo("RESTRICTED_DOCC")[2] == 9
+    
+    psi4.core.clean()
+
+if __name__ == "__main__":
+    test_helpers()

--- a/tutorials/Tutorial_01.02_forte_dets.ipynb
+++ b/tutorials/Tutorial_01.02_forte_dets.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,9 +34,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SCF Energy = -74.84159216002945\n"
+     ]
+    }
+   ],
    "source": [
     "# setup xyz geometry\n",
     "geom = \"\"\"\n",
@@ -57,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,14 +94,26 @@
     "              'RESTRICTED_DOCC' : [1,0,0,0,0,1,0,0]}\n",
     "nmopi = wfn.nmopi()\n",
     "point_group = wfn.molecule().point_group().symbol()\n",
-    "mo_space_info = forte.make_mo_space_info_from_map(nmopi,point_group,mos_spaces,[])"
+    "mo_space_info = forte.make_mo_space_info_from_map(nmopi,point_group,mos_spaces)\n",
+    "scf_info = forte.SCFInfo(wfn)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "mo_space_info.size('ACTIVE')"
    ]
@@ -113,11 +133,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of molecular orbitals: 7\n",
+      "Number of correlated molecular orbitals: 6\n",
+      "Frozen-core energy = -60.56668027959551\n",
+      "Nuclear repulsion energy = 8.731423976054998\n",
+      "Scalar energy = -17.04028141748399\n"
+     ]
+    }
+   ],
    "source": [
-    "ints = forte.make_ints_from_psi4(wfn, forte_options, mo_space_info)\n",
+    "ints = forte.make_ints_from_psi4(wfn, forte_options, scf_info, mo_space_info)\n",
     "print(f'Number of molecular orbitals: {ints.nmo()}')\n",
     "print(f'Number of correlated molecular orbitals: {ints.ncmo()}')\n",
     "\n",
@@ -144,9 +176,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Determinant: |00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000>\n",
+      "Determinant: |0000>\n"
+     ]
+    }
+   ],
    "source": [
     "d = forte.Determinant()\n",
     "print(f'Determinant: {d}')\n",
@@ -164,9 +205,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Determinant: |0+00>, sign = 1.0\n"
+     ]
+    }
+   ],
    "source": [
     "sign = d.create_alfa_bit(1)\n",
     "print(f'Determinant: {d.str(nact)}, sign = {sign}')"
@@ -181,9 +230,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Determinant: |0++0>, sign = -1.0\n"
+     ]
+    }
+   ],
    "source": [
     "sign = d.create_alfa_bit(2)\n",
     "print(f'Determinant: {d.str(nact)}, sign = {sign}')"
@@ -198,9 +255,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Determinant: |0+00>, sign = -1.0\n"
+     ]
+    }
+   ],
    "source": [
     "sign = d.destroy_alfa_bit(2)\n",
     "print(f'Determinant: {d.str(nact)}, sign = {sign}')"
@@ -222,9 +287,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of alpha electrons per irrep: (0, 0, 0, 0, 0, 0, 1, 1)\n",
+      "Number of beta electrons per irrep:  (0, 0, 0, 0, 0, 0, 1, 1)\n",
+      "Number of active orbtials per irrep: (1, 0, 0, 0, 0, 1, 1, 1)\n",
+      "Reference determinant: |0022>\n"
+     ]
+    }
+   ],
    "source": [
     "nirrep = mo_space_info.nirrep()\n",
     "nactpi = mo_space_info.dimension('ACTIVE').to_tuple()\n",
@@ -260,9 +336,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-74.84159216002945"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "as_ints.slater_rules(ref,ref) + as_ints.scalar_energy() + as_ints.nuclear_repulsion_energy() "
    ]
@@ -278,9 +365,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of alpha electrons: 2\n",
+      "Number of beta electrons:  2\n",
+      "==> List of FCI determinants <==\n",
+      "|2200>\n",
+      "|2020>\n",
+      "|2002>\n",
+      "|0220>\n",
+      "|0202>\n",
+      "|0022>\n"
+     ]
+    }
+   ],
    "source": [
     "import itertools\n",
     "import functools\n",
@@ -330,9 +433,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[-6.39776098e+01  2.76136366e-02  2.76136366e-02  4.26858692e-02\n",
+      "   4.26858692e-02  0.00000000e+00]\n",
+      " [ 2.76136366e-02 -6.57203915e+01  4.74444451e-02  1.55359164e-01\n",
+      "   0.00000000e+00  4.26858692e-02]\n",
+      " [ 2.76136366e-02  4.74444451e-02 -6.57203915e+01  0.00000000e+00\n",
+      "   1.55359164e-01  4.26858692e-02]\n",
+      " [ 4.26858692e-02  1.55359164e-01  0.00000000e+00 -6.51549711e+01\n",
+      "   4.74444451e-02  2.76136366e-02]\n",
+      " [ 4.26858692e-02  0.00000000e+00  1.55359164e-01  4.74444451e-02\n",
+      "  -6.51549711e+01  2.76136366e-02]\n",
+      " [ 0.00000000e+00  4.26858692e-02  4.26858692e-02  2.76136366e-02\n",
+      "   2.76136366e-02 -6.65327347e+01]]\n",
+      "FCI Energy = -74.84638013324044\n",
+      "FCI Energy Error = 8.526512829121202e-14\n",
+      "Index of the HF determinant in the FCI vector 5\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -359,6 +484,13 @@
     "index_hf = dets.index(ref)\n",
     "print(f'Index of the HF determinant in the FCI vector {index_hf}')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Description
Recent changes in APIs broke the `forte.utils.prepare_forte_objects` function and a tutorial. This short PR fixes them.

## Checklist
- [x] Ready to go!
