### PR TITLE
updates for c-f

### DIFF
--- a/forte/CMakeLists.txt
+++ b/forte/CMakeLists.txt
@@ -335,6 +335,7 @@ install(
   FILES
     $<TARGET_FILE:_forte>
     ../pytest.ini
+    options.yaml
   COMPONENT Forte_Python
   DESTINATION ${FORTE_INSTALL_PYMODDIR}/forte
   )

--- a/forte/base_classes/scf_info.h
+++ b/forte/base_classes/scf_info.h
@@ -30,7 +30,7 @@
 
 #include "psi4/libmints/dimension.h"
 
-#include "forte/helpers/observer.h"
+#include "../helpers/observer.h"
 
 namespace psi {
 class Vector;

--- a/forte/forte.cc
+++ b/forte/forte.cc
@@ -27,7 +27,7 @@
  */
 
 // #include <fstream>
-// #include "ambit/tensor.h"
+#include "ambit/tensor.h"
 // #include "psi4/libpsi4util/process.h"
 
 #include "version.h"

--- a/forte/integrals/active_space_integrals.cc
+++ b/forte/integrals/active_space_integrals.cc
@@ -27,6 +27,7 @@
  */
 
 #include <cmath>
+#include <algorithm>
 
 #include "psi4/psi4-dec.h"
 #include "psi4/libpsi4util/PsiOutStream.h"

--- a/forte/integrals/integrals.h
+++ b/forte/integrals/integrals.h
@@ -35,7 +35,7 @@
 #include "psi4/libmints/dimension.h"
 #include "ambit/blocked_tensor.h"
 
-#include "forte/helpers/observer.h"
+#include "../helpers/observer.h"
 
 class Tensor;
 


### PR DESCRIPTION
## Description
This is enough to get https://github.com/conda-forge/forte-feedstock/pull/8 to build, but the [main test](https://github.com/conda-forge/forte-feedstock/blob/main/recipe/test_forte.py) is [failing](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1230048&view=logs&j=d818e662-7181-5ce9-b265-50d03742b7af&t=367317f3-9b77-59ac-9e12-e56370c98acd&l=2888). Could someone check that that test is still in a good state?
 
## User Notes
- [ ] Features added
- [x] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features and included a reference `output.ref` file
- [ ] Removed comments in code and input files
- [ ] Documented source code
- [ ] Checked for redundant headers
- [ ] Checked for consistency in the formatting of the output file
- [ ] Documented new features in the manual
- [ ] Ready to go!
