### PR TITLE
`apply_antiherm` for complex-valued operators

### DIFF
--- a/forte/sparse_ci/sparse_fact_exp.cc
+++ b/forte/sparse_ci/sparse_fact_exp.cc
@@ -114,13 +114,13 @@ SparseState SparseFactExp::apply_antiherm(const SparseOperatorList& sop, const S
                 if (det.faster_can_apply_operator(sqop.cre(), sqop.ann())) {
                     const auto theta = t * faster_apply_operator_to_det(det, new_det, sqop.cre(),
                                                                         sqop.ann(), sign_mask);
-                    new_terms.emplace_back(det, c * (std::cos(theta) - 1.0));
-                    new_terms.emplace_back(new_det, c * std::sin(theta));
+                    new_terms.emplace_back(det, c * (std::cos(std::abs(theta)) - 1.0));
+                    new_terms.emplace_back(new_det, c * theta * std::sin(std::abs(theta)) / std::abs(theta));
                 } else if (det.faster_can_apply_operator(sqop.ann(), sqop.cre())) {
-                    const auto theta = -t * faster_apply_operator_to_det(det, new_det, sqop.ann(),
+                    const auto theta = -std::conj(t) * faster_apply_operator_to_det(det, new_det, sqop.ann(),
                                                                          sqop.cre(), sign_mask);
-                    new_terms.emplace_back(det, c * (std::cos(theta) - 1.0));
-                    new_terms.emplace_back(new_det, c * std::sin(theta));
+                    new_terms.emplace_back(det, c * (std::cos(std::abs(theta)) - 1.0));
+                    new_terms.emplace_back(new_det, c * theta * std::sin(std::abs(theta)) / std::abs(theta));
                 }
             }
         }

--- a/forte/sparse_ci/sparse_state_functions.cc
+++ b/forte/sparse_ci/sparse_state_functions.cc
@@ -203,7 +203,7 @@ void apply_operator_kernel_string(const auto& sop_groups, const auto& state_grou
                                 if constexpr (positive) {
                                     new_terms[new_det] += value * t * c;
                                 } else {
-                                    new_terms[new_det] -= value * t * c;
+                                    new_terms[new_det] -= value * std::conj(t) * c;
                                 }
                             }
                         }

--- a/tests/pytest/sparse_ci/test_sparse_exp.py
+++ b/tests/pytest/sparse_ci/test_sparse_exp.py
@@ -123,6 +123,21 @@ def test_sparse_exp_1():
     assert wfn[det("020")] == pytest.approx(0.676180171388, abs=1e-9)
     assert wfn[det("-+0")] == pytest.approx(0.016058887563, abs=1e-9)
 
+    ### Test the exponential operator with an antihermitian operator with complex coefficients ###
+    op = forte.SparseOperatorList()
+    op.add("[1a+ 0a-]", 0.1 + 0.2j)
+
+    exp = forte.SparseExp()
+    ref = forte.SparseState({forte.det("20"): 0.5, forte.det("02"): 0.8660254038})
+
+    op_inv = forte.SparseOperatorList()
+    op_inv.add("[0a+ 1a-]", 0.1 - 0.2j)
+
+    s1 = exp.apply_antiherm(op, ref)
+    s2 = exp.apply_antiherm(op_inv, s1)
+    assert s2[det("20")] == pytest.approx(0.5, abs=1e-9)
+    assert s2[det("02")] == pytest.approx(0.8660254038, abs=1e-9)
+
 
 def test_sparse_exp_2():
     # Compare the performance of the two methods to apply an operator to a state

--- a/tests/pytest/sparse_ci/test_sparse_exp.py
+++ b/tests/pytest/sparse_ci/test_sparse_exp.py
@@ -123,20 +123,53 @@ def test_sparse_exp_1():
     assert wfn[det("020")] == pytest.approx(0.676180171388, abs=1e-9)
     assert wfn[det("-+0")] == pytest.approx(0.016058887563, abs=1e-9)
 
-    ### Test the exponential operator with an antihermitian operator with complex coefficients ###
+    ### Test the factorized exponential operator with an antihermitian operator with complex coefficients ###
     op = forte.SparseOperatorList()
     op.add("[1a+ 0a-]", 0.1 + 0.2j)
 
-    exp = forte.SparseExp()
-    ref = forte.SparseState({forte.det("20"): 0.5, forte.det("02"): 0.8660254038})
-
     op_inv = forte.SparseOperatorList()
     op_inv.add("[0a+ 1a-]", 0.1 - 0.2j)
+
+    exp = forte.SparseFactExp()
+    ref = forte.SparseState({forte.det("20"): 0.5, forte.det("02"): 0.8660254038})
 
     s1 = exp.apply_antiherm(op, ref)
     s2 = exp.apply_antiherm(op_inv, s1)
     assert s2[det("20")] == pytest.approx(0.5, abs=1e-9)
     assert s2[det("02")] == pytest.approx(0.8660254038, abs=1e-9)
+
+    s1 = exp.apply_antiherm(op, ref, inverse=True)
+    s2 = exp.apply_antiherm(op_inv, ref, inverse=False)
+    assert s1 == s2
+
+    ### Test the exponential operator with an antihermitian operator with complex coefficients ###
+    op = forte.SparseOperatorList()
+    op.add("[1a+ 0a-]", 0.1 + 0.2j)
+    op_explicit = forte.SparseOperatorList()
+    op_explicit.add("[1a+ 0a-]", 0.1 + 0.2j)
+    op_explicit.add("[0a+ 1a-]", -0.1 + 0.2j)
+
+    op_inv = forte.SparseOperatorList()
+    op_inv.add("[0a+ 1a-]", 0.1 - 0.2j)
+    op_inv_explicit = forte.SparseOperatorList()
+    op_inv_explicit.add("[0a+ 1a-]", 0.1 - 0.2j)
+    op_inv_explicit.add("[1a+ 0a-]", -0.1 - 0.2j)
+
+    exp = forte.SparseExp()
+    ref = forte.SparseState({forte.det("20"): 0.5, forte.det("02"): 0.8660254038})
+
+    s1 = exp.apply_antiherm(op, ref)
+    s1_explicit = exp.apply_op(op_explicit, ref)
+    assert s1 == s1_explicit
+    s2 = exp.apply_antiherm(op_inv, s1)
+    assert s2[det("20")] == pytest.approx(0.5, abs=1e-9)
+    assert s2[det("02")] == pytest.approx(0.8660254038, abs=1e-9)
+    s2_explicit = exp.apply_op(op_inv_explicit, s1)
+    assert s2 == s2_explicit
+
+    s1 = exp.apply_antiherm(op, ref)
+    s2 = exp.apply_antiherm(op_inv, ref, scaling_factor=-1.0)
+    assert s1 == s2
 
 
 def test_sparse_exp_2():


### PR DESCRIPTION
## Description
`apply_antiherm` used to take in a `SparseOperatorList` $\sum_i \theta_i \tau_i$ and apply it as $\exp[\sum_i \theta_i (\tau_i-\tau_i^{\dagger})]$ (for unfactorized exponential, using Taylor series for the whole operator) or $\prod_i\exp[\theta_i (\tau_i-\tau_i^{\dagger})]$ (for factorized exponential, using a re-summed expression for each exponential). This assumed that $\\{\theta_i\\}$ are real. This PR lifts this restriction, allowing $\\{\theta_i\\}$ to be complex, and the corresponding exponentials are $\exp[\sum_i \theta_i \tau_i-\theta^*_i\tau_i^{\dagger}]$ and $\prod_i \exp[\theta_i \tau_i-{\theta}_i^\*\tau_i^{\dagger}]$.

The unfactorized case is trivial, but the factorized case require one to perform a re-summation of the Taylor series, to obtain
$$e^{\theta\tau-\theta^*\tau}=1 + \frac{\sin|\theta|}{|\theta|}(\theta\tau-\theta^{\*} \tau^{\dagger})+(\cos|\theta|-1)(\tau\tau^{\dagger}-\tau^{\dagger}\tau)$$

## Checklist
- [x] Added/updated tests of new features and included a reference `output.ref` file
- [x] Documented source code
- [x] Ready to go!
