### PR TITLE
Compute the excitation connection between two determinants

### DIFF
--- a/forte/api/determinant_api.cc
+++ b/forte/api/determinant_api.cc
@@ -95,6 +95,8 @@ void export_Determinant(py::module& m) {
                const std::vector<int>& bann,
                const std::vector<int>& bcre) { return gen_excitation(d, aann, acre, bann, bcre); },
             "Apply a generic excitation") // uses gen_excitation() defined in determinant.hpp
+        .def("excitation_connection", &Determinant::excitation_connection,
+             "Get the excitation connection between this and another determinant")
         .def("spin_flip", &Determinant::spin_flip, "Get the spin-flip determinant")
         .def(
             "str", [](const Determinant& a, int n) { return str(a, n); },

--- a/forte/sparse_ci/bitarray.hpp
+++ b/forte/sparse_ci/bitarray.hpp
@@ -440,7 +440,7 @@ template <size_t N> class BitArray {
         return ~word_t(0);
     }
 
-    /// Find the first bit set to one (starting from the lowest index)
+    /// Find the last bit set to one (starting from the lowest index)
     /// @return the index of the the last bit, or if all bits are one, returns ~0
     uint64_t find_last_one(size_t begin = 0, size_t end = nwords_) const {
         for (; begin + 1 < end; end--) {

--- a/forte/sparse_ci/determinant.hpp
+++ b/forte/sparse_ci/determinant.hpp
@@ -593,6 +593,36 @@ template <size_t N> class DeterminantImpl : public BitArray<N> {
         }
         return d;
     }
+
+    /// Describe the excitation connection of a determinant relative to this one
+    /// The excitation connection is a vector of 4 vectors:
+    /// [[alfa holes], [alfa particles], [beta holes], [beta particles]]
+    std::vector<std::vector<size_t>> 
+    excitation_connection(const DeterminantImpl<N>& d, const int norb) const {
+        if (static_cast<size_t>(norb) > nbits_half) {
+            throw std::range_error(
+                "Determinant::excitation_connection(int norb) was passed a value of norb (" +
+                std::to_string(norb) +
+                "), which is larger than the maximum number of alpha orbitals (" +
+                std::to_string(nbits_half) + ").");
+        }
+        std::vector<std::vector<size_t>> excitation(4);
+        for (size_t i = 0; i < static_cast<size_t>(norb); i++) {
+            if (get_alfa_bit(i) and not d.get_alfa_bit(i)) {
+                excitation[0].push_back(i);
+            }
+            if (not get_alfa_bit(i) and d.get_alfa_bit(i)) {
+                excitation[1].push_back(i);
+            }
+            if (get_beta_bit(i) and not d.get_beta_bit(i)) {
+                excitation[2].push_back(i);
+            }
+            if (not get_beta_bit(i) and d.get_beta_bit(i)) {
+                excitation[3].push_back(i);
+            }
+        }
+        return excitation;
+    }
 };
 
 // Functions

--- a/forte/sparse_ci/determinant.hpp
+++ b/forte/sparse_ci/determinant.hpp
@@ -597,17 +597,9 @@ template <size_t N> class DeterminantImpl : public BitArray<N> {
     /// Describe the excitation connection of a determinant relative to this one
     /// The excitation connection is a vector of 4 vectors:
     /// [[alfa holes], [alfa particles], [beta holes], [beta particles]]
-    std::vector<std::vector<size_t>> 
-    excitation_connection(const DeterminantImpl<N>& d, const int norb) const {
-        if (static_cast<size_t>(norb) > nbits_half) {
-            throw std::range_error(
-                "Determinant::excitation_connection(int norb) was passed a value of norb (" +
-                std::to_string(norb) +
-                "), which is larger than the maximum number of alpha orbitals (" +
-                std::to_string(nbits_half) + ").");
-        }
+    std::vector<std::vector<size_t>> excitation_connection(const DeterminantImpl<N>& d) const {
         std::vector<std::vector<size_t>> excitation(4);
-        for (size_t i = 0; i < static_cast<size_t>(norb); i++) {
+        for (size_t i = 0; i < nbits_half; i++) {
             if (get_alfa_bit(i) and not d.get_alfa_bit(i)) {
                 excitation[0].push_back(i);
             }

--- a/tests/pytest/determinant/test_dets.py
+++ b/tests/pytest/determinant/test_dets.py
@@ -213,6 +213,44 @@ def test_det_exciting():
     assert d7 == det("-2+")
 
 
+def test_excitation_connection():
+    """Test the excitation_connection function"""
+    d1 = det("220")
+    d2 = det("022")
+    conn = d1.excitation_connection(d2, 3)
+    assert conn[0] == [0]  # alfa hole
+    assert conn[1] == [2]  # alfa particle
+    assert conn[2] == [0]  # beta hole
+    assert conn[3] == [2]  # beta particle
+    conn = d2.excitation_connection(d1, 3)
+    assert conn[0] == [2]  # alfa hole
+    assert conn[1] == [0]  # alfa particle
+    assert conn[2] == [2]  # beta hole
+    assert conn[3] == [0]  # beta particle
+
+    # test different fock space
+    d1 = det("2")
+    d2 = det("0")
+    conn = d1.excitation_connection(d2, 1)
+    assert conn[0] == [0]  # alfa hole
+    assert conn[1] == []  # alfa particle
+    assert conn[2] == [0]  # beta hole
+    assert conn[3] == []  # beta particle
+    conn = d2.excitation_connection(d1, 1)
+    assert conn[0] == []  # alfa hole
+    assert conn[1] == [0]  # alfa particle
+    assert conn[2] == []  # beta hole
+    assert conn[3] == [0]  # beta particle
+
+    d1 = det("222+-00000")
+    d2 = det("-++0200-02")
+    conn = d1.excitation_connection(d2, 10)
+    assert conn[0] == [0, 3]  # alfa hole
+    assert conn[1] == [4, 9]  # alfa particle
+    assert conn[2] == [1, 2]  # beta hole
+    assert conn[3] == [7, 9]  # beta particle
+
+
 def test_det_symmetry():
     """Test class constructors"""
     if forte.Determinant.norb() >= 128:
@@ -287,6 +325,7 @@ if __name__ == "__main__":
     test_det_fill()
     test_det_getset()
     test_det_exciting()
+    test_excitation_connection()
     test_det_get_occ_vir()
     test_det_creann()
     test_det_equality()

--- a/tests/pytest/determinant/test_dets.py
+++ b/tests/pytest/determinant/test_dets.py
@@ -217,12 +217,12 @@ def test_excitation_connection():
     """Test the excitation_connection function"""
     d1 = det("220")
     d2 = det("022")
-    conn = d1.excitation_connection(d2, 3)
+    conn = d1.excitation_connection(d2)
     assert conn[0] == [0]  # alfa hole
     assert conn[1] == [2]  # alfa particle
     assert conn[2] == [0]  # beta hole
     assert conn[3] == [2]  # beta particle
-    conn = d2.excitation_connection(d1, 3)
+    conn = d2.excitation_connection(d1)
     assert conn[0] == [2]  # alfa hole
     assert conn[1] == [0]  # alfa particle
     assert conn[2] == [2]  # beta hole
@@ -231,12 +231,12 @@ def test_excitation_connection():
     # test different number of electrons
     d1 = det("2")
     d2 = det("0")
-    conn = d1.excitation_connection(d2, 1)
+    conn = d1.excitation_connection(d2)
     assert conn[0] == [0]  # alfa hole
     assert conn[1] == []  # alfa particle
     assert conn[2] == [0]  # beta hole
     assert conn[3] == []  # beta particle
-    conn = d2.excitation_connection(d1, 1)
+    conn = d2.excitation_connection(d1)
     assert conn[0] == []  # alfa hole
     assert conn[1] == [0]  # alfa particle
     assert conn[2] == []  # beta hole
@@ -244,20 +244,11 @@ def test_excitation_connection():
 
     d1 = det("222+-00000")
     d2 = det("-++0200-02")
-    conn = d1.excitation_connection(d2, 10)
+    conn = d1.excitation_connection(d2)
     assert conn[0] == [0, 3]  # alfa hole
     assert conn[1] == [4, 9]  # alfa particle
     assert conn[2] == [1, 2]  # beta hole
     assert conn[3] == [7, 9]  # beta particle
-
-    # test for when some electrons get masked by the norb argument
-    d1 = det("222+-00000")
-    d2 = det("-++0200-02")
-    conn = d1.excitation_connection(d2, 9)
-    assert conn[0] == [0, 3]  # alfa hole
-    assert conn[1] == [4]  # alfa particle
-    assert conn[2] == [1, 2]  # beta hole
-    assert conn[3] == [7]  # beta particle
 
 
 def test_det_symmetry():

--- a/tests/pytest/determinant/test_dets.py
+++ b/tests/pytest/determinant/test_dets.py
@@ -228,7 +228,7 @@ def test_excitation_connection():
     assert conn[2] == [2]  # beta hole
     assert conn[3] == [0]  # beta particle
 
-    # test different fock space
+    # test different number of electrons
     d1 = det("2")
     d2 = det("0")
     conn = d1.excitation_connection(d2, 1)
@@ -249,6 +249,15 @@ def test_excitation_connection():
     assert conn[1] == [4, 9]  # alfa particle
     assert conn[2] == [1, 2]  # beta hole
     assert conn[3] == [7, 9]  # beta particle
+
+    # test for when some electrons get masked by the norb argument
+    d1 = det("222+-00000")
+    d2 = det("-++0200-02")
+    conn = d1.excitation_connection(d2, 9)
+    assert conn[0] == [0, 3]  # alfa hole
+    assert conn[1] == [4]  # alfa particle
+    assert conn[2] == [1, 2]  # beta hole
+    assert conn[3] == [7]  # beta particle
 
 
 def test_det_symmetry():


### PR DESCRIPTION
## Description
This PR adds a class function `excitation_connection` to `DeterminantImpl`. This function takes in another arbitrary determinant (e.g. different number of electrons) and describes the excitation connection from this determinant to the input determinant in the form of a vector of vectors: `[[alfa holes], [alfa particles], [beta holes], [beta particles]]`.
For example, `det("20").excitation_connection(det("0+")) == [[0],[1],[0],[]]`.

## Checklist
- [x] Added/updated tests of new features and included a reference `output.ref` file
- [x] Documented source code
- [x] Ready to go!
