### PR TITLE
Add reverse option to `SparseFactExp`

### DIFF
--- a/forte/api/sparse_fact_exp_api.cc
+++ b/forte/api/sparse_fact_exp_api.cc
@@ -41,9 +41,9 @@ void export_SparseFactExp(py::module& m) {
         m, "SparseFactExp",
         "A class to compute the product exponential of a sparse operator using factorization")
         .def(py::init<double>(), "screen_thresh"_a = 1.0e-12)
-        .def("apply_op", &SparseFactExp::apply_op, "sop"_a, "state"_a, "inverse"_a = false)
+        .def("apply_op", &SparseFactExp::apply_op, "sop"_a, "state"_a, "inverse"_a = false, "reverse"_a = false)
         .def("apply_antiherm", &SparseFactExp::apply_antiherm, "sop"_a, "state"_a,
-             "inverse"_a = false);
+             "inverse"_a = false, "reverse"_a = false);
 }
 
 } // namespace forte

--- a/forte/sparse_ci/sparse_fact_exp.cc
+++ b/forte/sparse_ci/sparse_fact_exp.cc
@@ -36,7 +36,7 @@ namespace forte {
 SparseFactExp::SparseFactExp(double screen_thresh) : screen_thresh_(screen_thresh) {}
 
 SparseState SparseFactExp::apply_op(const SparseOperatorList& sop, const SparseState& state,
-                                    bool inverse) {
+                                    bool inverse, bool reverse) {
     // initialize a state object
     SparseState result(state);
 
@@ -47,7 +47,7 @@ SparseState SparseFactExp::apply_op(const SparseOperatorList& sop, const SparseS
     Determinant sign_mask;
     Determinant idx;
     for (size_t m = 0, nterms = sop.size(); m < nterms; m++) {
-        size_t n = inverse ? nterms - m - 1 : m;
+        size_t n = (inverse ^ reverse) ? nterms - m - 1 : m;
         const auto& [sqop, coefficient] = sop(n);
         if (not sqop.is_nilpotent()) {
             std::string msg =
@@ -82,7 +82,7 @@ SparseState SparseFactExp::apply_op(const SparseOperatorList& sop, const SparseS
 }
 
 SparseState SparseFactExp::apply_antiherm(const SparseOperatorList& sop, const SparseState& state,
-                                          bool inverse) {
+                                          bool inverse, bool reverse) {
 
     // initialize a state object
     SparseState result(state);
@@ -92,7 +92,7 @@ SparseState SparseFactExp::apply_antiherm(const SparseOperatorList& sop, const S
     Determinant sign_mask;
     Determinant idx;
     for (size_t m = 0, nterms = sop.size(); m < nterms; m++) {
-        size_t n = inverse ? nterms - m - 1 : m;
+        size_t n = (inverse ^ reverse) ? nterms - m - 1 : m;
 
         const auto& [sqop, coefficient] = sop(n);
         if (not sqop.is_nilpotent()) {

--- a/forte/sparse_ci/sparse_fact_exp.h
+++ b/forte/sparse_ci/sparse_fact_exp.h
@@ -64,7 +64,10 @@ class SparseFactExp {
     ///
     ///             exp(-op1) exp(-op2) ... |state>
     ///
-    SparseState apply_op(const SparseOperatorList& sop, const SparseState& state, bool inverse);
+    /// @param reverse If true, apply the operator in reverse order:
+    ///             ... exp(opN-1) exp(opN) |state>
+    SparseState apply_op(const SparseOperatorList& sop, const SparseState& state, 
+                         bool inverse, bool reverse = false);
 
     /// @brief Compute the factorized exponential applied to a state using an exact algorithm
     ///
@@ -82,8 +85,10 @@ class SparseFactExp {
     ///
     ///             exp(-op1 + op1^dagger) exp(-op2 + op2^dagger) ... |state>
     ///
+    /// @param reverse If true, apply the operator in reverse order:
+    ///             ... exp(opN-1) exp(opN) |state>
     SparseState apply_antiherm(const SparseOperatorList& sop, const SparseState& state,
-                               bool inverse);
+                               bool inverse, bool reverse = false);
 
   private:
     double screen_thresh_;

--- a/tests/pytest/sparse_ci/test_sparse_exp.py
+++ b/tests/pytest/sparse_ci/test_sparse_exp.py
@@ -3,11 +3,10 @@ import forte
 import numpy as np
 import time
 from forte import det
+import pytest
 
 
 def test_sparse_exp_1():
-    import pytest
-
     ### Test the linear operator ###
     op = forte.SparseOperator()
     ref = forte.SparseState({det("22"): 1.0})
@@ -26,6 +25,8 @@ def test_sparse_exp_1():
     assert wfn[det("0220")] == pytest.approx(0.15, abs=1e-9)
     assert wfn[det("2002")] == pytest.approx(-0.21, abs=1e-9)
 
+
+def test_sparse_exp_2():
     ### Test the exponential operator with excitation operator ###
     op = forte.SparseOperator()
     ref = forte.SparseState({det("22"): 1.0})
@@ -53,6 +54,8 @@ def test_sparse_exp_1():
     assert wfn[det("+0-2")] == pytest.approx(-0.0077, abs=1e-9)
     assert wfn[det("-0+2")] == pytest.approx(-0.0077, abs=1e-9)
 
+
+def test_sparse_exp_3():
     ### Test the exponential operator with antihermitian operator ###
     op = forte.SparseOperator()
     ref = forte.SparseState({det("22"): 1.0})
@@ -75,6 +78,8 @@ def test_sparse_exp_1():
     assert wfn2[det("+2-0")] == pytest.approx(0.0, abs=1e-9)
     assert wfn2[det("-2+0")] == pytest.approx(0.0, abs=1e-9)
 
+
+def test_sparse_exp_4():
     ### Test the factorized exponential operator with an antihermitian operator ###
     op = forte.SparseOperatorList()
     op.add("[2a+ 0a-]", 0.1)
@@ -112,7 +117,6 @@ def test_sparse_exp_1():
     op.add("[1b+ 0b-]", 0.05)
     op.add("[2a+ 2b+ 1b- 1a-]", -0.07)
 
-    dtest = det("20")
     ref = forte.SparseState({det("20"): 0.5, det("02"): 0.8660254038})
     factexp = forte.SparseFactExp()
     wfn = factexp.apply_antiherm(op, ref)
@@ -124,7 +128,115 @@ def test_sparse_exp_1():
     assert wfn[det("-+0")] == pytest.approx(0.016058887563, abs=1e-9)
 
 
-def test_sparse_exp_2():
+def test_sparse_exp_5():
+    ### Test the reverse argument of factorized exponential operator ###
+
+    # this is the manually reversed op from test_sparse_exp_4
+    op = forte.SparseOperatorList()
+    op.add("[2a+ 2b+ 0b- 0a-]", 0.15)
+    op.add("[2b+ 0b-]", 0.2)
+    op.add("[2a+ 0a-]", 0.1)
+    ref = forte.SparseState({det("22"): 1.0})
+
+    factexp = forte.SparseFactExp()
+    wfn = factexp.apply_antiherm(op, ref, reverse=True)
+
+    assert wfn[det("+2-0")] == pytest.approx(-0.197676811654, abs=1e-9)
+    assert wfn[det("-2+0")] == pytest.approx(-0.097843395007, abs=1e-9)
+    assert wfn[det("0220")] == pytest.approx(+0.165338757995, abs=1e-9)
+    assert wfn[det("2200")] == pytest.approx(+0.961256283877, abs=1e-9)
+
+    wfn2 = factexp.apply_antiherm(op, wfn, inverse=True, reverse=True)
+
+    assert wfn2[det("2200")] == pytest.approx(1.0, abs=1e-9)
+
+    op = forte.SparseOperatorList()
+    op.add("[2a+ 2b+ 1b- 1a-]", -0.07)
+    op.add("[1b+ 0b-]", 0.05)
+    op.add("[1a+ 1b+ 0b- 0a-]", -0.3)
+    op.add("[1a+ 0a-]", 0.1)
+
+    ref = forte.SparseState({det("20"): 0.5, det("02"): 0.8660254038})
+    factexp = forte.SparseFactExp()
+    wfn = factexp.apply_antiherm(op, ref, reverse=True)
+
+    assert wfn[det("200")] == pytest.approx(0.733340213919, abs=1e-9)
+    assert wfn[det("+-0")] == pytest.approx(-0.049868863373, abs=1e-9)
+    assert wfn[det("002")] == pytest.approx(-0.047410073759, abs=1e-9)
+    assert wfn[det("020")] == pytest.approx(0.676180171388, abs=1e-9)
+    assert wfn[det("-+0")] == pytest.approx(0.016058887563, abs=1e-9)
+
+    op = forte.SparseOperatorList()
+    ref = forte.SparseState({det("22"): 1.0})
+    op.add("[2a+ 0a-]", 0.1)
+    op.add("[2b+ 0b-]", 0.1)
+    op.add("[2a+ 2b+ 0b- 0a-]", 0.15)
+    op.add("[3a+ 3b+ 1b- 1a-]", -0.077)
+
+    exp = forte.SparseFactExp()
+    wfn = exp.apply_op(op, ref, reverse=True)
+    assert wfn[det("2200")] == pytest.approx(1.0, abs=1e-9)
+    assert wfn[det("0220")] == pytest.approx(0.16, abs=1e-9)
+    assert wfn[det("+2-0")] == pytest.approx(-0.1, abs=1e-9)
+    assert wfn[det("-2+0")] == pytest.approx(-0.1, abs=1e-9)
+    assert wfn[det("2002")] == pytest.approx(-0.077, abs=1e-9)
+    assert wfn[det("+0-2")] == pytest.approx(-0.0077, abs=1e-9)
+    assert wfn[det("-0+2")] == pytest.approx(-0.0077, abs=1e-9)
+
+
+def test_sparse_exp_6():
+    ### Test the factorized exponential operator with an antihermitian operator with complex coefficients ###
+    op = forte.SparseOperatorList()
+    op.add("[1a+ 0a-]", 0.1 + 0.2j)
+
+    op_inv = forte.SparseOperatorList()
+    op_inv.add("[0a+ 1a-]", 0.1 - 0.2j)
+
+    exp = forte.SparseFactExp()
+    ref = forte.SparseState({forte.det("20"): 0.5, forte.det("02"): 0.8660254038})
+
+    s1 = exp.apply_antiherm(op, ref)
+    s2 = exp.apply_antiherm(op_inv, s1)
+    assert s2[det("20")] == pytest.approx(0.5, abs=1e-9)
+    assert s2[det("02")] == pytest.approx(0.8660254038, abs=1e-9)
+
+    s1 = exp.apply_antiherm(op, ref, inverse=True)
+    s2 = exp.apply_antiherm(op_inv, ref, inverse=False)
+    assert s1 == s2
+
+
+def test_sparse_exp_7():
+    ### Test the exponential operator with an antihermitian operator with complex coefficients ###
+    op = forte.SparseOperatorList()
+    op.add("[1a+ 0a-]", 0.1 + 0.2j)
+    op_explicit = forte.SparseOperatorList()
+    op_explicit.add("[1a+ 0a-]", 0.1 + 0.2j)
+    op_explicit.add("[0a+ 1a-]", -0.1 + 0.2j)
+
+    op_inv = forte.SparseOperatorList()
+    op_inv.add("[0a+ 1a-]", 0.1 - 0.2j)
+    op_inv_explicit = forte.SparseOperatorList()
+    op_inv_explicit.add("[0a+ 1a-]", 0.1 - 0.2j)
+    op_inv_explicit.add("[1a+ 0a-]", -0.1 - 0.2j)
+
+    exp = forte.SparseExp()
+    ref = forte.SparseState({forte.det("20"): 0.5, forte.det("02"): 0.8660254038})
+
+    s1 = exp.apply_antiherm(op, ref)
+    s1_explicit = exp.apply_op(op_explicit, ref)
+    assert s1 == s1_explicit
+    s2 = exp.apply_antiherm(op_inv, s1)
+    assert s2[det("20")] == pytest.approx(0.5, abs=1e-9)
+    assert s2[det("02")] == pytest.approx(0.8660254038, abs=1e-9)
+    s2_explicit = exp.apply_op(op_inv_explicit, s1)
+    assert s2 == s2_explicit
+
+    s1 = exp.apply_antiherm(op, ref)
+    s2 = exp.apply_antiherm(op_inv, ref, scaling_factor=-1.0)
+    assert s1 == s2
+
+
+def test_sparse_exp_7():
     # Compare the performance of the two methods to apply an operator to a state
     # when the operator all commute with each other
     norb = 10
@@ -191,3 +303,8 @@ def test_sparse_exp_2():
 if __name__ == "__main__":
     test_sparse_exp_1()
     test_sparse_exp_2()
+    test_sparse_exp_3()
+    test_sparse_exp_4()
+    test_sparse_exp_5()
+    test_sparse_exp_6()
+    test_sparse_exp_7()

--- a/tests/pytest/sparse_ci/test_sparse_exp.py
+++ b/tests/pytest/sparse_ci/test_sparse_exp.py
@@ -206,37 +206,6 @@ def test_sparse_exp_6():
 
 
 def test_sparse_exp_7():
-    ### Test the exponential operator with an antihermitian operator with complex coefficients ###
-    op = forte.SparseOperatorList()
-    op.add("[1a+ 0a-]", 0.1 + 0.2j)
-    op_explicit = forte.SparseOperatorList()
-    op_explicit.add("[1a+ 0a-]", 0.1 + 0.2j)
-    op_explicit.add("[0a+ 1a-]", -0.1 + 0.2j)
-
-    op_inv = forte.SparseOperatorList()
-    op_inv.add("[0a+ 1a-]", 0.1 - 0.2j)
-    op_inv_explicit = forte.SparseOperatorList()
-    op_inv_explicit.add("[0a+ 1a-]", 0.1 - 0.2j)
-    op_inv_explicit.add("[1a+ 0a-]", -0.1 - 0.2j)
-
-    exp = forte.SparseExp()
-    ref = forte.SparseState({forte.det("20"): 0.5, forte.det("02"): 0.8660254038})
-
-    s1 = exp.apply_antiherm(op, ref)
-    s1_explicit = exp.apply_op(op_explicit, ref)
-    assert s1 == s1_explicit
-    s2 = exp.apply_antiherm(op_inv, s1)
-    assert s2[det("20")] == pytest.approx(0.5, abs=1e-9)
-    assert s2[det("02")] == pytest.approx(0.8660254038, abs=1e-9)
-    s2_explicit = exp.apply_op(op_inv_explicit, s1)
-    assert s2 == s2_explicit
-
-    s1 = exp.apply_antiherm(op, ref)
-    s2 = exp.apply_antiherm(op_inv, ref, scaling_factor=-1.0)
-    assert s1 == s2
-
-
-def test_sparse_exp_7():
     # Compare the performance of the two methods to apply an operator to a state
     # when the operator all commute with each other
     norb = 10

--- a/tests/pytest/sparse_ci/test_sparse_exp.py
+++ b/tests/pytest/sparse_ci/test_sparse_exp.py
@@ -185,27 +185,6 @@ def test_sparse_exp_5():
 
 
 def test_sparse_exp_6():
-    ### Test the factorized exponential operator with an antihermitian operator with complex coefficients ###
-    op = forte.SparseOperatorList()
-    op.add("[1a+ 0a-]", 0.1 + 0.2j)
-
-    op_inv = forte.SparseOperatorList()
-    op_inv.add("[0a+ 1a-]", 0.1 - 0.2j)
-
-    exp = forte.SparseFactExp()
-    ref = forte.SparseState({forte.det("20"): 0.5, forte.det("02"): 0.8660254038})
-
-    s1 = exp.apply_antiherm(op, ref)
-    s2 = exp.apply_antiherm(op_inv, s1)
-    assert s2[det("20")] == pytest.approx(0.5, abs=1e-9)
-    assert s2[det("02")] == pytest.approx(0.8660254038, abs=1e-9)
-
-    s1 = exp.apply_antiherm(op, ref, inverse=True)
-    s2 = exp.apply_antiherm(op_inv, ref, inverse=False)
-    assert s1 == s2
-
-
-def test_sparse_exp_7():
     # Compare the performance of the two methods to apply an operator to a state
     # when the operator all commute with each other
     norb = 10
@@ -276,4 +255,3 @@ if __name__ == "__main__":
     test_sparse_exp_4()
     test_sparse_exp_5()
     test_sparse_exp_6()
-    test_sparse_exp_7()


### PR DESCRIPTION
## Description
`SparseFactExp::apply_op/antiherm(oplist, state)` performs the action `... exp(oplist[1]) exp(oplist[0])|state>`, which is expected/conventional behavior for an operator list built iteratively, but is not what one might naively expect otherwise (e.g., if you have a list of singles and then doubles, you might expect the function to apply doubles onto the state first, then singles, etc). This PR adds the optional argument `reverse` to these two functions to do this. It works with the `inverse` argument in the expected way (inverse negates all coefficients, while XOR(inverse,reverse) determines if the list is reversed)

## Checklist
- [x] Added/updated tests of new features and included a reference `output.ref` file
- [x] Documented source code
- [x] Ready to go!
