### PR TITLE
add and iadd for VectorSpaceList

### DIFF
--- a/forte/api/sparse_operator_list_api.cc
+++ b/forte/api/sparse_operator_list_api.cc
@@ -164,7 +164,23 @@ void export_SparseOperatorList(py::module& m) {
                 auto sop = op.to_operator();
                 return apply_operator_lin(sop, st);
             },
-            "Multiply a SparseOperator and a SparseState");
+            "Multiply a SparseOperator and a SparseState")
+        .def(
+            "__add__",
+            [](const SparseOperatorList& op1, const SparseOperatorList& op2) {
+                SparseOperatorList result = op1;
+                result += op2;
+                return result;
+            },
+            "Add (concatenate) two SparseOperatorList objects")
+        .def(
+            "__iadd__",
+            [](SparseOperatorList& op1, const SparseOperatorList& op2) {
+                op1 += op2;
+                return op1;
+            },
+            "Add (concatenate) a SparseOperatorList object to this SparseOperatorList object");
+        
 
     // Wrapper class that holds a SparseOperator
     // and overloads operator* to apply forte::SparseExp.

--- a/forte/helpers/math_structures.h
+++ b/forte/helpers/math_structures.h
@@ -419,6 +419,19 @@ template <typename Derived, typename T, typename F> class VectorSpaceList {
     /// @brief Check if two vectors lists are equal
     bool operator==(const VectorSpaceList& rhs) const { return elements_ == rhs.elements_; }
 
+    /// @brief Concatenate two vectors
+    Derived operator+=(const Derived& rhs) {
+        elements_.insert(elements_.end(), rhs.elements_.begin(), rhs.elements_.end());
+        return static_cast<Derived&>(*this);
+    }
+
+    /// @brief Concatenate two vectors
+    Derived operator+(const Derived& rhs) const {
+        Derived result = static_cast<Derived&>(*this);
+        result += rhs;
+        return result;
+    }
+
     /// @brief  Get the adjoint of the vector
     VectorSpaceList adjoint() const {
         VectorSpaceList result;

--- a/tests/pytest/sparse_ci/test_sparse_operator.py
+++ b/tests/pytest/sparse_ci/test_sparse_operator.py
@@ -524,6 +524,8 @@ def test_sparse_operator_list_add():
     sop2.add("[0a+ 0a-]", 1.0)
     sop3 = sop1 + sop2
     assert len(sop3) == 2
+    assert sop3(0)[0].str() == "[1a+ 1a-]"
+    assert sop3(1)[0].str() == "[0a+ 0a-]"
 
 
 if __name__ == "__main__":

--- a/tests/pytest/sparse_ci/test_sparse_operator.py
+++ b/tests/pytest/sparse_ci/test_sparse_operator.py
@@ -517,6 +517,15 @@ def test_sparse_operator_list_remove():
     assert len(sopl) == 1
 
 
+def test_sparse_operator_list_add():
+    sop1 = forte.SparseOperatorList()
+    sop1.add("[1a+ 1a-]", 1.0)
+    sop2 = forte.SparseOperatorList()
+    sop2.add("[0a+ 0a-]", 1.0)
+    sop3 = sop1 + sop2
+    assert len(sop3) == 2
+
+
 if __name__ == "__main__":
     test_sparse_operator_creation()
     test_sparse_operator()
@@ -524,3 +533,4 @@ if __name__ == "__main__":
     test_sparse_operator_product()
     test_sparse_operator_list_reverse()
     test_sparse_operator_list_remove()
+    test_sparse_operator_list_add()


### PR DESCRIPTION
## Description
This PR implements and exports the `+` and `+=` operators for `VectorSpaceList` (upstream to `SparseOperatorList` etc). The behavior on the python side is the expected behavior for the addition of two lists, i.e., concatenation.

## Checklist
- [x] Added/updated tests of new features and included a reference `output.ref` file
- [x] Documented source code
- [x] Ready to go!
