### PR TITLE
SparseState spin2

### DIFF
--- a/forte/api/sparse_state_api.cc
+++ b/forte/api/sparse_state_api.cc
@@ -49,8 +49,7 @@ void export_SparseState(py::module& m) {
             py::keep_alive<0, 1>()) // Essential: keep object alive while iterator exists
         .def("str", &SparseState::str)
         .def("size", &SparseState::size)
-        .def("norm", &SparseState::norm, "p"_a = 2,
-             "Compute the p-norm of the vector (default p = 2, p = -1 for infinity norm)")
+        .def("norm", &SparseState::norm, "Compute the 2-norm of the vector")
         .def("add", &SparseState::add)
         .def("__iadd__", &SparseState::operator+=, "Add a SparseState to this SparseState")
         .def("__isub__", &SparseState::operator-=, "Subtract a SparseState from this SparseState")
@@ -75,5 +74,6 @@ void export_SparseState(py::module& m) {
     m.def("get_projection", &get_projection);
     m.def("spin2_sparse", &spin2_sparse);
     m.def("overlap", &overlap);
+    m.def("normalize", &normalize);
 }
 } // namespace forte

--- a/forte/api/sparse_state_api.cc
+++ b/forte/api/sparse_state_api.cc
@@ -75,6 +75,6 @@ void export_SparseState(py::module& m) {
     m.def("get_projection", &get_projection);
     m.def("spin2_sparse", &spin2_sparse);
     m.def("overlap", &overlap);
-    m.def("normalize", &normalize);
+    m.def("normalize", &normalize, "Returns a normalized version of the input SparseState"); 
 }
 } // namespace forte

--- a/forte/api/sparse_state_api.cc
+++ b/forte/api/sparse_state_api.cc
@@ -49,7 +49,8 @@ void export_SparseState(py::module& m) {
             py::keep_alive<0, 1>()) // Essential: keep object alive while iterator exists
         .def("str", &SparseState::str)
         .def("size", &SparseState::size)
-        .def("norm", &SparseState::norm, "Compute the 2-norm of the vector")
+        .def("norm", &SparseState::norm, "p"_a = 2,
+            "Calculate the p-norm of the SparseState (default p = 2, p = -1 for infinity norm)")
         .def("add", &SparseState::add)
         .def("__iadd__", &SparseState::operator+=, "Add a SparseState to this SparseState")
         .def("__isub__", &SparseState::operator-=, "Subtract a SparseState from this SparseState")

--- a/forte/api/sparse_state_api.cc
+++ b/forte/api/sparse_state_api.cc
@@ -73,6 +73,7 @@ void export_SparseState(py::module& m) {
 
     m.def("apply_number_projector", &apply_number_projector);
     m.def("get_projection", &get_projection);
+    m.def("spin2_sparse", &spin2_sparse);
     m.def("overlap", &overlap);
 }
 } // namespace forte

--- a/forte/api/sparse_state_api.cc
+++ b/forte/api/sparse_state_api.cc
@@ -73,7 +73,10 @@ void export_SparseState(py::module& m) {
 
     m.def("apply_number_projector", &apply_number_projector);
     m.def("get_projection", &get_projection);
-    m.def("spin2_sparse", &spin2_sparse);
+    // there's already a function called spin2, overload the spin2 function
+    m.def("spin2", [](const SparseState& left_state, const SparseState& right_state) {
+        return spin2(left_state, right_state);
+    }, "Calculate the <left_state|S^2|right_state> expectation value");
     m.def("overlap", &overlap);
     m.def("normalize", &normalize, "Returns a normalized version of the input SparseState"); 
 }

--- a/forte/sparse_ci/sparse_state.cc
+++ b/forte/sparse_ci/sparse_state.cc
@@ -34,7 +34,7 @@
 #include "helpers/timer.h"
 #include "helpers/string_algorithms.h"
 #include "integrals/active_space_integrals.h"
-
+#include "sparse_ci/determinant.hpp"
 #include "sparse_ci/sparse_state.h"
 
 namespace forte {
@@ -184,6 +184,17 @@ SparseState apply_number_projector(int na, int nb, const SparseState& state) {
 sparse_scalar_t overlap(const SparseState& left_state, const SparseState& right_state) {
     return left_state.dot(right_state);
 }
+
+sparse_scalar_t spin2_sparse(const SparseState& left_state, const SparseState& right_state) {
+    sparse_scalar_t s2 = 0.0;
+    for (const auto& [deti, ci] : left_state) {
+        for (const auto& [detj, cj] : right_state) {
+            s2 += ci * cj * spin2(deti, detj);
+        }
+    }
+    return s2;
+}
+
 
 } // namespace forte
 

--- a/forte/sparse_ci/sparse_state.cc
+++ b/forte/sparse_ci/sparse_state.cc
@@ -39,6 +39,14 @@
 
 namespace forte {
 
+double SparseState::norm() const {
+    double n = 0.0;
+    for (const auto& [det, c] : elements()) {
+        n += std::norm(c);
+    }
+    return std::sqrt(n);
+}
+
 SparseState apply_operator_impl(bool is_antihermitian, const SparseOperator& sop,
                                 const SparseState& state, double screen_thresh);
 
@@ -193,6 +201,15 @@ sparse_scalar_t spin2_sparse(const SparseState& left_state, const SparseState& r
         }
     }
     return s2;
+}
+
+SparseState normalize(const SparseState& state) {
+    SparseState new_state;
+    const auto n = state.norm();
+    for (const auto& [det, c] : state) {
+        new_state[det] = c / n;
+    }
+    return new_state;
 }
 
 

--- a/forte/sparse_ci/sparse_state.cc
+++ b/forte/sparse_ci/sparse_state.cc
@@ -185,22 +185,20 @@ sparse_scalar_t overlap(const SparseState& left_state, const SparseState& right_
     return left_state.dot(right_state);
 }
 
-sparse_scalar_t spin2_sparse(const SparseState& left_state, const SparseState& right_state) {
+sparse_scalar_t spin2(const SparseState& left_state, const SparseState& right_state) {
     sparse_scalar_t s2 = 0.0;
     for (const auto& [deti, ci] : left_state) {
         for (const auto& [detj, cj] : right_state) {
-            s2 += ci * cj * spin2(deti, detj);
+            s2 += conjugate(ci) * cj * spin2(deti, detj);
         }
     }
     return s2;
 }
 
 SparseState normalize(const SparseState& state) {
-    SparseState new_state;
+    SparseState new_state(state);
     const auto n = state.norm();
-    for (const auto& [det, c] : state) {
-        new_state[det] = c / n;
-    }
+    new_state /= n;
     return new_state;
 }
 

--- a/forte/sparse_ci/sparse_state.cc
+++ b/forte/sparse_ci/sparse_state.cc
@@ -39,14 +39,6 @@
 
 namespace forte {
 
-double SparseState::norm() const {
-    double n = 0.0;
-    for (const auto& [det, c] : elements()) {
-        n += std::norm(c);
-    }
-    return std::sqrt(n);
-}
-
 SparseState apply_operator_impl(bool is_antihermitian, const SparseOperator& sop,
                                 const SparseState& state, double screen_thresh);
 

--- a/forte/sparse_ci/sparse_state.h
+++ b/forte/sparse_ci/sparse_state.h
@@ -74,8 +74,9 @@ SparseState apply_number_projector(int na, int nb, const SparseState& state);
 sparse_scalar_t overlap(const SparseState& left_state, const SparseState& right_state);
 
 /// compute the S^2 expectation value
-sparse_scalar_t spin2_sparse(const SparseState& left_state, const SparseState& right_state);
+sparse_scalar_t spin2(const SparseState& left_state, const SparseState& right_state);
 
+/// Return the normalized state
 SparseState normalize(const SparseState& state);
 
 } // namespace forte

--- a/forte/sparse_ci/sparse_state.h
+++ b/forte/sparse_ci/sparse_state.h
@@ -44,6 +44,8 @@ class SparseState
     /// @return a string representation of the object
     /// @param n the number of spatial orbitals to print
     std::string str(int n = 0) const;
+    /// @brief  compute the 2-norm of the vector
+    double norm() const;
 };
 
 // Functions to apply operators to a state
@@ -75,5 +77,7 @@ sparse_scalar_t overlap(const SparseState& left_state, const SparseState& right_
 
 /// compute the S^2 expectation value
 sparse_scalar_t spin2_sparse(const SparseState& left_state, const SparseState& right_state);
+
+SparseState normalize(const SparseState& state);
 
 } // namespace forte

--- a/forte/sparse_ci/sparse_state.h
+++ b/forte/sparse_ci/sparse_state.h
@@ -73,4 +73,7 @@ SparseState apply_number_projector(int na, int nb, const SparseState& state);
 /// compute the overlap value <left_state|right_state>
 sparse_scalar_t overlap(const SparseState& left_state, const SparseState& right_state);
 
+/// compute the S^2 expectation value
+sparse_scalar_t spin2_sparse(const SparseState& left_state, const SparseState& right_state);
+
 } // namespace forte

--- a/forte/sparse_ci/sparse_state.h
+++ b/forte/sparse_ci/sparse_state.h
@@ -44,8 +44,6 @@ class SparseState
     /// @return a string representation of the object
     /// @param n the number of spatial orbitals to print
     std::string str(int n = 0) const;
-    /// @brief  compute the 2-norm of the vector
-    double norm() const;
 };
 
 // Functions to apply operators to a state

--- a/tests/pytest/sparse_ci/test_sparse_state.py
+++ b/tests/pytest/sparse_ci/test_sparse_state.py
@@ -8,6 +8,7 @@ def test_sparse_vector():
     import pytest
     import forte
     from forte import det
+    import math
 
     ### Overlap tests ###
     ref = forte.SparseState({det(""): 1.0, det("+"): 1.0, det("-"): 1.0, det("2"): 1.0, det("02"): 1.0})
@@ -36,6 +37,14 @@ def test_sparse_vector():
     proj4 = forte.SparseState({det("-"): 1.0})
     test_proj4 = forte.apply_number_projector(0, 1, ref)
     assert proj4 == test_proj4
+
+    ref4 = forte.SparseState({det("+"): 1, det("-"): 1})
+    ref4 = forte.normalize(ref4)
+    assert forte.spin2_sparse(ref4,ref4) == pytest.approx(0.75, abs=1e-9)
+
+    ref5 = forte.SparseState({det("2"): 1})
+    assert forte.spin2_sparse(ref5,ref5) == pytest.approx(0, abs=1e-9)
+    
 
 
 if __name__ == "__main__":

--- a/tests/pytest/sparse_ci/test_sparse_state.py
+++ b/tests/pytest/sparse_ci/test_sparse_state.py
@@ -40,10 +40,11 @@ def test_sparse_vector():
 
     ref4 = forte.SparseState({det("+"): 1, det("-"): 1})
     ref4 = forte.normalize(ref4)
-    assert forte.spin2_sparse(ref4,ref4) == pytest.approx(0.75, abs=1e-9)
+    assert ref4.norm() == pytest.approx(1.0, abs=1e-9)
+    assert forte.spin2(ref4,ref4) == pytest.approx(0.75, abs=1e-9)
 
     ref5 = forte.SparseState({det("2"): 1})
-    assert forte.spin2_sparse(ref5,ref5) == pytest.approx(0, abs=1e-9)
+    assert forte.spin2(ref5,ref5) == pytest.approx(0, abs=1e-9)
     
 
 


### PR DESCRIPTION
## Description
Add ability to calculate <Psi0|S^2|Psi1> where Psi0 and Psi1 are `SparseState` objects. Also normalize (global function) function for `SparseState`.

## Checklist
- [x] Added/updated tests of new features and included a reference `output.ref` file
- [x] Ready to go!
