### PR TITLE
Enable initializing a SparseOperator with ndarrays

### DIFF
--- a/forte/api/sparse_operator_api.cc
+++ b/forte/api/sparse_operator_api.cc
@@ -32,6 +32,7 @@
 #include <pybind11/operators.h>
 
 #include "helpers/string_algorithms.h"
+#include "helpers/ndarray/ndarray.hpp"
 
 #include "integrals/active_space_integrals.h"
 
@@ -362,9 +363,15 @@ void export_SparseOperator(py::module& m) {
         },
         "list"_a, "Create a SparseOperator object from a list of Tuple[SQOperatorString, complex]");
 
-    m.def("sparse_operator_hamiltonian", &sparse_operator_hamiltonian,
-          "Create a SparseOperator object from an ActiveSpaceIntegrals object", "as_ints"_a,
-          "screen_thresh"_a = 1.0e-12);
+    // two functions, need to be overloaded
+    m.def("sparse_operator_hamiltonian", py::overload_cast<std::shared_ptr<ActiveSpaceIntegrals>, double>(&sparse_operator_hamiltonian),
+          "as_ints"_a, "screen_thresh"_a = 1.0e-12,
+          "Create a SparseOperator representing the Hamiltonian from ActiveSpaceIntegrals");
+    m.def("sparse_operator_hamiltonian", py::overload_cast<double, ndarray<double>&, ndarray<double>&,
+                                           ndarray<double>&, ndarray<double>&, ndarray<double>&, double>(
+                                           &sparse_operator_hamiltonian),
+                                           "scalar"_a, "oei_a"_a, "oei_b"_a, "tei_aa"_a, "tei_ab"_a, "tei_bb"_a, "screen_thresh"_a = 1.0e-12,
+                                           "Create a SparseOperator representing the Hamiltonian from raw integrals");
 
     m.def("new_product", [](const SparseOperator A, const SparseOperator B) {
         SparseOperator C;

--- a/forte/sparse_ci/sparse_operator_hamiltonian.h
+++ b/forte/sparse_ci/sparse_operator_hamiltonian.h
@@ -31,6 +31,7 @@
 #include <memory>
 
 #include "sparse_ci/sparse_operator.h"
+#include "helpers/ndarray/ndarray.hpp"
 
 namespace forte {
 
@@ -41,6 +42,12 @@ class ActiveSpaceIntegrals;
 /// @param as_ints the ActiveSpaceIntegrals object containing the integrals
 /// @param screen_thresh the threshold to screen the integrals
 SparseOperator sparse_operator_hamiltonian(std::shared_ptr<ActiveSpaceIntegrals> as_ints,
-                                           double screen_thresh = 1e-14);
+                                           double screen_thresh = 1e-12);
+
+SparseOperator sparse_operator_hamiltonian(double scalar, 
+                                           ndarray<double>& oei_a, ndarray<double>& oei_b,
+                                           ndarray<double>& tei_aa, ndarray<double>& tei_ab, ndarray<double>& tei_bb,
+                                           double screen_thresh = 1e-12);
+
 
 } // namespace forte


### PR DESCRIPTION
## Description
Existing convenience class `SparseOperatorHamiltonian` provides a function to initialize a SparseOperator with an active space integral object. This overloads that function (also exported) to work with arbitrary (newly implemented) ndarray inputs, which enables any python-side numpy arrays to be used for integrals.

## Checklist
- [ ] Added/updated tests of new features and included a reference `output.ref` file
- [ ] Ready to go!
